### PR TITLE
fix: display full output path when generating a client 

### DIFF
--- a/cmd/program/client.go
+++ b/cmd/program/client.go
@@ -206,9 +206,17 @@ func (m *GenerateClientModel) renderGenerate() string {
 				parts := strings.Split(generatedFile.Path, "/")
 				prePath := filepath.Join(parts[0 : len(parts)-1]...)
 
+				if m.OutputDir != "" {
+					if prePath != "" {
+						prePath = fmt.Sprintf("%s/%s", m.OutputDir, prePath)
+					} else {
+						prePath = m.OutputDir
+					}
+				}
+
 				b.WriteString(
 					colors.Gray(
-						fmt.Sprintf("- %s/%s%s", prePath, colors.Cyan(functionName).String(), colors.Gray(".ts").String()),
+						fmt.Sprintf("%s/%s%s", prePath, colors.Cyan(functionName).String(), colors.Gray(".ts").String()),
 					).Highlight().String(),
 				)
 				b.WriteString("\n")


### PR DESCRIPTION
If generated a client with an output dir flag e.g. `-o ../my/frontend` we didn't show the correct output path. 

New output

**Single file client**
```
📦 Generating client SDK..                         
✅ All done!                                       
                                                   
The following files were generated:                
                                                   
../customDir/@teamkeel/client/keelClient.ts  
```

**Package client**
```
📦 Generating client SDK..                         
✅ All done!                                       
                                                   
The following files were generated:                
                                                   
../customDir/core.ts   
../customDir/@teamkeel/client/index.ts  
../customDir/@teamkeel/client/types.ts  
../customDir/@teamkeel/client/package.ts
```

