### PR TITLE
fix: increase cli database wait time and improved error message

### DIFF
--- a/cmd/database/database.go
+++ b/cmd/database/database.go
@@ -435,15 +435,15 @@ func connectAndWaitForDbServer(serverConnectionInfo *db.ConnectionInfo) (server 
 		return nil, err
 	}
 
-	// ping() the database server until it is available.
+	// ping() the database for 5 seconds until it is available.
 	var pingError error
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 20; i++ {
 		if pingError = server.Ping(); pingError == nil {
 			break
 		}
 		time.Sleep(250 * time.Millisecond)
 	}
-	return server, nil
+	return server, pingError
 }
 
 // createVolume creates the Docker volume we'll persist the database(s) on,


### PR DESCRIPTION
I found that the database wasn't always available in time when running `keel test`.  Increased the wait from 2.5 seconds to 5 seconds.  It would be great to capture telemetry on this.

Also, previously, if the database wasn't ready, the error was misleading:
```
Error: ERROR: database "keel_e4bc5aa7b1d1de4a38651ee3c16d52b5" already exists (SQLSTATE 42P04)
```

Now returning this:
```
Error: failed to connect to `host=0.0.0.0 user=postgres database=`: server error (FATAL: the database system is starting up (SQLSTATE 57P03))
```