### PR TITLE
feat: support human readable schedule expressions and better validation

### DIFF
--- a/cron/cron.go
+++ b/cron/cron.go
@@ -1,0 +1,611 @@
+package cron
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/samber/lo"
+)
+
+type Error struct {
+	Message string
+	Token   *Token
+}
+
+func (e Error) Error() string {
+	position := ""
+	if e.Token != nil {
+		position = fmt.Sprintf("(%d:%d) ", e.Token.Start, e.Token.End)
+	}
+	return fmt.Sprintf("%s%s", position, e.Message)
+}
+
+func ToError(err error) (Error, bool) {
+	if err == nil {
+		return Error{}, false
+	}
+	e, ok := err.(Error)
+	return e, ok
+}
+
+func Parse(src string) (*CronExpression, error) {
+	if strings.TrimSpace(src) == "" {
+		return nil, Error{Message: "input is empty"}
+	}
+
+	tokens := toTokens(src)
+	token := tokens.Peek()
+
+	// If first token is an integer, integer range, or starts with '*' then parse as unix-cron
+	if intValueRegex.MatchString(token.Value) || strings.HasPrefix(token.Value, "*") {
+		return parseUnixCron(toTokens(src))
+	}
+
+	// Otherwise lower-case input and parse as human-readable expression
+	tokens = toTokens(strings.ToLower(src))
+
+	// First token must be 'every'
+	token = tokens.Next()
+	if token.Value != "every" {
+		return nil, Error{Message: "invalid schedule - must be expression like 'every day at 9am' or cron syntax e.g. '0 9 * * *'"}
+	}
+
+	token = tokens.Peek()
+	if token == nil {
+		return nil, Error{Message: "unexpected end of input - expected time interval or day e.g. '10 minutes' or 'monday'"}
+	}
+
+	var c *CronExpression
+
+	// If next token is integer then parse as interval expression e.g. 'every 10 minutes'.
+	// Else parse as day expression e.g. 'every monday at 9am'
+	_, err := strconv.Atoi(token.Value)
+	if err == nil {
+		c, err = parseIntervalCron(tokens)
+	} else {
+		c, err = parseDayCron(tokens)
+	}
+
+	if err != nil {
+		return c, err
+	}
+
+	// Check there are no more tokens
+	if tokens.Peek() != nil {
+		t := tokens.Next()
+		return nil, Error{Message: fmt.Sprintf("unexpected token '%s' - expected end of input", t.Value), Token: t}
+	}
+
+	return c, err
+}
+
+func parseIntervalCron(tokens *Tokens) (*CronExpression, error) {
+	c := &CronExpression{
+		DayOfMonth: "?",
+		Month:      "*",
+		DayOfWeek:  "*",
+	}
+
+	// At this point we know we have a next token and that it is an integer
+	token := tokens.Next()
+	intToken := token
+	interval, _ := strconv.Atoi(token.Value)
+
+	token, err := tokens.Match("minutes", "hours")
+	if err != nil {
+		return nil, err
+	}
+
+	switch token.Value {
+	case "minutes":
+		if 60%interval != 0 {
+			return nil, Error{Message: "value of minutes must divide evenly by 60", Token: intToken}
+		}
+		c.Minutes = fmt.Sprintf("*/%d", interval)
+		c.Hours = "*"
+	case "hours":
+		if 24%interval != 0 {
+			return nil, Error{Message: "value of hours must divide evenly by 24", Token: intToken}
+		}
+		c.Minutes = "0"
+		c.Hours = fmt.Sprintf("*/%d", interval)
+	}
+
+	// optional "from <start-hour> to <end-hour>"
+	token, err = tokens.MatchOrNil("from")
+	if err != nil {
+		return nil, err
+	}
+	if token != nil {
+		start, err := parseTime(tokens.Next())
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = tokens.Match("to")
+		if err != nil {
+			return nil, err
+		}
+
+		endToken := tokens.Next()
+		end, err := parseTime(endToken)
+		if err != nil {
+			return nil, err
+		}
+
+		if end < start {
+			return nil, Error{Message: "end time of schedule must be before start time", Token: endToken}
+		}
+
+		switch c.Hours {
+		case "*":
+			// If hours is '*' then expression is like 'every 10 minutes from 9am to 11am' in
+			// which case we can just set the hours field to 9-11
+			c.Hours = fmt.Sprintf("%d-%d", start, end)
+		default:
+			// Otherwise the expression is like 'every 2 hours from 9am to 3pm, in which case
+			// we need to change the hours field to respect both the range and the interval
+			// e.g. from '9-15' to '9,11,13,15'
+			h := start
+			hours := []int{}
+			for h <= end {
+				hours = append(hours, h)
+				h += interval
+			}
+			c.Hours = strings.Join(
+				lo.Map(hours, func(v int, _ int) string {
+					return fmt.Sprintf("%d", v)
+				}),
+				",",
+			)
+		}
+	}
+
+	return c, nil
+}
+
+var dayOfWeekMap = map[string]string{
+	"sunday":    "SUN",
+	"monday":    "MON",
+	"tuesday":   "TUE",
+	"wednesday": "WED",
+	"thursday":  "THU",
+	"friday":    "FRI",
+	"saturday":  "SAT",
+}
+
+func parseDayCron(tokens *Tokens) (*CronExpression, error) {
+	c := &CronExpression{
+		Minutes:    "0",
+		DayOfMonth: "?",
+		Month:      "*",
+	}
+
+	// days can be a list e.g. 'every monday, wednesday, and friday ...'
+	dayTokens := tokens.List()
+	days := []string{}
+
+	for _, token := range dayTokens {
+		switch {
+		case token.Value == "day":
+			if len(dayTokens) > 1 {
+				return nil, Error{Message: "cannot use 'day' with other values", Token: token}
+			}
+			c.DayOfWeek = "*"
+		case token.Value == "weekday":
+			if len(dayTokens) > 1 {
+				return nil, Error{Message: "cannot use 'weekday' with other values", Token: token}
+			}
+			c.DayOfWeek = "MON-FRI"
+		default:
+			day, ok := dayOfWeekMap[token.Value]
+			if !ok {
+				msg := fmt.Sprintf("invalid day '%s' - expected day of week e.g. 'monday'", token.Value)
+				if len(days) == 0 {
+					msg += ", 'day' for every day, or 'weekday' for monday-friday"
+				}
+				return nil, Error{Message: msg, Token: token}
+			}
+			if c.DayOfWeek != "" {
+				return nil, Error{Message: "cannot use specific days as well as 'day' or 'weekday'", Token: token}
+			}
+			days = append(days, day)
+		}
+	}
+
+	if len(days) > 0 {
+		c.DayOfWeek = strings.Join(days, ",")
+	}
+
+	_, err := tokens.Match("at")
+	if err != nil {
+		return nil, err
+	}
+
+	// hours can also be a list e.g. 'every monday at 9am and 12pm'
+	hours := []string{}
+	for _, token := range tokens.List() {
+		hour, err := parseTime(token)
+		if err != nil {
+			return nil, err
+		}
+
+		hours = append(hours, fmt.Sprintf("%d", hour))
+	}
+	if len(hours) == 0 {
+		return nil, Error{Message: "unexpected end of input - expected time e.g. '9am'"}
+	}
+
+	c.Hours = strings.Join(hours, ",")
+	return c, nil
+}
+
+type CronFieldConfig struct {
+	label      string
+	min        int
+	max        int
+	altValues  []string
+	stepValues bool
+}
+
+var (
+	cronFieldConfigs = []CronFieldConfig{
+		{"seconds", 0, 59, []string{}, true},
+		{"hours", 0, 23, []string{}, true},
+		{"day-of-month", 1, 31, []string{}, true},
+		{"month", 1, 12, []string{"", "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"}, true},
+
+		// AWS EventBridge cron does not allow '/' (step values) in the day-of-week field (according to their docs)
+		{"day-of-week", 0, 6, []string{"SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"}, false},
+	}
+	intValueRegex   = regexp.MustCompile(`^(\d+)(?:-(\d+))?$`)
+	namedValueRegex = regexp.MustCompile(`^([a-zA-Z]+)(?:-([a-zA-Z]+))?$`)
+)
+
+func parseUnixCron(tokens *Tokens) (*CronExpression, error) {
+
+	// group tokens into cron fields, which are separated by whitespace
+	groups := [][]*Token{}
+	var prev *Token
+	token := tokens.Next()
+	for token != nil {
+		if prev == nil || token.Start-prev.End > 0 {
+			// new group
+			groups = append(groups, []*Token{token})
+		} else {
+			// same group
+			idx := len(groups) - 1
+			groups[idx] = append(groups[idx], token)
+		}
+		prev = token
+		token = tokens.Next()
+	}
+
+	if len(groups) != 5 {
+		return nil, Error{Message: "wrong number of fields - cron expression must have five fields"}
+	}
+
+	c := &CronExpression{}
+
+	for i, group := range groups {
+		// remove any commas
+		group = lo.Filter(group, func(t *Token, _ int) bool {
+			return t.Value != ","
+		})
+
+		cfg := cronFieldConfigs[i]
+		values := []string{}
+
+		for _, token := range group {
+			switch {
+			case token.Value == "*":
+				values = append(values, "*")
+			case strings.HasPrefix(token.Value, "*/"):
+				if !cfg.stepValues {
+					return nil, Error{Message: fmt.Sprintf("step values are not allowed in %s field", cfg.label), Token: token}
+				}
+				min := cfg.min
+				if min == 0 {
+					min = 1
+				}
+				trimmed := strings.TrimPrefix(token.Value, "*/")
+				n, err := strconv.Atoi(trimmed)
+				if err != nil || n < min || n > cfg.max {
+					return nil, Error{
+						Message: fmt.Sprintf("invalid step value '%s' for %s field - must be integer between %d and %d", trimmed, cfg.label, min, cfg.max),
+						Token:   token,
+					}
+				}
+				values = append(values, token.Value)
+			case intValueRegex.MatchString(token.Value):
+				matches := intValueRegex.FindStringSubmatch(token.Value)
+				matches = matches[1:]
+				if matches[1] == "" {
+					matches = matches[:1]
+				}
+				ints := lo.Map(matches, func(s string, _ int) int {
+					v, _ := strconv.Atoi(s)
+					return v
+				})
+				for i, v := range ints {
+					if v < cfg.min || v > cfg.max {
+						return nil, Error{
+							Message: fmt.Sprintf("invalid value '%d' for %s field - must be integer between %d and %d", v, cfg.label, cfg.min, cfg.max),
+							Token:   token,
+						}
+					}
+					if i == 1 && v < ints[0] {
+						return nil, Error{
+							Message: "invalid range - left value must be smaller than right value",
+							Token:   token,
+						}
+					}
+				}
+				if len(cfg.altValues) > 0 {
+					altValues := lo.Map(ints, func(v int, _ int) string {
+						return cfg.altValues[v]
+					})
+					values = append(values, strings.Join(altValues, "-"))
+				} else {
+					values = append(values, token.Value)
+				}
+			case namedValueRegex.MatchString(token.Value):
+				matches := namedValueRegex.FindStringSubmatch(token.Value)
+				matches = matches[1:]
+				if matches[1] == "" {
+					matches = matches[:1]
+				}
+				for _, v := range matches {
+					if !lo.Contains(cfg.altValues, strings.ToUpper(v)) {
+						return nil, Error{
+							Message: fmt.Sprintf("invalid value '%s' for %s field", v, cfg.label),
+							Token:   token,
+						}
+					}
+				}
+				values = append(values, strings.ToUpper(token.Value))
+			default:
+				return nil, Error{
+					Message: fmt.Sprintf("invalid value '%s' for %s field", token.Value, cfg.label),
+					Token:   token,
+				}
+			}
+		}
+
+		fieldValue := strings.Join(values, ",")
+		switch i {
+		case 0:
+			c.Minutes = fieldValue
+		case 1:
+			c.Hours = fieldValue
+		case 2:
+			c.DayOfMonth = fieldValue
+		case 3:
+			c.Month = fieldValue
+		case 4:
+			c.DayOfWeek = fieldValue
+		}
+	}
+
+	// From AWS EventBridge cron docs:
+	// > You can't specify the Day-of-month and Day-of-week fields in the same cron expression.
+	// > If you specify a value or a * (asterisk) in one of the fields, you must use a ? (question mark) in the other.
+	switch {
+	case c.DayOfMonth == "*":
+		c.DayOfMonth = "?"
+	case c.DayOfWeek == "*":
+		c.DayOfWeek = "?"
+	}
+	if c.DayOfMonth != "?" && c.DayOfWeek != "?" {
+		return nil, Error{Message: "cannot specify values for both day-of-month and day-of-week - if one is provided the other must be '*'"}
+	}
+
+	return c, nil
+}
+
+var (
+	twelveHourTime     = regexp.MustCompile(`^(\d{1,2})(am|pm)$`)
+	twentyFourHourTime = regexp.MustCompile(`^(\d{1,2}):(\d{2})$`)
+)
+
+func parseTime(token *Token) (int, error) {
+	if token == nil {
+		return 0, Error{Message: "unexpected end of input - expected time e.g. '9am'"}
+	}
+
+	switch {
+	case twelveHourTime.MatchString(token.Value):
+		matches := twelveHourTime.FindStringSubmatch(strings.ToLower(token.Value))
+		// Due to the regex we know matches[1] is an integer
+		hour, _ := strconv.Atoi(matches[1])
+
+		// But it may be out-of-bounds for a 12-hour time
+		if hour < 1 || hour > 12 {
+			return 0, Error{Message: fmt.Sprintf("invalid 12-hour time '%s'", token.Value), Token: token}
+		}
+
+		if matches[2] == "pm" && hour != 12 {
+			hour += 12
+		}
+		if matches[2] == "am" && hour == 12 {
+			hour = 0
+		}
+
+		return hour, nil
+	case twentyFourHourTime.MatchString(token.Value):
+		return 0, Error{Message: "24-hour format isn't supported", Token: token}
+	default:
+		return 0, Error{
+			Message: fmt.Sprintf("invalid time '%s' - must be 12-hour format e.g. '9am'", token.Value),
+			Token:   token,
+		}
+	}
+}
+
+type CronExpression struct {
+	Minutes    string
+	Hours      string
+	DayOfMonth string
+	Month      string
+	DayOfWeek  string
+}
+
+func (c *CronExpression) String() string {
+	return fmt.Sprintf("%s %s %s %s %s *", c.Minutes, c.Hours, c.DayOfMonth, c.Month, c.DayOfWeek)
+}
+
+type Tokens struct {
+	tokens    []*Token
+	currIndex int
+}
+
+// Peek returns the next token or nil but does not advance the current token
+func (t *Tokens) Peek() *Token {
+	i := t.currIndex
+	i++
+	if i > len(t.tokens)-1 {
+		return nil
+	}
+	return t.tokens[i]
+}
+
+// Next returns the next token or nil and advances the current token
+func (t *Tokens) Next() *Token {
+	t.currIndex++
+	if t.currIndex > len(t.tokens)-1 {
+		return nil
+	}
+	return t.tokens[t.currIndex]
+}
+
+// MatchOrNil is like Next() but checks that the next token (if it exists)
+// matches one of the expected values
+func (t *Tokens) MatchOrNil(expected ...string) (*Token, error) {
+	tok := t.Next()
+	if tok == nil {
+		return nil, nil
+	}
+	if len(expected) > 0 {
+		match := false
+		for _, v := range expected {
+			if tok.Value == v {
+				match = true
+			}
+		}
+		if !match {
+			return nil, Error{
+				Message: fmt.Sprintf("unexpected token '%s' - expected %s", tok.Value, expectedToString(expected...)),
+				Token:   tok,
+			}
+		}
+	}
+	return tok, nil
+}
+
+// Match is like like MatchOrNil but will return an error if the returned token is nil
+func (t *Tokens) Match(expected ...string) (*Token, error) {
+	tok, err := t.MatchOrNil(expected...)
+	if err != nil {
+		return tok, err
+	}
+	if tok == nil {
+		return nil, Error{Message: fmt.Sprintf("unexpected end of input - expected %s", expectedToString(expected...))}
+	}
+	return tok, nil
+}
+
+// List starts at the next token and will keep consuming tokens while they are in a list. A list is separated by
+// commas and 'and'.
+// As an example both 'a,b,c' and 'a, b, and c' would result in the list ['a', 'b', 'c'].
+func (t *Tokens) List() []*Token {
+	list := []*Token{}
+	next := t.Peek()
+	isSeperator := true
+
+	for {
+		if next == nil {
+			return list
+		}
+
+		if next.Value == "," || next.Value == "and" {
+			_ = t.Next()
+			next = t.Peek()
+			isSeperator = true
+			continue
+		}
+
+		if !isSeperator {
+			return list
+		}
+
+		isSeperator = false
+		list = append(list, next)
+		_ = t.Next()
+		next = t.Peek()
+	}
+}
+
+func expectedToString(expected ...string) string {
+	quoted := lo.Map(expected, func(s string, _ int) string {
+		return fmt.Sprintf("'%s'", s)
+	})
+	switch len(quoted) {
+	case 1:
+		return quoted[0]
+	case 2:
+		return strings.Join(quoted, " or ")
+	default:
+		return strings.Join(quoted[:len(quoted)-1], ", ") + " or " + quoted[len(quoted)-1]
+	}
+}
+
+type Token struct {
+	Value string
+	Start int
+	End   int
+}
+
+// toTokens breaks src up into tokens. It is a very crude/simple lexer.
+func toTokens(src string) *Tokens {
+	tokens := &Tokens{currIndex: -1}
+	var t *Token
+
+	for i, char := range src {
+		// Ignore whitespace
+		if char == ' ' {
+			continue
+		}
+
+		// If no token make a new one
+		if t == nil {
+			t = &Token{
+				Start: i + 1,
+			}
+			tokens.tokens = append(tokens.tokens, t)
+		}
+
+		t.Value = fmt.Sprintf("%s%c", t.Value, char)
+
+		// We've reached the end of the current token if one of the following is true:
+		// [1] this is the last character of src
+		// [2] the next character is whitespace
+		// [3] the next character is a comma
+		// [4] this character is a comma
+		isEndOfToken :=
+			(i == len(src)-1 || // [1]
+				src[i+1] == ' ' || // [2]
+				src[i+1] == ',' || // [3]
+				char == ',') // [4]
+
+		if isEndOfToken {
+			// +2 here because we want the end position to point to the character
+			// after the final character of this token
+			t.End = i + 2
+			t = nil
+		}
+	}
+
+	return tokens
+}

--- a/cron/cron_test.go
+++ b/cron/cron_test.go
@@ -1,0 +1,245 @@
+package cron_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/teamkeel/keel/cron"
+)
+
+type Fixture struct {
+	input    string
+	expected string
+}
+
+func TestParseCron(t *testing.T) {
+	fixtures := []Fixture{
+		{
+			"every 10 minutes",
+			"*/10 * ? * * *",
+		},
+		{
+			"   EveRy    10    mInUteS  ", // not fussy about whitespace or casing
+			"*/10 * ? * * *",
+		},
+		{
+			"every 30 minutes from 9am to 5pm",
+			"*/30 9-17 ? * * *",
+		},
+		{
+			"every 2 hours",
+			"0 */2 ? * * *",
+		},
+		{
+			"every 2 hours from 7am to 7pm",
+			"0 7,9,11,13,15,17,19 ? * * *",
+		},
+		{
+			"every monday at 10am",
+			"0 10 ? * MON *",
+		},
+		{
+			"every monday,wednesday,friday at 10am",
+			"0 10 ? * MON,WED,FRI *",
+		},
+		{
+			"every monday, wednesday, friday at 10am",
+			"0 10 ? * MON,WED,FRI *",
+		},
+		{
+			"every monday, wednesday, and friday at 10am",
+			"0 10 ? * MON,WED,FRI *",
+		},
+		{
+			"every tuesday and thursday at 9pm",
+			"0 21 ? * TUE,THU *",
+		},
+		{
+			"every tuesday and thursday and friday at 9pm",
+			"0 21 ? * TUE,THU,FRI *",
+		},
+		{
+			"every day at 4pm",
+			"0 16 ? * * *",
+		},
+		{
+			"every weekday at 7am",
+			"0 7 ? * MON-FRI *",
+		},
+		{
+			"every weekday at 9am and 5pm",
+			"0 9,17 ? * MON-FRI *",
+		},
+		{
+			"every monday,tuesday,wednesday at 9am,12pm,5pm",
+			"0 9,12,17 ? * MON,TUE,WED *",
+		},
+		{
+			"every day at 12am",
+			"0 0 ? * * *",
+		},
+		{
+			"* * * * *",
+			"* * ? * * *", // day-of-month becomes '?'
+		},
+		{
+			"* * * * 1,3,5",         // unix cron uses 0-indexed days-of-week starting on sunday
+			"* * ? * MON,WED,FRI *", // day-of-month becomes '?' and convert int values to named
+		},
+		{
+			"* * * 1,4,7,10 *",
+			"* * ? JAN,APR,JUL,OCT * *", // day-of-month becomes '?' and convert int values to named
+		},
+		{
+			"*/2 */3 */4 */5 *",   // weird but valid cron - every 2nd minute of every 3rd hour of every 4th day of the month of every 5th month
+			"*/2 */3 */4 */5 ? *", // day-of-week becomes '?' because day-of-month has value
+		},
+		{
+			"* * * JAN-MAR MON-FRI",
+			"* * ? JAN-MAR MON-FRI *", // day-of-month becomes '?'
+		},
+	}
+
+	for _, fixture := range fixtures {
+		t.Run(fixture.input, func(t *testing.T) {
+			s, err := cron.Parse(fixture.input)
+			require.NoError(t, err)
+			assert.Equal(t, fixture.expected, s.String())
+		})
+	}
+}
+
+func TestParseCronError(t *testing.T) {
+	fixtures := []Fixture{
+		{
+			"9am on mondays",
+			"invalid schedule - must be expression like 'every day at 9am' or cron syntax e.g. '0 9 * * *'",
+		},
+		{
+			"every",
+			"unexpected end of input - expected time interval or day e.g. '10 minutes' or 'monday'",
+		},
+		{
+			"every 20",
+			"unexpected end of input - expected 'minutes' or 'hours'",
+		},
+		{
+			"every 20 cats",
+			"(10:14) unexpected token 'cats' - expected 'minutes' or 'hours'",
+		},
+		{
+			"every 13 minutes",
+			"(7:9) value of minutes must divide evenly by 60",
+		},
+		{
+			"every 5 hours",
+			"(7:8) value of hours must divide evenly by 24",
+		},
+		{
+			"every 10 minutes from 5pm to 10am",
+			"(30:34) end time of schedule must be before start time",
+		},
+		{
+			"every 10 minutes from 5pm until 10am",
+			"(27:32) unexpected token 'until' - expected 'to'",
+		},
+		{
+			"every 2 hours between 9am and 3pm",
+			"(15:22) unexpected token 'between' - expected 'from'",
+		},
+		{
+			"every 2 hours from breakfast to 3pm",
+			"(20:29) invalid time 'breakfast' - must be 12-hour format e.g. '9am'",
+		},
+		{
+			"every 2 hours from 9am to sunset",
+			"(27:33) invalid time 'sunset' - must be 12-hour format e.g. '9am'",
+		},
+		{
+			"every funday at 10am",
+			"(7:13) invalid day 'funday' - expected day of week e.g. 'monday', 'day' for every day, or 'weekday' for monday-friday",
+		},
+		{
+			"every wednesday before 12pm",
+			"(17:23) unexpected token 'before' - expected 'at'",
+		},
+		{
+			"every wednesday at midday",
+			"(20:26) invalid time 'midday' - must be 12-hour format e.g. '9am'",
+		},
+		{
+			"every monday at 13am",
+			"(17:21) invalid 12-hour time '13am'",
+		},
+		{
+			"every monday at",
+			"unexpected end of input - expected time e.g. '9am'",
+		},
+		{
+			"every saturday at 14:00",
+			"(19:24) 24-hour format isn't supported",
+		},
+		{
+			"every monday and weekday at 12pm",
+			"(18:25) cannot use 'weekday' with other values",
+		},
+		{
+			"every day at 9am on the dot",
+			"(18:20) unexpected token 'on' - expected end of input",
+		},
+		{
+			"* * *",
+			"wrong number of fields - cron expression must have five fields",
+		},
+		{
+			"*/foo * * * *",
+			"(1:6) invalid step value 'foo' for seconds field - must be integer between 1 and 59",
+		},
+		{
+			"*/71 * * * *",
+			"(1:5) invalid step value '71' for seconds field - must be integer between 1 and 59",
+		},
+		{
+			"20-10 * * * *",
+			"(1:6) invalid range - left value must be smaller than right value",
+		},
+		{
+			"0 42 * * *",
+			"(3:5) invalid value '42' for hours field - must be integer between 0 and 23",
+		},
+		{
+			"0 9 35 * *",
+			"(5:7) invalid value '35' for day-of-month field - must be integer between 1 and 31",
+		},
+		{
+			"0 9 * 13 *",
+			"(7:9) invalid value '13' for month field - must be integer between 1 and 12",
+		},
+		{
+			"0 9 * FOO *",
+			"(7:10) invalid value 'FOO' for month field",
+		},
+		{
+			"0 9 * JAN-ERP *",
+			"(7:14) invalid value 'ERP' for month field",
+		},
+		{
+			"0 9 * * */2",
+			"(9:12) step values are not allowed in day-of-week field",
+		},
+		{
+			"0 9 1 * MON",
+			"cannot specify values for both day-of-month and day-of-week - if one is provided the other must be '*'",
+		},
+	}
+
+	for _, fixture := range fixtures {
+		t.Run(fixture.input, func(t *testing.T) {
+			s, err := cron.Parse(fixture.input)
+			assert.Nil(t, s)
+			require.NotNil(t, err)
+			assert.Equal(t, fixture.expected, err.Error())
+		})
+	}
+}

--- a/schema/makeproto.go
+++ b/schema/makeproto.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/samber/lo"
 	"github.com/teamkeel/keel/casing"
+	"github.com/teamkeel/keel/cron"
 	"github.com/teamkeel/keel/proto"
 	"github.com/teamkeel/keel/schema/parser"
 	"github.com/teamkeel/keel/schema/query"
@@ -1663,13 +1664,15 @@ func (scm *Builder) applyJobAttribute(parserJob *parser.JobNode, protoJob *proto
 	case parser.AttributePermission:
 		protoJob.Permissions = append(protoJob.Permissions, scm.permissionAttributeToProtoPermission(attribute))
 	case parser.AttributeSchedule:
-		schedule, err := attribute.Arguments[0].Expression.ToString()
-		if err != nil {
-			panic(err)
-		}
+		val, _ := attribute.Arguments[0].Expression.ToValue()
+
+		src := strings.TrimPrefix(*val.String, `"`)
+		src = strings.TrimSuffix(src, `"`)
+
+		c, _ := cron.Parse(src)
 
 		protoJob.Schedule = &proto.Schedule{
-			Expression: schedule,
+			Expression: c.String(),
 		}
 	}
 }

--- a/schema/testdata/proto_job_scheduled/proto.json
+++ b/schema/testdata/proto_job_scheduled/proto.json
@@ -233,9 +233,21 @@
   ],
   "jobs": [
     {
-      "name": "MyJob",
+      "name": "UnixCron",
       "schedule": {
-        "expression": "\"* * * * *\""
+        "expression": "*/10 * ? * MON-WED *"
+      }
+    },
+    {
+      "name": "IntervalCron",
+      "schedule": {
+        "expression": "*/10 * ? * * *"
+      }
+    },
+    {
+      "name": "DayCron",
+      "schedule": {
+        "expression": "0 9 ? * MON *"
       }
     }
   ]

--- a/schema/testdata/proto_job_scheduled/schema.keel
+++ b/schema/testdata/proto_job_scheduled/schema.keel
@@ -1,3 +1,11 @@
-job MyJob {
-    @schedule("* * * * *")
+job UnixCron {
+    @schedule("*/10 * * * 1-3")
+}
+
+job IntervalCron {
+    @schedule("every 10 minutes")
+}
+
+job DayCron {
+    @schedule("every monday at 9am")
 }

--- a/schema/testdata/validation_jobs_attributes/errors.json
+++ b/schema/testdata/validation_jobs_attributes/errors.json
@@ -18,20 +18,20 @@
       }
     },
     {
-      "message": "Scheduled job 'MyJob2' cannot be defined with inputs",
-      "hint": "Remove the inputs section to define a scheduled job",
+      "message": "Job 'MyJob2' is scheduled and so cannot also have inputs",
+      "hint": "",
       "code": "JobDefinitionError",
       "pos": {
         "filename": "testdata/validation_jobs_attributes/schema.keel",
-        "offset": 111,
-        "line": 12,
+        "offset": 60,
+        "line": 7,
         "column": 5
       },
       "endPos": {
         "filename": "testdata/validation_jobs_attributes/schema.keel",
-        "offset": 120,
-        "line": 12,
-        "column": 14
+        "offset": 66,
+        "line": 7,
+        "column": 11
       }
     }
   ]

--- a/schema/testdata/validation_jobs_duplicate_inputs_names/errors.json
+++ b/schema/testdata/validation_jobs_duplicate_inputs_names/errors.json
@@ -2,7 +2,7 @@
   "errors": [
     {
       "message": "Job input with name 'myField' already exists",
-      "hint": "Rename the input with a unique name",
+      "hint": "",
       "code": "DuplicateDefinitionError",
       "pos": {
         "filename": "testdata/validation_jobs_duplicate_inputs_names/schema.keel",

--- a/schema/testdata/validation_jobs_duplicate_names/errors.json
+++ b/schema/testdata/validation_jobs_duplicate_names/errors.json
@@ -1,9 +1,9 @@
 {
   "errors": [
     {
-      "message": "Job with name 'MyJob' already exists",
-      "hint": "Rename the job with a unique name",
-      "code": "DuplicateDefinitionError",
+      "message": "There is already a job with the name MyJob",
+      "hint": "Job names must be unique",
+      "code": "NamingError",
       "pos": {
         "filename": "testdata/validation_jobs_duplicate_names/schema.keel",
         "offset": 46,

--- a/schema/testdata/validation_jobs_schedule/errors.json
+++ b/schema/testdata/validation_jobs_schedule/errors.json
@@ -1,156 +1,122 @@
 {
   "errors": [
     {
-      "message": "Job with name 'MyJob' already exists",
-      "hint": "Rename the job with a unique name",
-      "code": "DuplicateDefinitionError",
+      "message": "@schedule must have exactly one argument",
+      "hint": "",
+      "code": "AttributeArgumentError",
       "pos": {
         "filename": "testdata/validation_jobs_schedule/schema.keel",
-        "offset": 46,
-        "line": 5,
+        "offset": 17,
+        "line": 2,
         "column": 5
       },
       "endPos": {
         "filename": "testdata/validation_jobs_schedule/schema.keel",
-        "offset": 51,
-        "line": 5,
-        "column": 10
+        "offset": 26,
+        "line": 2,
+        "column": 14
       }
     },
     {
       "message": "@schedule must have exactly one argument",
       "hint": "",
-      "code": "AttributeNotAllowedError",
+      "code": "AttributeArgumentError",
       "pos": {
         "filename": "testdata/validation_jobs_schedule/schema.keel",
-        "offset": 58,
+        "offset": 52,
         "line": 6,
         "column": 5
       },
       "endPos": {
         "filename": "testdata/validation_jobs_schedule/schema.keel",
-        "offset": 67,
+        "offset": 61,
         "line": 6,
         "column": 14
       }
     },
     {
-      "message": "Job with name 'MyJob' already exists",
-      "hint": "Rename the job with a unique name",
-      "code": "DuplicateDefinitionError",
+      "message": "argument must be a string",
+      "hint": "e.g. @schedule(\"every 10 minutes\")",
+      "code": "AttributeArgumentError",
       "pos": {
         "filename": "testdata/validation_jobs_schedule/schema.keel",
-        "offset": 108,
-        "line": 9,
-        "column": 5
-      },
-      "endPos": {
-        "filename": "testdata/validation_jobs_schedule/schema.keel",
-        "offset": 113,
-        "line": 9,
-        "column": 10
-      }
-    },
-    {
-      "message": "Job with name 'MyJob' already exists",
-      "hint": "Rename the job with a unique name",
-      "code": "DuplicateDefinitionError",
-      "pos": {
-        "filename": "testdata/validation_jobs_schedule/schema.keel",
-        "offset": 147,
+        "offset": 156,
         "line": 13,
-        "column": 5
+        "column": 15
       },
       "endPos": {
         "filename": "testdata/validation_jobs_schedule/schema.keel",
-        "offset": 152,
+        "offset": 160,
         "line": 13,
-        "column": 10
+        "column": 19
       }
     },
     {
-      "message": "@schedule argument is not correctly formatted",
-      "hint": "schedule should be in the following format @schedule(\"0 6 * * * *\")",
-      "code": "AttributeNotAllowedError",
+      "message": "argument to @schedule cannot be labelled",
+      "hint": "",
+      "code": "AttributeArgumentError",
       "pos": {
         "filename": "testdata/validation_jobs_schedule/schema.keel",
-        "offset": 159,
-        "line": 14,
-        "column": 5
+        "offset": 194,
+        "line": 17,
+        "column": 15
       },
       "endPos": {
         "filename": "testdata/validation_jobs_schedule/schema.keel",
-        "offset": 168,
-        "line": 14,
-        "column": 14
+        "offset": 198,
+        "line": 17,
+        "column": 19
       }
     },
     {
-      "message": "Job with name 'MyJob' already exists",
-      "hint": "Rename the job with a unique name",
-      "code": "DuplicateDefinitionError",
+      "message": "unexpected token 'cats' - expected 'minutes' or 'hours'",
+      "hint": "",
+      "code": "AttributeArgumentError",
       "pos": {
         "filename": "testdata/validation_jobs_schedule/schema.keel",
-        "offset": 180,
-        "line": 17,
-        "column": 5
+        "offset": 256,
+        "line": 21,
+        "column": 25
       },
       "endPos": {
         "filename": "testdata/validation_jobs_schedule/schema.keel",
-        "offset": 185,
-        "line": 17,
-        "column": 10
+        "offset": 260,
+        "line": 21,
+        "column": 29
       }
     },
     {
-      "message": "@schedule must not have a label",
+      "message": "invalid value 'BOB' for day-of-week field",
+      "hint": "",
+      "code": "AttributeArgumentError",
+      "pos": {
+        "filename": "testdata/validation_jobs_schedule/schema.keel",
+        "offset": 310,
+        "line": 25,
+        "column": 27
+      },
+      "endPos": {
+        "filename": "testdata/validation_jobs_schedule/schema.keel",
+        "offset": 313,
+        "line": 25,
+        "column": 30
+      }
+    },
+    {
+      "message": "A job cannot have more than one @schedule attribute",
       "hint": "",
       "code": "AttributeNotAllowedError",
       "pos": {
         "filename": "testdata/validation_jobs_schedule/schema.keel",
-        "offset": 192,
-        "line": 18,
+        "offset": 376,
+        "line": 30,
         "column": 5
       },
       "endPos": {
         "filename": "testdata/validation_jobs_schedule/schema.keel",
-        "offset": 201,
-        "line": 18,
+        "offset": 385,
+        "line": 30,
         "column": 14
-      }
-    },
-    {
-      "message": "@schedule argument is not correctly formatted",
-      "hint": "schedule should be in the following format @schedule(\"0 6 * * * *\")",
-      "code": "AttributeNotAllowedError",
-      "pos": {
-        "filename": "testdata/validation_jobs_schedule/schema.keel",
-        "offset": 192,
-        "line": 18,
-        "column": 5
-      },
-      "endPos": {
-        "filename": "testdata/validation_jobs_schedule/schema.keel",
-        "offset": 201,
-        "line": 18,
-        "column": 14
-      }
-    },
-    {
-      "message": "Job with name 'MyJob' already exists",
-      "hint": "Rename the job with a unique name",
-      "code": "DuplicateDefinitionError",
-      "pos": {
-        "filename": "testdata/validation_jobs_schedule/schema.keel",
-        "offset": 219,
-        "line": 21,
-        "column": 5
-      },
-      "endPos": {
-        "filename": "testdata/validation_jobs_schedule/schema.keel",
-        "offset": 224,
-        "line": 21,
-        "column": 10
       }
     }
   ]

--- a/schema/testdata/validation_jobs_schedule/schema.keel
+++ b/schema/testdata/validation_jobs_schedule/schema.keel
@@ -1,23 +1,31 @@
-job MyJob {
-    @schedule("0 2 1 1 2")
+job NoArgs {
+    @schedule
 }
 
-job MyJob {
-    @schedule("0 6 * * *", "America/New_York")
+job TooManyArgs {
+    @schedule(
+        "every 10 minutes",
+        "also mondays"
+    )
 }
 
-job MyJob {
-    @schedule("121212")
+job WrongArgType {
+    @schedule(1234)
 }
 
-job MyJob {
-    @schedule("")
+job Labelled {
+    @schedule(cron: "foo")
 }
 
-job MyJob {
-    @schedule(cron: "")
+job InvalidSchedule {
+    @schedule("every 10 cats")
 }
 
-job MyJob {
-    @schedule(1234123)
+job InvalidCron {
+    @schedule("*/10 * * * BOB")
+}
+
+job TwoSchedules {
+    @schedule("every 10 minutes")
+    @schedule("every 2 hours")
 }

--- a/schema/validation/duplicate_definition.go
+++ b/schema/validation/duplicate_definition.go
@@ -7,11 +7,13 @@ import (
 	"github.com/teamkeel/keel/schema/validation/errorhandling"
 )
 
-// DuplicateDefinitionRule checks the uniqueness of model, enum and message names.
+// DuplicateDefinitionRule checks the uniqueness of model, enum, message, and job names.
 //
 // Model, enum, and message names need to be globally unique.
+// There cannot be two jobs with the same name
 func DuplicateDefinitionRule(asts []*parser.AST, errs *errorhandling.ValidationErrors) Visitor {
 	names := map[string]string{}
+	jobs := map[string]bool{}
 
 	return Visitor{
 		EnterModel: func(n *parser.ModelNode) {
@@ -41,15 +43,29 @@ func DuplicateDefinitionRule(asts []*parser.AST, errs *errorhandling.ValidationE
 			}
 			names[n.Name.Value] = "message"
 		},
+		EnterJob: func(n *parser.JobNode) {
+			if _, ok := jobs[n.Name.Value]; ok {
+				errs.AppendError(
+					duplicateDefinitionError(n.Name, "job"),
+				)
+				return
+			}
+			jobs[n.Name.Value] = true
+		},
 	}
 }
 
 func duplicateDefinitionError(n parser.NameNode, existingEntity string) *errorhandling.ValidationError {
+	hint := "Use unique names between models, enums and messages"
+	if existingEntity == "job" {
+		hint = "Job names must be unique"
+	}
+
 	return errorhandling.NewValidationErrorWithDetails(
 		errorhandling.NamingError,
 		errorhandling.ErrorDetails{
 			Message: fmt.Sprintf("There is already a %s with the name %s", existingEntity, n.Value),
-			Hint:    "Use unique names between models, enums and messages",
+			Hint:    hint,
 		},
 		n,
 	)

--- a/schema/validation/schedule_attribute.go
+++ b/schema/validation/schedule_attribute.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"strings"
 
+	"github.com/teamkeel/keel/cron"
 	"github.com/teamkeel/keel/schema/parser"
 	"github.com/teamkeel/keel/schema/validation/errorhandling"
 )
@@ -16,35 +17,79 @@ func ScheduleAttributeRule(asts []*parser.AST, errs *errorhandling.ValidationErr
 
 			if len(attribute.Arguments) != 1 {
 				errs.AppendError(errorhandling.NewValidationErrorWithDetails(
-					errorhandling.AttributeNotAllowedError,
+					errorhandling.AttributeArgumentError,
 					errorhandling.ErrorDetails{
 						Message: "@schedule must have exactly one argument",
 					},
 					attribute.Name,
 				))
+				return
 			}
 
-			if attribute.Arguments[0].Label != nil {
+			arg := attribute.Arguments[0]
+			if arg.Label != nil {
 				errs.AppendError(errorhandling.NewValidationErrorWithDetails(
-					errorhandling.AttributeNotAllowedError,
+					errorhandling.AttributeArgumentError,
 					errorhandling.ErrorDetails{
-						Message: "@schedule must not have a label",
+						Message: "argument to @schedule cannot be labelled",
 					},
-					attribute.Name,
+					arg.Label,
 				))
+				return
 			}
 
-			operand := attribute.Arguments[0].Expression.Tokens[0].Value
-			removed := strings.ReplaceAll(operand, "\"", "")
-			if removed == "" {
+			op, err := arg.Expression.ToValue()
+			if err != nil || op.String == nil {
 				errs.AppendError(errorhandling.NewValidationErrorWithDetails(
-					errorhandling.AttributeNotAllowedError,
+					errorhandling.AttributeArgumentError,
 					errorhandling.ErrorDetails{
-						Message: "@schedule argument is not correctly formatted",
-						Hint:    "schedule should be in the following format @schedule(\"0 6 * * * *\")",
+						Message: "argument must be a string",
+						Hint:    "e.g. @schedule(\"every 10 minutes\")",
 					},
-					attribute.Name,
+					arg.Expression,
 				))
+				return
+			}
+
+			src := strings.TrimPrefix(*op.String, `"`)
+			src = strings.TrimSuffix(src, `"`)
+
+			_, err = cron.Parse(src)
+			if err != nil {
+				cronError, ok := cron.ToError(err)
+				if !ok || cronError.Token == nil {
+					errs.AppendError(errorhandling.NewValidationErrorWithDetails(
+						errorhandling.AttributeArgumentError,
+						errorhandling.ErrorDetails{
+							Message: err.Error(),
+						},
+						arg.Expression,
+					))
+					return
+				}
+
+				start, end := arg.Expression.GetPositionRange()
+				tok := cronError.Token
+				endOffset := (len(*op.String) - tok.End)
+
+				errs.AppendError(&errorhandling.ValidationError{
+					Code: string(errorhandling.AttributeArgumentError),
+					ErrorDetails: &errorhandling.ErrorDetails{
+						Message: cronError.Message,
+					},
+					Pos: errorhandling.LexerPos{
+						Filename: start.Filename,
+						Offset:   start.Offset + tok.Start,
+						Line:     start.Line,
+						Column:   start.Column + tok.Start,
+					},
+					EndPos: errorhandling.LexerPos{
+						Filename: end.Filename,
+						Offset:   end.Offset - endOffset,
+						Line:     end.Line,
+						Column:   end.Column - endOffset,
+					},
+				})
 			}
 		},
 	}


### PR DESCRIPTION
### Summary

* Human-readable schedule expressions like **"every 10 minutes"** or **"every monday at 9am"** with strict validation
* Validation for cron-syntax with conversion from unix-style to what EventBridge expects
* Validation that there is only one `@schedule` attribute in a job - we only support one

### Human-readable schedules

The following formats are supported:

* `every N minutes`
* `every N minutes from T to T`
* `every N hours`
* `every N hours from T to T`
* `every D at T`

Where `N` is an integer, `T` is a 12-hour time, and `D` is a day. 

In the `every D at T` format both `D` and `T` can be lists of values, for example **"every monday and friday at 9am, 12pm, and 5pm"** produces the cron expression `0 9,12,17 ? * MON,FRI *`. `D` can also be `day` for everyday or `weekday` for MON-FRI.

### Cron schedules

Cron syntax is still supported but it is now strictly validated against unix-style rules with the following two exceptions:

* You can't have a value in both day-of-month and day-of-week - this is an EventBridge limitation
* You can't use a step value (e.g. `*/2`) in day-of-week - EventBridge does not support this

### Validation

Validation errors will point to the relevant part of the string where the error occurs (where possible). For example:

<img width="824" alt="Screenshot 2023-11-03 at 13 09 54" src="https://github.com/teamkeel/keel/assets/1671025/b4234259-8785-4ac1-bc9e-de9a58ee7b22">







