### PR TITLE
fix: named inputs as lhs expression operand

### DIFF
--- a/integration/testdata/operation_list_where_explicit/main.test.ts
+++ b/integration/testdata/operation_list_where_explicit/main.test.ts
@@ -17,6 +17,20 @@ test("List Where filters - using equal operator (string) - filters correctly", a
   expect(results[0].title).toEqual("Fred");
 });
 
+test("List Where filters inverse - using equal operator (string) - filters correctly", async () => {
+  await actions.createPost({ title: "Fred" });
+  await actions.createPost({ title: "NotFred" });
+
+  const { results } = await actions.listPostsEqualStringInverse({
+    where: {
+      whereArg: "Fred",
+    },
+  });
+
+  expect(results.length).toEqual(1);
+  expect(results[0].title).toEqual("Fred");
+});
+
 test("List Where filters - using not equal operator (string) - filters correctly", async () => {
   await actions.createPost({ title: "Fred" });
   await actions.createPost({ title: "NotFred" });

--- a/integration/testdata/operation_list_where_explicit/schema.keel
+++ b/integration/testdata/operation_list_where_explicit/schema.keel
@@ -11,6 +11,9 @@ model Post {
         list listPostsEqualString(whereArg: Text) {
             @where(post.title == whereArg)
         }
+        list listPostsEqualStringInverse(whereArg: Text) {
+            @where(whereArg == post.title)
+        }
         list listPostsNotEqualString(whereArg: Text) {
             @where(post.title != whereArg)
         }

--- a/schema/expressions/scope.go
+++ b/schema/expressions/scope.go
@@ -362,15 +362,8 @@ func applyAdditionalOperandScopes(asts []*parser.AST, scope *ExpressionScope, co
 	switch attribute.Name.Value {
 	case parser.AttributePermission:
 		// no inputs allowed in permissions
-	case parser.AttributeValidate:
-		if position == OperandPositionLhs {
-			scope = applyInputsInScope(asts, context, scope)
-		}
 	default:
-		// todo: is this correct?
-		if position == OperandPositionRhs {
-			scope = applyInputsInScope(asts, context, scope)
-		}
+		scope = applyInputsInScope(asts, context, scope)
 	}
 
 	return scope.Merge(additionalScope)

--- a/schema/testdata/proto_expression_named_inputs/proto.json
+++ b/schema/testdata/proto_expression_named_inputs/proto.json
@@ -8,31 +8,8 @@
           "name": "name",
           "type": {
             "type": "TYPE_STRING"
-          }
-        },
-        {
-          "modelName": "Person",
-          "name": "public",
-          "type": {
-            "type": "TYPE_BOOL"
-          }
-        },
-        {
-          "modelName": "Person",
-          "name": "dateOfDeath",
-          "type": {
-            "type": "TYPE_DATE"
           },
           "optional": true
-        },
-        {
-          "modelName": "Person",
-          "name": "identity",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "Identity"
-          },
-          "foreignKeyFieldName": "identityId"
         },
         {
           "modelName": "Person",
@@ -64,40 +41,38 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Person",
-          "name": "identityId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Identity",
-            "relatedModelField": "id"
-          }
         }
       ],
       "actions": [
         {
           "modelName": "Person",
-          "name": "getPeople",
-          "type": "ACTION_TYPE_LIST",
+          "name": "getBob",
+          "type": "ACTION_TYPE_GET",
           "implementation": "ACTION_IMPLEMENTATION_AUTO",
-          "permissions": [
-            {
-              "modelName": "Person",
-              "actionName": "getPeople",
-              "expression": {
-                "source": "person.public == true"
-              }
-            }
-          ],
           "whereExpressions": [
             {
-              "source": "person.public == true"
+              "source": "n == \"Bob\""
+            },
+            {
+              "source": "\"Bob\" == n"
             }
           ],
-          "inputMessageName": "GetPeopleInput"
+          "inputMessageName": "GetBobInput"
+        },
+        {
+          "modelName": "Person",
+          "name": "getPerson",
+          "type": "ACTION_TYPE_GET",
+          "implementation": "ACTION_IMPLEMENTATION_AUTO",
+          "whereExpressions": [
+            {
+              "source": "n == person.name"
+            },
+            {
+              "source": "person.name == n"
+            }
+          ],
+          "inputMessageName": "GetPersonInput"
         },
         {
           "modelName": "Person",
@@ -106,25 +81,10 @@
           "implementation": "ACTION_IMPLEMENTATION_AUTO",
           "setExpressions": [
             {
-              "source": "person.identity = ctx.identity"
-            },
-            {
-              "source": "person.public = true"
+              "source": "person.name = n"
             }
           ],
           "inputMessageName": "CreatePersonInput"
-        },
-        {
-          "modelName": "Person",
-          "name": "kill",
-          "type": "ACTION_TYPE_UPDATE",
-          "implementation": "ACTION_IMPLEMENTATION_AUTO",
-          "setExpressions": [
-            {
-              "source": "person.dateOfDeath = ctx.now"
-            }
-          ],
-          "inputMessageName": "KillInput"
         }
       ]
     },
@@ -259,144 +219,10 @@
       "name": "Any"
     },
     {
-      "name": "StringQueryInput",
+      "name": "GetBobInput",
       "fields": [
         {
-          "messageName": "StringQueryInput",
-          "name": "equals",
-          "type": {
-            "type": "TYPE_STRING"
-          },
-          "optional": true,
-          "nullable": true
-        },
-        {
-          "messageName": "StringQueryInput",
-          "name": "notEquals",
-          "type": {
-            "type": "TYPE_STRING"
-          },
-          "optional": true,
-          "nullable": true
-        },
-        {
-          "messageName": "StringQueryInput",
-          "name": "startsWith",
-          "type": {
-            "type": "TYPE_STRING"
-          },
-          "optional": true
-        },
-        {
-          "messageName": "StringQueryInput",
-          "name": "endsWith",
-          "type": {
-            "type": "TYPE_STRING"
-          },
-          "optional": true
-        },
-        {
-          "messageName": "StringQueryInput",
-          "name": "contains",
-          "type": {
-            "type": "TYPE_STRING"
-          },
-          "optional": true
-        },
-        {
-          "messageName": "StringQueryInput",
-          "name": "oneOf",
-          "type": {
-            "type": "TYPE_STRING",
-            "repeated": true
-          },
-          "optional": true
-        }
-      ]
-    },
-    {
-      "name": "GetPeopleWhere",
-      "fields": [
-        {
-          "messageName": "GetPeopleWhere",
-          "name": "name",
-          "type": {
-            "type": "TYPE_MESSAGE",
-            "messageName": "StringQueryInput"
-          },
-          "target": [
-            "name"
-          ]
-        }
-      ]
-    },
-    {
-      "name": "GetPeopleInput",
-      "fields": [
-        {
-          "messageName": "GetPeopleInput",
-          "name": "where",
-          "type": {
-            "type": "TYPE_MESSAGE",
-            "messageName": "GetPeopleWhere"
-          }
-        },
-        {
-          "messageName": "GetPeopleInput",
-          "name": "first",
-          "type": {
-            "type": "TYPE_INT"
-          },
-          "optional": true
-        },
-        {
-          "messageName": "GetPeopleInput",
-          "name": "after",
-          "type": {
-            "type": "TYPE_STRING"
-          },
-          "optional": true
-        },
-        {
-          "messageName": "GetPeopleInput",
-          "name": "last",
-          "type": {
-            "type": "TYPE_INT"
-          },
-          "optional": true
-        },
-        {
-          "messageName": "GetPeopleInput",
-          "name": "before",
-          "type": {
-            "type": "TYPE_STRING"
-          },
-          "optional": true
-        }
-      ]
-    },
-    {
-      "name": "CreatePersonInput",
-      "fields": [
-        {
-          "messageName": "CreatePersonInput",
-          "name": "name",
-          "type": {
-            "type": "TYPE_STRING",
-            "modelName": "Person",
-            "fieldName": "name"
-          },
-          "target": [
-            "name"
-          ]
-        }
-      ]
-    },
-    {
-      "name": "KillWhere",
-      "fields": [
-        {
-          "messageName": "KillWhere",
+          "messageName": "GetBobInput",
           "name": "id",
           "type": {
             "type": "TYPE_ID",
@@ -406,31 +232,49 @@
           "target": [
             "id"
           ]
+        },
+        {
+          "messageName": "GetBobInput",
+          "name": "n",
+          "type": {
+            "type": "TYPE_STRING"
+          }
         }
       ]
     },
     {
-      "name": "KillValues"
-    },
-    {
-      "name": "KillInput",
+      "name": "GetPersonInput",
       "fields": [
         {
-          "messageName": "KillInput",
-          "name": "where",
+          "messageName": "GetPersonInput",
+          "name": "id",
           "type": {
-            "type": "TYPE_MESSAGE",
-            "messageName": "KillWhere"
-          }
+            "type": "TYPE_ID",
+            "modelName": "Person",
+            "fieldName": "id"
+          },
+          "target": [
+            "id"
+          ]
         },
         {
-          "messageName": "KillInput",
-          "name": "values",
+          "messageName": "GetPersonInput",
+          "name": "n",
           "type": {
-            "type": "TYPE_MESSAGE",
-            "messageName": "KillValues"
-          },
-          "optional": true
+            "type": "TYPE_STRING"
+          }
+        }
+      ]
+    },
+    {
+      "name": "CreatePersonInput",
+      "fields": [
+        {
+          "messageName": "CreatePersonInput",
+          "name": "n",
+          "type": {
+            "type": "TYPE_STRING"
+          }
         }
       ]
     },

--- a/schema/testdata/proto_expression_named_inputs/proto.json
+++ b/schema/testdata/proto_expression_named_inputs/proto.json
@@ -1,0 +1,541 @@
+{
+  "models": [
+    {
+      "name": "Person",
+      "fields": [
+        {
+          "modelName": "Person",
+          "name": "name",
+          "type": {
+            "type": "TYPE_STRING"
+          }
+        },
+        {
+          "modelName": "Person",
+          "name": "public",
+          "type": {
+            "type": "TYPE_BOOL"
+          }
+        },
+        {
+          "modelName": "Person",
+          "name": "dateOfDeath",
+          "type": {
+            "type": "TYPE_DATE"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Person",
+          "name": "identity",
+          "type": {
+            "type": "TYPE_MODEL",
+            "modelName": "Identity"
+          },
+          "foreignKeyFieldName": "identityId"
+        },
+        {
+          "modelName": "Person",
+          "name": "id",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "primaryKey": true,
+          "defaultValue": {
+            "useZeroValue": true
+          }
+        },
+        {
+          "modelName": "Person",
+          "name": "createdAt",
+          "type": {
+            "type": "TYPE_DATETIME"
+          },
+          "defaultValue": {
+            "useZeroValue": true
+          }
+        },
+        {
+          "modelName": "Person",
+          "name": "updatedAt",
+          "type": {
+            "type": "TYPE_DATETIME"
+          },
+          "defaultValue": {
+            "useZeroValue": true
+          }
+        },
+        {
+          "modelName": "Person",
+          "name": "identityId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Identity",
+            "relatedModelField": "id"
+          }
+        }
+      ],
+      "actions": [
+        {
+          "modelName": "Person",
+          "name": "getPeople",
+          "type": "ACTION_TYPE_LIST",
+          "implementation": "ACTION_IMPLEMENTATION_AUTO",
+          "permissions": [
+            {
+              "modelName": "Person",
+              "actionName": "getPeople",
+              "expression": {
+                "source": "person.public == true"
+              }
+            }
+          ],
+          "whereExpressions": [
+            {
+              "source": "person.public == true"
+            }
+          ],
+          "inputMessageName": "GetPeopleInput"
+        },
+        {
+          "modelName": "Person",
+          "name": "createPerson",
+          "type": "ACTION_TYPE_CREATE",
+          "implementation": "ACTION_IMPLEMENTATION_AUTO",
+          "setExpressions": [
+            {
+              "source": "person.identity = ctx.identity"
+            },
+            {
+              "source": "person.public = true"
+            }
+          ],
+          "inputMessageName": "CreatePersonInput"
+        },
+        {
+          "modelName": "Person",
+          "name": "kill",
+          "type": "ACTION_TYPE_UPDATE",
+          "implementation": "ACTION_IMPLEMENTATION_AUTO",
+          "setExpressions": [
+            {
+              "source": "person.dateOfDeath = ctx.now"
+            }
+          ],
+          "inputMessageName": "KillInput"
+        }
+      ]
+    },
+    {
+      "name": "Identity",
+      "fields": [
+        {
+          "modelName": "Identity",
+          "name": "email",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true,
+          "uniqueWith": [
+            "issuer"
+          ]
+        },
+        {
+          "modelName": "Identity",
+          "name": "emailVerified",
+          "type": {
+            "type": "TYPE_BOOL"
+          },
+          "defaultValue": {
+            "expression": {
+              "source": "false"
+            }
+          }
+        },
+        {
+          "modelName": "Identity",
+          "name": "password",
+          "type": {
+            "type": "TYPE_PASSWORD"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Identity",
+          "name": "externalId",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Identity",
+          "name": "issuer",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true,
+          "uniqueWith": [
+            "email"
+          ]
+        },
+        {
+          "modelName": "Identity",
+          "name": "id",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "primaryKey": true,
+          "defaultValue": {
+            "useZeroValue": true
+          }
+        },
+        {
+          "modelName": "Identity",
+          "name": "createdAt",
+          "type": {
+            "type": "TYPE_DATETIME"
+          },
+          "defaultValue": {
+            "useZeroValue": true
+          }
+        },
+        {
+          "modelName": "Identity",
+          "name": "updatedAt",
+          "type": {
+            "type": "TYPE_DATETIME"
+          },
+          "defaultValue": {
+            "useZeroValue": true
+          }
+        }
+      ],
+      "actions": [
+        {
+          "modelName": "Identity",
+          "name": "authenticate",
+          "type": "ACTION_TYPE_WRITE",
+          "implementation": "ACTION_IMPLEMENTATION_RUNTIME",
+          "inputMessageName": "AuthenticateInput",
+          "responseMessageName": "AuthenticateResponse"
+        },
+        {
+          "modelName": "Identity",
+          "name": "requestPasswordReset",
+          "type": "ACTION_TYPE_WRITE",
+          "implementation": "ACTION_IMPLEMENTATION_RUNTIME",
+          "inputMessageName": "RequestPasswordResetInput",
+          "responseMessageName": "RequestPasswordResetResponse"
+        },
+        {
+          "modelName": "Identity",
+          "name": "resetPassword",
+          "type": "ACTION_TYPE_WRITE",
+          "implementation": "ACTION_IMPLEMENTATION_RUNTIME",
+          "inputMessageName": "ResetPasswordInput",
+          "responseMessageName": "ResetPasswordResponse"
+        }
+      ]
+    }
+  ],
+  "apis": [
+    {
+      "name": "Api",
+      "apiModels": [
+        {
+          "modelName": "Identity"
+        },
+        {
+          "modelName": "Person"
+        }
+      ]
+    }
+  ],
+  "messages": [
+    {
+      "name": "Any"
+    },
+    {
+      "name": "StringQueryInput",
+      "fields": [
+        {
+          "messageName": "StringQueryInput",
+          "name": "equals",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true,
+          "nullable": true
+        },
+        {
+          "messageName": "StringQueryInput",
+          "name": "notEquals",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true,
+          "nullable": true
+        },
+        {
+          "messageName": "StringQueryInput",
+          "name": "startsWith",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "messageName": "StringQueryInput",
+          "name": "endsWith",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "messageName": "StringQueryInput",
+          "name": "contains",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "messageName": "StringQueryInput",
+          "name": "oneOf",
+          "type": {
+            "type": "TYPE_STRING",
+            "repeated": true
+          },
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "GetPeopleWhere",
+      "fields": [
+        {
+          "messageName": "GetPeopleWhere",
+          "name": "name",
+          "type": {
+            "type": "TYPE_MESSAGE",
+            "messageName": "StringQueryInput"
+          },
+          "target": [
+            "name"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "GetPeopleInput",
+      "fields": [
+        {
+          "messageName": "GetPeopleInput",
+          "name": "where",
+          "type": {
+            "type": "TYPE_MESSAGE",
+            "messageName": "GetPeopleWhere"
+          }
+        },
+        {
+          "messageName": "GetPeopleInput",
+          "name": "first",
+          "type": {
+            "type": "TYPE_INT"
+          },
+          "optional": true
+        },
+        {
+          "messageName": "GetPeopleInput",
+          "name": "after",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "messageName": "GetPeopleInput",
+          "name": "last",
+          "type": {
+            "type": "TYPE_INT"
+          },
+          "optional": true
+        },
+        {
+          "messageName": "GetPeopleInput",
+          "name": "before",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "CreatePersonInput",
+      "fields": [
+        {
+          "messageName": "CreatePersonInput",
+          "name": "name",
+          "type": {
+            "type": "TYPE_STRING",
+            "modelName": "Person",
+            "fieldName": "name"
+          },
+          "target": [
+            "name"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "KillWhere",
+      "fields": [
+        {
+          "messageName": "KillWhere",
+          "name": "id",
+          "type": {
+            "type": "TYPE_ID",
+            "modelName": "Person",
+            "fieldName": "id"
+          },
+          "target": [
+            "id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "KillValues"
+    },
+    {
+      "name": "KillInput",
+      "fields": [
+        {
+          "messageName": "KillInput",
+          "name": "where",
+          "type": {
+            "type": "TYPE_MESSAGE",
+            "messageName": "KillWhere"
+          }
+        },
+        {
+          "messageName": "KillInput",
+          "name": "values",
+          "type": {
+            "type": "TYPE_MESSAGE",
+            "messageName": "KillValues"
+          },
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "EmailPasswordInput",
+      "fields": [
+        {
+          "messageName": "EmailPasswordInput",
+          "name": "email",
+          "type": {
+            "type": "TYPE_STRING"
+          }
+        },
+        {
+          "messageName": "EmailPasswordInput",
+          "name": "password",
+          "type": {
+            "type": "TYPE_STRING"
+          }
+        }
+      ]
+    },
+    {
+      "name": "AuthenticateInput",
+      "fields": [
+        {
+          "messageName": "AuthenticateInput",
+          "name": "createIfNotExists",
+          "type": {
+            "type": "TYPE_BOOL"
+          },
+          "optional": true
+        },
+        {
+          "messageName": "AuthenticateInput",
+          "name": "emailPassword",
+          "type": {
+            "type": "TYPE_MESSAGE",
+            "messageName": "EmailPasswordInput"
+          }
+        }
+      ]
+    },
+    {
+      "name": "AuthenticateResponse",
+      "fields": [
+        {
+          "messageName": "AuthenticateResponse",
+          "name": "identityCreated",
+          "type": {
+            "type": "TYPE_BOOL"
+          }
+        },
+        {
+          "messageName": "AuthenticateResponse",
+          "name": "token",
+          "type": {
+            "type": "TYPE_STRING"
+          }
+        }
+      ]
+    },
+    {
+      "name": "RequestPasswordResetInput",
+      "fields": [
+        {
+          "messageName": "RequestPasswordResetInput",
+          "name": "email",
+          "type": {
+            "type": "TYPE_STRING"
+          }
+        },
+        {
+          "messageName": "RequestPasswordResetInput",
+          "name": "redirectUrl",
+          "type": {
+            "type": "TYPE_STRING"
+          }
+        }
+      ]
+    },
+    {
+      "name": "RequestPasswordResetResponse"
+    },
+    {
+      "name": "ResetPasswordInput",
+      "fields": [
+        {
+          "messageName": "ResetPasswordInput",
+          "name": "token",
+          "type": {
+            "type": "TYPE_STRING"
+          }
+        },
+        {
+          "messageName": "ResetPasswordInput",
+          "name": "password",
+          "type": {
+            "type": "TYPE_STRING"
+          }
+        }
+      ]
+    },
+    {
+      "name": "ResetPasswordResponse"
+    }
+  ]
+}

--- a/schema/testdata/proto_expression_named_inputs/schema.keel
+++ b/schema/testdata/proto_expression_named_inputs/schema.keel
@@ -1,0 +1,19 @@
+model Person {
+    fields {
+        name Text?
+    }
+
+    actions {
+        get getBob(id, n: Text) {
+            @where(n == "Bob")
+            @where("Bob" == n)
+        }
+        get getPerson(id, n: Text) {
+            @where(n == person.name)
+            @where(person.name == n)
+        }
+        create createPerson() with (n: Text) {
+            @set(person.name = n)
+        }
+    }
+}

--- a/schema/testdata/validation_set_attribute_lhs_is_invalid/errors.json
+++ b/schema/testdata/validation_set_attribute_lhs_is_invalid/errors.json
@@ -1,40 +1,6 @@
 {
   "errors": [
     {
-      "message": "'name' not found",
-      "hint": "Did you mean ctx, or post?",
-      "code": "E020",
-      "pos": {
-        "filename": "testdata/validation_set_attribute_lhs_is_invalid/schema.keel",
-        "offset": 197,
-        "line": 10,
-        "column": 18
-      },
-      "endPos": {
-        "filename": "testdata/validation_set_attribute_lhs_is_invalid/schema.keel",
-        "offset": 201,
-        "line": 10,
-        "column": 22
-      }
-    },
-    {
-      "message": "'n' not found",
-      "hint": "Did you mean ctx, or post?",
-      "code": "E020",
-      "pos": {
-        "filename": "testdata/validation_set_attribute_lhs_is_invalid/schema.keel",
-        "offset": 296,
-        "line": 13,
-        "column": 18
-      },
-      "endPos": {
-        "filename": "testdata/validation_set_attribute_lhs_is_invalid/schema.keel",
-        "offset": 297,
-        "line": 13,
-        "column": 19
-      }
-    },
-    {
       "message": "'publisher' not found",
       "hint": "Did you mean ctx, or post?",
       "code": "E020",
@@ -49,6 +15,40 @@
         "offset": 907,
         "line": 31,
         "column": 27
+      }
+    },
+    {
+      "message": "The @set attribute can only be used to set model fields",
+      "hint": "For example, assign a value to a field on this model with @set(post.isActive = true)",
+      "code": "AttributeArgumentError",
+      "pos": {
+        "filename": "testdata/validation_set_attribute_lhs_is_invalid/schema.keel",
+        "offset": 197,
+        "line": 10,
+        "column": 18
+      },
+      "endPos": {
+        "filename": "testdata/validation_set_attribute_lhs_is_invalid/schema.keel",
+        "offset": 201,
+        "line": 10,
+        "column": 22
+      }
+    },
+    {
+      "message": "The @set attribute can only be used to set model fields",
+      "hint": "For example, assign a value to a field on this model with @set(post.isActive = true)",
+      "code": "AttributeArgumentError",
+      "pos": {
+        "filename": "testdata/validation_set_attribute_lhs_is_invalid/schema.keel",
+        "offset": 296,
+        "line": 13,
+        "column": 18
+      },
+      "endPos": {
+        "filename": "testdata/validation_set_attribute_lhs_is_invalid/schema.keel",
+        "offset": 297,
+        "line": 13,
+        "column": 19
       }
     },
     {


### PR DESCRIPTION
Allow named inputs as LHS operands in expressions
===

Fix to allow named inputs as the LHS operand.  For example:

```
get getPerson(id, n: Text) {
    @where(n == person.name)
}
```

However, when used with `@set`, the error message is more appropriate:

<img width="750" alt="image" src="https://github.com/teamkeel/keel/assets/6212830/4970bd34-61d3-4881-ad7d-4f7cc353ee43">
