### PR TITLE
fix: return record or null from findOne method in QueryBuilder

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,8 +1,3 @@
 module.exports = {
-  extends: ['@commitlint/config-conventional'],
-  rules: {
-    'body-max-length': [2, 'always', 300],
-    'body-case': [1, "always", "sentence-case"],
-    'subject-case': [2, "always", ["sentence-case", "lower-case"]]
-  }
-}
+  extends: ["@commitlint/config-conventional"],
+};

--- a/integration/testdata/built_in_actions/main.test.ts
+++ b/integration/testdata/built_in_actions/main.test.ts
@@ -40,6 +40,11 @@ test("get action", async () => {
   expect(fetchedPost!.id).toEqual(post.id);
 });
 
+test("get action - no result", async () => {
+  const fetchedPost = await actions.getPost({ id: "1234" });
+  expect(fetchedPost).toEqual(null);
+});
+
 test("list action - equals", async () => {
   await models.post.create({ title: "apple", subTitle: "def" });
   await models.post.create({ title: "apple", subTitle: "efg" });

--- a/integration/testdata/with_custom_function/tests.test.ts
+++ b/integration/testdata/with_custom_function/tests.test.ts
@@ -61,6 +61,11 @@ test("fetching a person by id", async () => {
   expect(person.id).toEqual(fetchedPerson!.id);
 });
 
+test("fetching a person by id - no result", async () => {
+  const fetchedPerson = await actions.getPerson({ id: "1234" });
+  expect(fetchedPerson).toEqual(null);
+});
+
 test("fetching person by additional unique field (not PK)", async () => {
   const person = await models.person.create({
     name: "bar",

--- a/integration/testdata/with_custom_function_hooks/main.test.ts
+++ b/integration/testdata/with_custom_function_hooks/main.test.ts
@@ -182,13 +182,10 @@ describe("query hooks", () => {
     });
 
     // the beforeQuery adds a constraint that also adds gender = Female to the query
-    await expect(
-      actions.withIdentity(identity).getPersonBeforeQuery({
-        id: person.id,
-      })
-    ).toHaveError({
-      message: "no result",
+    const res = await actions.withIdentity(identity).getPersonBeforeQuery({
+      id: person.id,
     });
+    expect(res).toEqual(null);
   });
 
   test("get.afterQuery", async () => {

--- a/packages/functions-runtime/src/QueryBuilder.js
+++ b/packages/functions-runtime/src/QueryBuilder.js
@@ -134,8 +134,7 @@ class QueryBuilder {
 
       span.setAttribute("sql", builder.compile().sql);
 
-      const row = await builder.executeTakeFirstOrThrow();
-
+      const row = await builder.executeTakeFirst();
       if (!row) {
         return null;
       }

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -123,7 +123,7 @@ func Run(ctx context.Context, opts *RunnerOpts) error {
 		functionsServer, err = node.StartDevelopmentServer(ctx, opts.Dir, &node.ServerOpts{
 			EnvVars: functionEnvVars,
 			Output:  os.Stdout,
-			Debug:   true, // todo: configurable
+			Debug:   os.Getenv("DEBUG_FUNCTIONS") == "true",
 		})
 
 		if err != nil {


### PR DESCRIPTION
I was actually trying to fix a different bug but hit this on the way.

Crazy thing was we had a test asserting that it was broken... 🙃 