### PR TITLE
fix: set unique to true for primary key fields in the proto.schema

### DIFF
--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -289,7 +289,7 @@ func New(ctx context.Context, schema *proto.Schema, database db.Database) (*Migr
 				return c.TableName == tableName && c.ConstraintType == "u" && len(c.ConstrainedColumns) == 1 && c.ConstrainedColumns[0] == int64(column.ColumnNum)
 			})
 
-			if field.Unique && !hasUniqueConstraint {
+			if field.Unique && !field.PrimaryKey && !hasUniqueConstraint {
 				uniqueStmt, err := addUniqueConstraintStmt(schema, model.Name, []string{field.Name})
 				if err != nil {
 					return nil, err

--- a/migrations/sql.go
+++ b/migrations/sql.go
@@ -85,7 +85,7 @@ func createTableStmt(schema *proto.Schema, model *proto.Model) (string, error) {
 				PrimaryKeyConstraintName(model.Name, field.Name),
 				Identifier(field.Name)))
 		}
-		if field.Unique {
+		if field.Unique && !field.PrimaryKey {
 			uniqueStmt, err := addUniqueConstraintStmt(schema, model.Name, []string{field.Name})
 			if err != nil {
 				return "", err
@@ -150,7 +150,7 @@ func addColumnStmt(schema *proto.Schema, modelName string, field *proto.Field) (
 		fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s;", Identifier(modelName), stmt),
 	)
 
-	if field.Unique {
+	if field.Unique && !field.PrimaryKey {
 		stmt, err := addUniqueConstraintStmt(schema, modelName, []string{field.Name})
 		if err != nil {
 			return "", err

--- a/schema/makeproto.go
+++ b/schema/makeproto.go
@@ -1558,6 +1558,7 @@ func (scm *Builder) applyFieldAttributes(parserField *parser.FieldNode, protoFie
 			protoField.Unique = true
 		case parser.AttributePrimaryKey:
 			protoField.PrimaryKey = true
+			protoField.Unique = true
 		case parser.AttributeDefault:
 			defaultValue := &proto.DefaultValue{}
 			if len(fieldAttribute.Arguments) == 1 {

--- a/schema/testdata/proto_action_inputs_in_both_query_and_with/proto.json
+++ b/schema/testdata/proto_action_inputs_in_both_query_and_with/proto.json
@@ -49,6 +49,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -184,6 +185,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_action_inputs_long_form/proto.json
+++ b/schema/testdata/proto_action_inputs_long_form/proto.json
@@ -16,6 +16,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -140,6 +141,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_action_inputs_with_empty/proto.json
+++ b/schema/testdata/proto_action_inputs_with_empty/proto.json
@@ -24,6 +24,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -136,6 +137,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_action_inputs_with_omitted/proto.json
+++ b/schema/testdata/proto_action_inputs_with_omitted/proto.json
@@ -24,6 +24,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -136,6 +137,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_api/proto.json
+++ b/schema/testdata/proto_api/proto.json
@@ -9,6 +9,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -45,6 +46,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -131,6 +133,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_arbitrary_function/proto.json
+++ b/schema/testdata/proto_arbitrary_function/proto.json
@@ -9,6 +9,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -105,6 +106,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_arbitrary_function_any_type/proto.json
+++ b/schema/testdata/proto_arbitrary_function_any_type/proto.json
@@ -9,6 +9,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -105,6 +106,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_arbitrary_function_inline_inputs/proto.json
+++ b/schema/testdata/proto_arbitrary_function_inline_inputs/proto.json
@@ -16,6 +16,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -112,6 +113,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_arbitrary_function_no_inputs/proto.json
+++ b/schema/testdata/proto_arbitrary_function_no_inputs/proto.json
@@ -9,6 +9,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -129,6 +130,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_arbitrary_functions_any/proto.json
+++ b/schema/testdata/proto_arbitrary_functions_any/proto.json
@@ -9,6 +9,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -113,6 +114,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_attribute_on/proto.json
+++ b/schema/testdata/proto_attribute_on/proto.json
@@ -23,6 +23,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -73,6 +74,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -159,6 +161,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_attribute_orderby/proto.json
+++ b/schema/testdata/proto_attribute_orderby/proto.json
@@ -23,6 +23,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -128,6 +129,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_attribute_sortable/proto.json
+++ b/schema/testdata/proto_attribute_sortable/proto.json
@@ -23,6 +23,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -118,6 +119,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_basics/proto.json
+++ b/schema/testdata/proto_basics/proto.json
@@ -16,6 +16,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -102,6 +103,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_delete_action/proto.json
+++ b/schema/testdata/proto_delete_action/proto.json
@@ -9,6 +9,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -104,6 +105,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_empty_fields/proto.json
+++ b/schema/testdata/proto_empty_fields/proto.json
@@ -9,6 +9,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -95,6 +96,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_enums/proto.json
+++ b/schema/testdata/proto_enums/proto.json
@@ -59,6 +59,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_environment_variables/proto.json
+++ b/schema/testdata/proto_environment_variables/proto.json
@@ -9,6 +9,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -106,6 +107,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_expression_identity_field_comparison/proto.json
+++ b/schema/testdata/proto_expression_identity_field_comparison/proto.json
@@ -18,6 +18,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -74,6 +75,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -148,6 +150,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -276,6 +279,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_expression_named_inputs/proto.json
+++ b/schema/testdata/proto_expression_named_inputs/proto.json
@@ -17,6 +17,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -147,6 +148,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_expressions/proto.json
+++ b/schema/testdata/proto_expressions/proto.json
@@ -40,6 +40,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -187,6 +188,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_expressions_compare_model_operand/proto.json
+++ b/schema/testdata/proto_expressions_compare_model_operand/proto.json
@@ -20,6 +20,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -79,6 +80,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -195,6 +197,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_expressions_null_values/proto.json
+++ b/schema/testdata/proto_expressions_null_values/proto.json
@@ -17,6 +17,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -129,6 +130,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_field_array_of_same_message_type/proto.json
+++ b/schema/testdata/proto_field_array_of_same_message_type/proto.json
@@ -9,6 +9,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -105,6 +106,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_field_optional_of_same_message_type/proto.json
+++ b/schema/testdata/proto_field_optional_of_same_message_type/proto.json
@@ -9,6 +9,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -105,6 +106,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_field_optional_of_same_model_type/proto.json
+++ b/schema/testdata/proto_field_optional_of_same_model_type/proto.json
@@ -30,6 +30,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -137,6 +138,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_fields_attributes/proto.json
+++ b/schema/testdata/proto_fields_attributes/proto.json
@@ -45,6 +45,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -143,6 +144,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_fields_names/proto.json
+++ b/schema/testdata/proto_fields_names/proto.json
@@ -23,6 +23,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -109,6 +110,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_fields_optional/proto.json
+++ b/schema/testdata/proto_fields_optional/proto.json
@@ -17,6 +17,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -103,6 +104,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_fields_types/proto.json
+++ b/schema/testdata/proto_fields_types/proto.json
@@ -54,6 +54,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -151,6 +152,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_functions/proto.json
+++ b/schema/testdata/proto_functions/proto.json
@@ -9,6 +9,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -104,6 +105,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_functions_inputs/proto.json
+++ b/schema/testdata/proto_functions_inputs/proto.json
@@ -16,6 +16,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -132,6 +133,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_identity_backlinks/proto.json
+++ b/schema/testdata/proto_identity_backlinks/proto.json
@@ -20,6 +20,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -118,6 +119,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_identity_backlinks_relation_attribute/proto.json
+++ b/schema/testdata/proto_identity_backlinks_relation_attribute/proto.json
@@ -31,6 +31,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -141,6 +142,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_job_adhoc/proto.json
+++ b/schema/testdata/proto_job_adhoc/proto.json
@@ -59,6 +59,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_job_fields/proto.json
+++ b/schema/testdata/proto_job_fields/proto.json
@@ -59,6 +59,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_job_permissions_expressions/proto.json
+++ b/schema/testdata/proto_job_permissions_expressions/proto.json
@@ -59,6 +59,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_job_permissions_roles/proto.json
+++ b/schema/testdata/proto_job_permissions_roles/proto.json
@@ -59,6 +59,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_job_scheduled/proto.json
+++ b/schema/testdata/proto_job_scheduled/proto.json
@@ -59,6 +59,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_message_enum_field/proto.json
+++ b/schema/testdata/proto_message_enum_field/proto.json
@@ -16,6 +16,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -112,6 +113,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_message_type/proto.json
+++ b/schema/testdata/proto_message_type/proto.json
@@ -16,6 +16,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -112,6 +113,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_message_type_nested_model/proto.json
+++ b/schema/testdata/proto_message_type_nested_model/proto.json
@@ -16,6 +16,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -112,6 +113,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_models_multiple/proto.json
+++ b/schema/testdata/proto_models_multiple/proto.json
@@ -9,6 +9,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -45,6 +46,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -131,6 +133,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_models_permissions/proto.json
+++ b/schema/testdata/proto_models_permissions/proto.json
@@ -16,6 +16,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -126,6 +127,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_models_unique/proto.json
+++ b/schema/testdata/proto_models_unique/proto.json
@@ -29,6 +29,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -115,6 +116,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_operations_attr_set/proto.json
+++ b/schema/testdata/proto_operations_attr_set/proto.json
@@ -23,6 +23,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -123,6 +124,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_operations_attr_validate/proto.json
+++ b/schema/testdata/proto_operations_attr_validate/proto.json
@@ -16,6 +16,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -116,6 +117,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_operations_attr_where/proto.json
+++ b/schema/testdata/proto_operations_attr_where/proto.json
@@ -17,6 +17,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -117,6 +118,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_operations_create_all_required_inputs/proto.json
+++ b/schema/testdata/proto_operations_create_all_required_inputs/proto.json
@@ -24,6 +24,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -119,6 +120,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_operations_create_relationships/proto.json
+++ b/schema/testdata/proto_operations_create_relationships/proto.json
@@ -26,6 +26,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -104,6 +105,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -185,6 +187,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -271,6 +274,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_operations_get_unique_input/proto.json
+++ b/schema/testdata/proto_operations_get_unique_input/proto.json
@@ -9,6 +9,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -104,6 +105,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_operations_get_unique_where/proto.json
+++ b/schema/testdata/proto_operations_get_unique_where/proto.json
@@ -17,6 +17,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -117,6 +118,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_operations_inputs/proto.json
+++ b/schema/testdata/proto_operations_inputs/proto.json
@@ -23,6 +23,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -139,6 +140,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_operations_list_nested_input_optional_model/proto.json
+++ b/schema/testdata/proto_operations_list_nested_input_optional_model/proto.json
@@ -26,6 +26,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -83,6 +84,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -141,6 +143,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -247,6 +250,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_operations_multiple/proto.json
+++ b/schema/testdata/proto_operations_multiple/proto.json
@@ -9,6 +9,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -111,6 +112,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_operations_nested_model_input/proto.json
+++ b/schema/testdata/proto_operations_nested_model_input/proto.json
@@ -26,6 +26,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -102,6 +103,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -169,6 +171,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -233,6 +236,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -328,6 +332,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_operations_permissions/proto.json
+++ b/schema/testdata/proto_operations_permissions/proto.json
@@ -16,6 +16,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -130,6 +131,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_operations_types/proto.json
+++ b/schema/testdata/proto_operations_types/proto.json
@@ -17,6 +17,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -133,6 +134,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_optional_inputs/proto.json
+++ b/schema/testdata/proto_optional_inputs/proto.json
@@ -24,6 +24,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -133,6 +134,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_optional_nested_input/proto.json
+++ b/schema/testdata/proto_optional_nested_input/proto.json
@@ -35,6 +35,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -132,6 +133,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -218,6 +220,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_permission_expression_with_identity/proto.json
+++ b/schema/testdata/proto_permission_expression_with_identity/proto.json
@@ -21,6 +21,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -145,6 +146,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_relations_both_sides/proto.json
+++ b/schema/testdata/proto_relations_both_sides/proto.json
@@ -19,6 +19,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -65,6 +66,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -162,6 +164,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_relations_multi_uses_reln_attribute/proto.json
+++ b/schema/testdata/proto_relations_multi_uses_reln_attribute/proto.json
@@ -39,6 +39,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -116,6 +117,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -224,6 +226,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_relations_single/proto.json
+++ b/schema/testdata/proto_relations_single/proto.json
@@ -9,6 +9,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -54,6 +55,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -151,6 +153,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_relationships_create_with_implicit_input/proto.json
+++ b/schema/testdata/proto_relationships_create_with_implicit_input/proto.json
@@ -35,6 +35,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -117,6 +118,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -203,6 +205,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_relationships_mixed/proto.json
+++ b/schema/testdata/proto_relationships_mixed/proto.json
@@ -39,6 +39,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -118,6 +119,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -215,6 +217,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_relationships_mixed_one_to_many_single_sided/proto.json
+++ b/schema/testdata/proto_relationships_mixed_one_to_many_single_sided/proto.json
@@ -39,6 +39,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -128,6 +129,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -214,6 +216,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_relationships_mixed_one_to_one_single_sided/proto.json
+++ b/schema/testdata/proto_relationships_mixed_one_to_one_single_sided/proto.json
@@ -39,6 +39,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -129,6 +130,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -215,6 +217,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_relationships_mixed_one_to_one_single_sided_2/proto.json
+++ b/schema/testdata/proto_relationships_mixed_one_to_one_single_sided_2/proto.json
@@ -29,6 +29,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -117,6 +118,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -215,6 +217,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_relationships_mixed_with_self_relationship/proto.json
+++ b/schema/testdata/proto_relationships_mixed_with_self_relationship/proto.json
@@ -52,6 +52,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -132,6 +133,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -229,6 +231,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_relationships_one_to_many_multi_one_sided/proto.json
+++ b/schema/testdata/proto_relationships_one_to_many_multi_one_sided/proto.json
@@ -18,6 +18,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -74,6 +75,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -171,6 +173,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_relationships_one_to_many_multi_one_sided_same_side/proto.json
+++ b/schema/testdata/proto_relationships_one_to_many_multi_one_sided_same_side/proto.json
@@ -27,6 +27,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -85,6 +86,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -171,6 +173,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_relationships_one_to_many_single_sided_multiple/proto.json
+++ b/schema/testdata/proto_relationships_one_to_many_single_sided_multiple/proto.json
@@ -27,6 +27,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -103,6 +104,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -211,6 +213,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_relationships_one_to_one/proto.json
+++ b/schema/testdata/proto_relationships_one_to_one/proto.json
@@ -19,6 +19,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -83,6 +84,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -169,6 +171,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_relationships_one_to_one_both_directions/proto.json
+++ b/schema/testdata/proto_relationships_one_to_one_both_directions/proto.json
@@ -29,6 +29,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -97,6 +98,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -195,6 +197,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_relationships_one_to_one_both_directions_missing_relation_attribute/proto.json
+++ b/schema/testdata/proto_relationships_one_to_one_both_directions_missing_relation_attribute/proto.json
@@ -29,6 +29,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -97,6 +98,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -195,6 +197,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_relationships_one_to_one_both_directions_no_relation_attribute/proto.json
+++ b/schema/testdata/proto_relationships_one_to_one_both_directions_no_relation_attribute/proto.json
@@ -29,6 +29,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -97,6 +98,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -195,6 +197,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_relationships_one_to_one_both_sides/proto.json
+++ b/schema/testdata/proto_relationships_one_to_one_both_sides/proto.json
@@ -20,6 +20,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -93,6 +94,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -179,6 +181,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_relationships_one_to_one_missing_reln/proto.json
+++ b/schema/testdata/proto_relationships_one_to_one_missing_reln/proto.json
@@ -31,6 +31,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -109,6 +110,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -195,6 +197,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_relationships_one_to_one_multi_layered/proto.json
+++ b/schema/testdata/proto_relationships_one_to_one_multi_layered/proto.json
@@ -27,6 +27,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -112,6 +113,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -186,6 +188,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -281,6 +284,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_relationships_one_to_one_unique_both_sides/proto.json
+++ b/schema/testdata/proto_relationships_one_to_one_unique_both_sides/proto.json
@@ -19,6 +19,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -77,6 +78,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -175,6 +177,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_relationships_one_to_one_with_unique/proto.json
+++ b/schema/testdata/proto_relationships_one_to_one_with_unique/proto.json
@@ -30,6 +30,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -89,6 +90,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -187,6 +189,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_relationships_self_referencing_multiple/proto.json
+++ b/schema/testdata/proto_relationships_self_referencing_multiple/proto.json
@@ -51,6 +51,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -161,6 +162,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_relationships_self_referencing_no_reln_attribute/proto.json
+++ b/schema/testdata/proto_relationships_self_referencing_no_reln_attribute/proto.json
@@ -30,6 +30,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -99,6 +100,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -197,6 +199,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_relationships_self_referencing_uses_reln_attribute/proto.json
+++ b/schema/testdata/proto_relationships_self_referencing_uses_reln_attribute/proto.json
@@ -30,6 +30,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -99,6 +100,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -197,6 +199,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_relationships_update_with_explicit_input/proto.json
+++ b/schema/testdata/proto_relationships_update_with_explicit_input/proto.json
@@ -35,6 +35,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -145,6 +146,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -231,6 +233,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_relationships_update_with_implicit_input/proto.json
+++ b/schema/testdata/proto_relationships_update_with_implicit_input/proto.json
@@ -35,6 +35,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -131,6 +132,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -217,6 +219,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_roles/proto.json
+++ b/schema/testdata/proto_roles/proto.json
@@ -59,6 +59,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_secrets/proto.json
+++ b/schema/testdata/proto_secrets/proto.json
@@ -9,6 +9,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -106,6 +107,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_set_attribute_backlink_repeated_rhs_fields/proto.json
+++ b/schema/testdata/proto_set_attribute_backlink_repeated_rhs_fields/proto.json
@@ -67,6 +67,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -211,6 +212,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -292,6 +294,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -378,6 +381,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_set_attribute_backlinks/proto.json
+++ b/schema/testdata/proto_set_attribute_backlinks/proto.json
@@ -67,6 +67,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -208,6 +209,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -289,6 +291,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -375,6 +378,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_set_attribute_ctx_identity_fields/proto.json
+++ b/schema/testdata/proto_set_attribute_ctx_identity_fields/proto.json
@@ -44,6 +44,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -198,6 +199,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_set_attribute_lhs_within_write_scope/proto.json
+++ b/schema/testdata/proto_set_attribute_lhs_within_write_scope/proto.json
@@ -45,6 +45,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -273,6 +274,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -377,6 +379,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -452,6 +455,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -506,6 +510,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -604,6 +609,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_unique_attribute/proto.json
+++ b/schema/testdata/proto_unique_attribute/proto.json
@@ -31,6 +31,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -78,6 +79,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -164,6 +166,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_unique_composite_lookup/proto.json
+++ b/schema/testdata/proto_unique_composite_lookup/proto.json
@@ -29,6 +29,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -144,6 +145,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -307,6 +309,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -396,6 +399,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -498,6 +502,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_unique_lookup/proto.json
+++ b/schema/testdata/proto_unique_lookup/proto.json
@@ -24,6 +24,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -197,6 +198,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -306,6 +308,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_unique_lookup_model/proto.json
+++ b/schema/testdata/proto_unique_lookup_model/proto.json
@@ -20,6 +20,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -132,6 +133,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/proto_unique_lookup_nested/proto.json
+++ b/schema/testdata/proto_unique_lookup_nested/proto.json
@@ -36,6 +36,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -185,6 +186,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -280,6 +282,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/validation_create_inputs_missing_reln_valid/proto.json
+++ b/schema/testdata/validation_create_inputs_missing_reln_valid/proto.json
@@ -16,6 +16,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -68,6 +69,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -186,6 +188,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/validation_default_zero/proto.json
+++ b/schema/testdata/validation_default_zero/proto.json
@@ -19,6 +19,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -105,6 +106,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/validation_delete_operation_unique_lookup_in_inputs/proto.json
+++ b/schema/testdata/validation_delete_operation_unique_lookup_in_inputs/proto.json
@@ -16,6 +16,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -116,6 +117,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/validation_delete_operation_unique_lookup_in_wheres/proto.json
+++ b/schema/testdata/validation_delete_operation_unique_lookup_in_wheres/proto.json
@@ -24,6 +24,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -127,6 +128,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/validation_enum_default/proto.json
+++ b/schema/testdata/validation_enum_default/proto.json
@@ -22,6 +22,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -108,6 +109,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/validation_expression_enum_field_comparison/proto.json
+++ b/schema/testdata/validation_expression_enum_field_comparison/proto.json
@@ -25,6 +25,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -129,6 +130,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/validation_expression_enum_set/proto.json
+++ b/schema/testdata/validation_expression_enum_set/proto.json
@@ -17,6 +17,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -117,6 +118,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/validation_expression_nullish_optional_comparison/proto.json
+++ b/schema/testdata/validation_expression_nullish_optional_comparison/proto.json
@@ -19,6 +19,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -140,6 +141,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/validation_get_operation_unique_lookup_in_inputs/proto.json
+++ b/schema/testdata/validation_get_operation_unique_lookup_in_inputs/proto.json
@@ -16,6 +16,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -116,6 +117,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/validation_get_operation_unique_lookup_in_wheres/proto.json
+++ b/schema/testdata/validation_get_operation_unique_lookup_in_wheres/proto.json
@@ -24,6 +24,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -127,6 +128,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/validation_relationships_create_with_explicit_input/proto.json
+++ b/schema/testdata/validation_relationships_create_with_explicit_input/proto.json
@@ -35,6 +35,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -145,6 +146,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -231,6 +233,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/validation_request_headers_expression/proto.json
+++ b/schema/testdata/validation_request_headers_expression/proto.json
@@ -16,6 +16,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -116,6 +117,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/validation_update_operation_unique_lookup_in_inputs/proto.json
+++ b/schema/testdata/validation_update_operation_unique_lookup_in_inputs/proto.json
@@ -16,6 +16,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -116,6 +117,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/validation_update_operation_unique_lookup_in_wheres/proto.json
+++ b/schema/testdata/validation_update_operation_unique_lookup_in_wheres/proto.json
@@ -24,6 +24,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -127,6 +128,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true

--- a/schema/testdata/validation_where_expression_allowed_operators_builtin_types/proto.json
+++ b/schema/testdata/validation_where_expression_allowed_operators_builtin_types/proto.json
@@ -113,6 +113,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true
@@ -358,6 +359,7 @@
           "type": {
             "type": "TYPE_ID"
           },
+          "unique": true,
           "primaryKey": true,
           "defaultValue": {
             "useZeroValue": true


### PR DESCRIPTION
Fixes the proto schema to have primary key fields set as unique. It is misleading if the flag is set to false. 