### PR TITLE
feat: keelconfig auth configuration

### DIFF
--- a/cmd/program/commands.go
+++ b/cmd/program/commands.go
@@ -526,10 +526,11 @@ func SetSecret(path, environment, key, value string) error {
 	if err != nil {
 		return err
 	}
-
+	fmt.Println(projectPath)
 	config := cliconfig.New(&cliconfig.Options{
 		WorkingDir: projectPath,
 	})
+	fmt.Println(path)
 
 	return config.SetSecret(path, environment, key, value)
 }

--- a/cmd/program/commands.go
+++ b/cmd/program/commands.go
@@ -526,11 +526,10 @@ func SetSecret(path, environment, key, value string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println(projectPath)
+
 	config := cliconfig.New(&cliconfig.Options{
 		WorkingDir: projectPath,
 	})
-	fmt.Println(path)
 
 	return config.SetSecret(path, environment, key, value)
 }

--- a/cmd/program/model.go
+++ b/cmd/program/model.go
@@ -400,6 +400,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		ctx = db.WithDatabase(ctx, m.Database)
 		ctx = runtimectx.WithSecrets(ctx, m.Secrets)
+		ctx = runtimectx.WithOAuthConfig(ctx, &m.Config.Auth)
 
 		mailClient := mail.NewSMTPClientFromEnv()
 		if mailClient != nil {

--- a/config/auth.go
+++ b/config/auth.go
@@ -22,9 +22,8 @@ var (
 )
 
 type AuthConfig struct {
-	Tokens              *TokensConfig `yaml:"tokens"`
-	AllowAnyOidcIssuers bool          `yaml:"allowAnyOidcIssuer"`
-	Providers           []Provider    `yaml:"providers"`
+	Tokens    *TokensConfig `yaml:"tokens"`
+	Providers []Provider    `yaml:"providers"`
 }
 
 type TokensConfig struct {

--- a/config/auth.go
+++ b/config/auth.go
@@ -1,0 +1,164 @@
+package config
+
+import (
+	"net/url"
+
+	"github.com/samber/lo"
+)
+
+const (
+	GoogleProvider        = "google"
+	OpenIdConnectProvider = "oidc"
+	OAuthProvider         = "oauth"
+)
+
+var (
+	SupportedProviderTypes = []string{
+		GoogleProvider,
+		OpenIdConnectProvider,
+		OAuthProvider,
+	}
+)
+
+type AuthConfig struct {
+	Tokens              *TokensConfig `yaml:"tokens"`
+	AllowAnyOidcIssuers bool          `yaml:"allowAnyOidcIssuer"`
+	Providers           []Provider    `yaml:"providers"`
+}
+
+type TokensConfig struct {
+	AccessTokenExpiry  int `yaml:"accessTokenExpiry"`
+	RefreshTokenExpiry int `yaml:"refreshTokenExpiry"`
+}
+
+type Provider struct {
+	Type             string `yaml:"type"`
+	Name             string `yaml:"name"`
+	ClientId         string `yaml:"clientId"`
+	IssuerUrl        string `yaml:"issuerUrl"`
+	TokenUrl         string `yaml:"tokenUrl"`
+	AuthorizationUrl string `yaml:"authorizationUrl"`
+}
+
+func (c *AuthConfig) GetOidcProviders() []Provider {
+	oidcProviders := []Provider{}
+	for _, p := range c.Providers {
+		if p.Type == OpenIdConnectProvider {
+			oidcProviders = append(oidcProviders, p)
+		}
+	}
+	return oidcProviders
+}
+
+func (c *AuthConfig) HasOidcIssuer(issuer string) bool {
+	for _, p := range c.Providers {
+		if p.IssuerUrl == issuer {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *AuthConfig) GetOAuthProviders() []Provider {
+	oidcProviders := []Provider{}
+	for _, p := range c.Providers {
+		if p.Type == OAuthProvider {
+			oidcProviders = append(oidcProviders, p)
+		}
+	}
+	return oidcProviders
+}
+
+// findAuthProviderMissingName checks for missing provider names
+func findAuthProviderMissingName(providers []Provider) []Provider {
+	invalid := []Provider{}
+	for _, p := range providers {
+		if p.Name == "" {
+			invalid = append(invalid, p)
+		}
+	}
+
+	return invalid
+}
+
+// findAuthProviderDuplicateName checks for duplicate auth provider names
+func findAuthProviderDuplicateName(providers []Provider) []Provider {
+	keys := make(map[string]bool)
+
+	duplicates := []Provider{}
+	for _, p := range providers {
+		if _, value := keys[p.Name]; !value {
+			keys[p.Name] = true
+		} else {
+			duplicates = append(duplicates, p)
+		}
+	}
+
+	return duplicates
+}
+
+// findAuthProviderInvalidType checks for invalid provider types
+func findAuthProviderInvalidType(providers []Provider) []Provider {
+	invalid := []Provider{}
+	for _, p := range providers {
+		if !lo.Contains(SupportedProviderTypes, p.Type) {
+			invalid = append(invalid, p)
+		}
+	}
+
+	return invalid
+}
+
+// findAuthProviderMissingClientId checks for missing client IDs
+func findAuthProviderMissingClientId(providers []Provider) []Provider {
+	invalid := []Provider{}
+	for _, p := range providers {
+		if p.ClientId == "" {
+			invalid = append(invalid, p)
+		}
+	}
+
+	return invalid
+}
+
+// findAuthProviderMissingIssuerUrl checks for missing or invalid issuer URLs
+func findAuthProviderMissingOrInvalidIssuerUrl(providers []Provider) []Provider {
+	invalid := []Provider{}
+	for _, p := range providers {
+		u, err := url.Parse(p.IssuerUrl)
+		if err != nil || u.Scheme != "https" {
+			invalid = append(invalid, p)
+			continue
+		}
+	}
+
+	return invalid
+}
+
+// findAuthProviderMissingOrInvalidTokenUrl checks for missing or invalid token URLs
+func findAuthProviderMissingOrInvalidTokenUrl(providers []Provider) []Provider {
+	invalid := []Provider{}
+	for _, p := range providers {
+		u, err := url.Parse(p.TokenUrl)
+		if err != nil || u.Scheme != "https" {
+			invalid = append(invalid, p)
+			continue
+		}
+	}
+
+	return invalid
+}
+
+// findAuthProviderMissingOrInvalidAuthorizationUrl checks for missing or invalid authorization URLs
+func findAuthProviderMissingOrInvalidAuthorizationUrl(providers []Provider) []Provider {
+	invalid := []Provider{}
+	for _, p := range providers {
+		u, err := url.Parse(p.AuthorizationUrl)
+		if err != nil || u.Scheme != "https" {
+			invalid = append(invalid, p)
+			continue
+		}
+	}
+
+	return invalid
+}

--- a/config/config.go
+++ b/config/config.go
@@ -254,7 +254,7 @@ func Validate(config *ProjectConfig) *ConfigErrors {
 	}
 
 	missingProviderNames := findAuthProviderMissingName(config.Auth.Providers)
-	for i, _ := range missingProviderNames {
+	for i := range missingProviderNames {
 		errors = append(errors, &ConfigError{
 			Type:    "missing",
 			Message: fmt.Sprintf(ConfigAuthProviderMissingFieldAtIndexErrorString, i, "name"),

--- a/config/config.go
+++ b/config/config.go
@@ -239,14 +239,14 @@ func Validate(config *ProjectConfig) *ConfigErrors {
 		}
 	}
 
-	if config.Auth.Tokens.AccessTokenExpiry <= 0 {
+	if config.Auth.Tokens != nil && config.Auth.Tokens.AccessTokenExpiry <= 0 {
 		errors = append(errors, &ConfigError{
 			Type:    "invalid",
 			Message: fmt.Sprintf(ConfigAuthTokenExpiryMustBePositive, "access", "accessTokenExpiry"),
 		})
 	}
 
-	if config.Auth.Tokens.RefreshTokenExpiry <= 0 {
+	if config.Auth.Tokens != nil && config.Auth.Tokens.RefreshTokenExpiry <= 0 {
 		errors = append(errors, &ConfigError{
 			Type:    "invalid",
 			Message: fmt.Sprintf(ConfigAuthTokenExpiryMustBePositive, "refresh", "refreshTokenExpiry"),

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -123,6 +123,13 @@ func TestAuthTokens(t *testing.T) {
 	assert.Equal(t, 604800, config.Auth.Tokens.RefreshTokenExpiry)
 }
 
+func TestAuthNegativeTokenLifespan(t *testing.T) {
+	_, err := Load("fixtures/test_auth_negative_token_lifespan.yaml")
+
+	assert.Contains(t, err.Error(), "access token lifespan cannot be negative or zero for field: accessTokenExpiry\n")
+	assert.Contains(t, err.Error(), "refresh token lifespan cannot be negative or zero for field: refreshTokenExpiry\n")
+}
+
 func TestAuthProviders(t *testing.T) {
 	config, err := Load("fixtures/test_auth.yaml")
 	assert.NoError(t, err)
@@ -192,4 +199,21 @@ func TestMissingOrInvalidTokenEndpoint(t *testing.T) {
 	assert.Contains(t, err.Error(), "auth provider 'not-https' has missing or invalid https url for field: tokenUrl\n")
 	assert.Contains(t, err.Error(), "auth provider 'missing-schema' has missing or invalid https url for field: tokenUrl\n")
 	assert.Contains(t, err.Error(), "auth provider 'missing-endpoint' has missing or invalid https url for field: tokenUrl\n")
+}
+
+func TestHasIssuer(t *testing.T) {
+	config, err := Load("fixtures/test_auth.yaml")
+	assert.NoError(t, err)
+
+	hasGoogleIssuer, err := config.Auth.HasOidcIssuer("https://accounts.google.com/")
+	assert.NoError(t, err)
+	assert.True(t, hasGoogleIssuer)
+
+	hasCustomIssuer, err := config.Auth.HasOidcIssuer("https://dev-skhlutl45lbqkvhv.us.auth0.com")
+	assert.NoError(t, err)
+	assert.True(t, hasCustomIssuer)
+
+	hasUnknownIssuer, err := config.Auth.HasOidcIssuer("https://nope.com")
+	assert.NoError(t, err)
+	assert.False(t, hasUnknownIssuer)
 }

--- a/config/fixtures/test_auth.yaml
+++ b/config/fixtures/test_auth.yaml
@@ -1,0 +1,28 @@
+auth:
+  tokens:
+    accessTokenExpiry: 3600
+    refreshTokenExpiry: 604800
+    
+  providers:
+    # Built-in Google provider
+    - type: google
+      name: google-1
+      clientId: foo_1
+
+    # Built-in Google provider
+    - type: google
+      name: google_2
+      clientId: foo_2
+
+    # Custom OIDC
+    - type: oidc
+      name: Baidu
+      issuerUrl: 'https://dev-skhlutl45lbqkvhv.us.auth0.com'
+      clientId: 'kasj28fnq09ak'
+
+    # Custom OAuth
+    - type: oauth
+      name: Github
+      clientId: hfjuw983h1hfsdf
+      authorizationUrl: https://github.com/auth
+      tokenUrl: https://github.com/token

--- a/config/fixtures/test_auth_duplicate_names.yaml
+++ b/config/fixtures/test_auth_duplicate_names.yaml
@@ -1,0 +1,17 @@
+auth:
+  providers:
+    - type: google
+      name: my_google
+      clientId: foo_1
+
+    - type: oidc
+      name: Baidu
+      issuerUrl: 'https://dev-skhlutl45lbqkvhv.us.auth0.com'
+      clientId: 'kasj28fnq09ak'
+
+    # Duplicate name
+    - type: oauth
+      name: my_google
+      clientId: hfjuw983h1hfsdf
+      authorizationUrl: https://github.com/auth
+      tokenUrl: https://github.com/token

--- a/config/fixtures/test_auth_invalid_auth_url.yaml
+++ b/config/fixtures/test_auth_invalid_auth_url.yaml
@@ -1,0 +1,22 @@
+auth:
+  tokens:
+    accessTokenExpiry: 3600
+    refreshTokenExpiry: 604800
+    
+  providers:
+    - type: oauth
+      name: not-https
+      clientId: hfjuw983h1hfsdf
+      authorizationUrl: http://github.com/auth
+      tokenUrl: http://github.com/token
+
+    - type: oauth
+      name: missing-schema
+      clientId: hfjuw983h1hfsdf
+      authorizationUrl: github.com/auth
+      tokenUrl: https://github.com/token
+
+    - type: oauth
+      name: missing-endpoint
+      clientId: hfjuw983h1hfsdf
+      tokenUrl: https://github.com/token

--- a/config/fixtures/test_auth_invalid_issuer.yaml
+++ b/config/fixtures/test_auth_invalid_issuer.yaml
@@ -1,0 +1,30 @@
+auth:
+  tokens:
+    accessTokenExpiry: 3600
+    refreshTokenExpiry: 604800
+    
+  providers:
+    - type: oidc
+      name: not-https
+      issuerUrl: 'http://not-https.com'
+      clientId: 'kasj28fnq09ak'
+
+    - type: oidc
+      name: missing-issuer
+      clientId: 'kasj28fnq09ak'
+
+    - type: oidc
+      name: no-schema
+      issuerUrl: 'not-https.com'
+      clientId: 'kasj28fnq09ak'
+
+    - type: oidc
+      name: invalid-url
+      issuerUrl: 'whoops'
+      clientId: 'kasj28fnq09ak'
+
+    - type: oauth
+      name: myOAuthProvider
+      clientId: 'kasj28fnq09ak'
+      issuerUrl: 'not an error'
+

--- a/config/fixtures/test_auth_invalid_token_url.yaml
+++ b/config/fixtures/test_auth_invalid_token_url.yaml
@@ -1,0 +1,22 @@
+auth:
+  tokens:
+    accessTokenExpiry: 3600
+    refreshTokenExpiry: 604800
+    
+  providers:
+    - type: oauth
+      name: not-https
+      clientId: hfjuw983h1hfsdf
+      authorizationUrl: https://github.com/auth
+      tokenUrl: http://github.com/token
+
+    - type: oauth
+      name: missing-schema
+      clientId: hfjuw983h1hfsdf
+      authorizationUrl: https://github.com/auth
+      tokenUrl: github.com/token
+
+    - type: oauth
+      name: missing-endpoint
+      clientId: hfjuw983h1hfsdf
+      authorizationUrl: https://github.com/auth

--- a/config/fixtures/test_auth_invalid_types.yaml
+++ b/config/fixtures/test_auth_invalid_types.yaml
@@ -1,0 +1,20 @@
+auth:
+  providers:
+    - type: google_1
+      name: google_1
+      clientId: foo_1
+
+    - type: Google
+      name: google_2
+      clientId: foo_2
+
+    - type: oauth
+      name: Github
+      clientId: hfjuw983h1hfsdf
+      authorizationUrl: https://github.com/auth
+      tokenUrl: https://github.com/token
+
+    - type: whoops
+      name: Baidu
+      issuerUrl: 'https://dev-skhlutl45lbqkvhv.us.auth0.com'
+      clientId: 'kasj28fnq09ak'

--- a/config/fixtures/test_auth_missing_client_ids.yaml
+++ b/config/fixtures/test_auth_missing_client_ids.yaml
@@ -1,0 +1,13 @@
+auth:
+  providers:
+    - type: google
+      name: google_1
+
+    - type: oidc
+      name: Baidu
+      issuerUrl: 'https://dev-skhlutl45lbqkvhv.us.auth0.com'
+
+    - type: oauth
+      name: Github
+      authorizationUrl: https://github.com/auth
+      tokenUrl: https://github.com/token

--- a/config/fixtures/test_auth_missing_names.yaml
+++ b/config/fixtures/test_auth_missing_names.yaml
@@ -1,0 +1,11 @@
+auth:
+  tokens:
+    accessTokenExpiry: 3600
+    refreshTokenExpiry: 604800
+    
+  providers:
+    - type: google
+
+    - type: oidc
+
+    - type: oauth

--- a/config/fixtures/test_auth_negative_token_lifespan.yaml
+++ b/config/fixtures/test_auth_negative_token_lifespan.yaml
@@ -1,0 +1,4 @@
+auth:
+  tokens:
+    accessTokenExpiry: -1
+    refreshTokenExpiry: -1

--- a/runtime/apis/authapi/token_endpoint_test.go
+++ b/runtime/apis/authapi/token_endpoint_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/teamkeel/keel/config"
 	"github.com/teamkeel/keel/proto"
 	"github.com/teamkeel/keel/runtime"
 	"github.com/teamkeel/keel/runtime/apis/authapi"
@@ -28,14 +29,20 @@ func TestTokenExchange_ValidNewIdentity(t *testing.T) {
 	ctx, database, schema := keeltesting.MakeContext(t, authTestSchema, true)
 	defer database.Close()
 
-	// Set up auth config
-	ctx = runtimectx.WithAuthConfig(ctx, runtimectx.AuthConfig{
-		AllowAnyIssuers: true,
-	})
-
 	// OIDC test server
 	server, err := oauthtest.NewOIDCServer()
 	require.NoError(t, err)
+
+	// Set up auth config
+	ctx = runtimectx.WithOAuthConfig(ctx, &config.AuthConfig{
+		Providers: []config.Provider{
+			{
+				Type:      config.OpenIdConnectProvider,
+				Name:      "my-oidc",
+				IssuerUrl: server.Issuer,
+			},
+		},
+	})
 
 	server.SetUser("id|285620", &oauth.UserClaims{
 		Email: "keelson@keel.so",
@@ -59,7 +66,7 @@ func TestTokenExchange_ValidNewIdentity(t *testing.T) {
 	require.NotEmpty(t, validResponse.RefreshToken)
 	require.True(t, authapi.HasContentType(httpResponse.Header, "application/json"))
 
-	sub, iss, err := oauth.ValidateAccessToken(ctx, validResponse.AccessToken, "")
+	sub, iss, err := oauth.ValidateAccessToken(ctx, validResponse.AccessToken)
 	require.NoError(t, err)
 	require.Equal(t, "https://keel.so", iss)
 
@@ -88,14 +95,20 @@ func TestTokenExchange_ValidNewIdentityAllUserInfo(t *testing.T) {
 	ctx, database, schema := keeltesting.MakeContext(t, authTestSchema, true)
 	defer database.Close()
 
-	// Set up auth config
-	ctx = runtimectx.WithAuthConfig(ctx, runtimectx.AuthConfig{
-		AllowAnyIssuers: true,
-	})
-
 	// OIDC test server
 	server, err := oauthtest.NewOIDCServer()
 	require.NoError(t, err)
+
+	// Set up auth config
+	ctx = runtimectx.WithOAuthConfig(ctx, &config.AuthConfig{
+		Providers: []config.Provider{
+			{
+				Type:      config.OpenIdConnectProvider,
+				Name:      "my-oidc",
+				IssuerUrl: server.Issuer,
+			},
+		},
+	})
 
 	server.SetUser("id|285620", &oauth.UserClaims{
 		Email:               "keelson@keel.so",
@@ -132,7 +145,7 @@ func TestTokenExchange_ValidNewIdentityAllUserInfo(t *testing.T) {
 	require.NotEmpty(t, validResponse.ExpiresIn)
 	require.True(t, authapi.HasContentType(httpResponse.Header, "application/json"))
 
-	sub, iss, err := oauth.ValidateAccessToken(ctx, validResponse.AccessToken, "")
+	sub, iss, err := oauth.ValidateAccessToken(ctx, validResponse.AccessToken)
 	require.NoError(t, err)
 	require.Equal(t, "https://keel.so", iss)
 
@@ -163,14 +176,20 @@ func TestTokenExchange_ValidUpdatedIdentity(t *testing.T) {
 	ctx, database, schema := keeltesting.MakeContext(t, authTestSchema, true)
 	defer database.Close()
 
-	// Set up auth config
-	ctx = runtimectx.WithAuthConfig(ctx, runtimectx.AuthConfig{
-		AllowAnyIssuers: true,
-	})
-
 	// OIDC test server
 	server, err := oauthtest.NewOIDCServer()
 	require.NoError(t, err)
+
+	// Set up auth config
+	ctx = runtimectx.WithOAuthConfig(ctx, &config.AuthConfig{
+		Providers: []config.Provider{
+			{
+				Type:      config.OpenIdConnectProvider,
+				Name:      "my-oidc",
+				IssuerUrl: server.Issuer,
+			},
+		},
+	})
 
 	var inserted []map[string]any
 	database.GetDB().Raw(fmt.Sprintf("INSERT INTO identity (external_id, issuer, email) VALUES ('id|285620','%s','weaveton@keel.so') RETURNING *", server.Issuer)).Scan(&inserted)
@@ -196,7 +215,7 @@ func TestTokenExchange_ValidUpdatedIdentity(t *testing.T) {
 	require.NotEmpty(t, validResponse.ExpiresIn)
 	require.True(t, authapi.HasContentType(httpResponse.Header, "application/json"))
 
-	sub, iss, err := oauth.ValidateAccessToken(ctx, validResponse.AccessToken, "")
+	sub, iss, err := oauth.ValidateAccessToken(ctx, validResponse.AccessToken)
 	require.NoError(t, err)
 	require.Equal(t, "https://keel.so", iss)
 
@@ -426,14 +445,20 @@ func TestRefreshToken_Valid(t *testing.T) {
 	ctx, database, schema := keeltesting.MakeContext(t, authTestSchema, true)
 	defer database.Close()
 
-	// Set up auth config
-	ctx = runtimectx.WithAuthConfig(ctx, runtimectx.AuthConfig{
-		AllowAnyIssuers: true,
-	})
-
 	// OIDC test server
 	server, err := oauthtest.NewOIDCServer()
 	require.NoError(t, err)
+
+	// Set up auth config
+	ctx = runtimectx.WithOAuthConfig(ctx, &config.AuthConfig{
+		Providers: []config.Provider{
+			{
+				Type:      config.OpenIdConnectProvider,
+				Name:      "my-oidc",
+				IssuerUrl: server.Issuer,
+			},
+		},
+	})
 
 	server.SetUser("id|285620", &oauth.UserClaims{
 		Email: "keelson@keel.so",

--- a/runtime/oauth/access_token_test.go
+++ b/runtime/oauth/access_token_test.go
@@ -22,7 +22,6 @@ func newContextWithPK() context.Context {
 
 	pk, _ := testhelpers.GetEmbeddedPrivateKey()
 	ctx = runtimectx.WithPrivateKey(ctx, pk)
-	ctx = runtimectx.WithOAuthConfig(ctx, &config.AuthConfig{})
 
 	return ctx
 }

--- a/runtime/oauth/access_token_test.go
+++ b/runtime/oauth/access_token_test.go
@@ -1,0 +1,279 @@
+package oauth_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/segmentio/ksuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/teamkeel/keel/config"
+	"github.com/teamkeel/keel/runtime/oauth"
+	"github.com/teamkeel/keel/runtime/runtimectx"
+	"github.com/teamkeel/keel/testhelpers"
+)
+
+func newContextWithPK() context.Context {
+	ctx := context.Background()
+
+	pk, _ := testhelpers.GetEmbeddedPrivateKey()
+	ctx = runtimectx.WithPrivateKey(ctx, pk)
+	ctx = runtimectx.WithOAuthConfig(ctx, &config.AuthConfig{})
+
+	return ctx
+}
+
+func TestAccessTokenGenerationAndParsingWithoutPrivateKey(t *testing.T) {
+	ctx := newContextWithPK()
+	identityId := ksuid.New()
+
+	bearerJwt, _, err := oauth.GenerateAccessToken(ctx, identityId.String())
+	require.NoError(t, err)
+	require.NotEmpty(t, bearerJwt)
+
+	parsedId, iss, err := oauth.ValidateAccessToken(ctx, bearerJwt)
+	require.NoError(t, err)
+	require.Equal(t, identityId.String(), parsedId)
+	require.Equal(t, oauth.KeelIssuer, iss)
+}
+
+func TestAccessTokenGenerationAndParsingWithSamePrivateKey(t *testing.T) {
+	ctx := newContextWithPK()
+	identityId := ksuid.New()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	ctx = runtimectx.WithPrivateKey(ctx, privateKey)
+	require.NoError(t, err)
+
+	bearerJwt, _, err := oauth.GenerateAccessToken(ctx, identityId.String())
+	require.NoError(t, err)
+	require.NotEmpty(t, bearerJwt)
+
+	parsedId, iss, err := oauth.ValidateAccessToken(ctx, bearerJwt)
+	require.NoError(t, err)
+	require.Equal(t, identityId.String(), parsedId)
+	require.Equal(t, oauth.KeelIssuer, iss)
+}
+
+func TestAccessTokenGenerationWithPrivateKeyAndParsingWithoutPrivateKey(t *testing.T) {
+	ctx := newContextWithPK()
+	identityId := ksuid.New()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	ctx = runtimectx.WithPrivateKey(ctx, privateKey)
+	require.NoError(t, err)
+
+	bearerJwt, _, err := oauth.GenerateAccessToken(ctx, identityId.String())
+	require.NoError(t, err)
+	require.NotEmpty(t, bearerJwt)
+
+	ctx = newContextWithPK()
+	parsedId, iss, err := oauth.ValidateAccessToken(ctx, bearerJwt)
+	require.ErrorIs(t, oauth.ErrInvalidToken, err)
+	require.Empty(t, parsedId)
+	require.Empty(t, iss)
+}
+
+func TestAccessTokenGenerationWithoutPrivateKeyAndParsingWithPrivateKey(t *testing.T) {
+	ctx := newContextWithPK()
+	identityId := ksuid.New()
+
+	bearerJwt, _, err := oauth.GenerateAccessToken(ctx, identityId.String())
+	require.NoError(t, err)
+	require.NotEmpty(t, bearerJwt)
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	ctx = runtimectx.WithPrivateKey(ctx, privateKey)
+	require.NoError(t, err)
+
+	parsedId, iss, err := oauth.ValidateAccessToken(ctx, bearerJwt)
+	require.ErrorIs(t, oauth.ErrInvalidToken, err)
+	require.Empty(t, parsedId)
+	require.Empty(t, iss)
+}
+
+func TestAccessTokenGenerationAndParsingWithDifferentPrivateKeys(t *testing.T) {
+	ctx := newContextWithPK()
+	identityId := ksuid.New()
+
+	privateKey1, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	ctx = runtimectx.WithPrivateKey(ctx, privateKey1)
+	require.NoError(t, err)
+
+	bearerJwt, _, err := oauth.GenerateAccessToken(ctx, identityId.String())
+	require.NoError(t, err)
+	require.NotEmpty(t, bearerJwt)
+
+	privateKey2, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	ctx = runtimectx.WithPrivateKey(ctx, privateKey2)
+	require.NoError(t, err)
+
+	parsedId, iss, err := oauth.ValidateAccessToken(ctx, bearerJwt)
+	require.ErrorIs(t, oauth.ErrInvalidToken, err)
+	require.Empty(t, parsedId)
+	require.Empty(t, iss)
+}
+
+func TestAccessTokenIsRSAMethodWithPrivateKey(t *testing.T) {
+	ctx := newContextWithPK()
+	identityId := ksuid.New()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	ctx = runtimectx.WithPrivateKey(ctx, privateKey)
+	require.NoError(t, err)
+
+	jwtToken, _, err := oauth.GenerateAccessToken(ctx, identityId.String())
+	require.NoError(t, err)
+	require.NotEmpty(t, jwtToken)
+
+	_, err = jwt.ParseWithClaims(jwtToken, &oauth.AccessTokenClaims{}, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
+			assert.Fail(t, "Invalid signing method. Expected RSA.")
+		}
+		return &privateKey.PublicKey, nil
+	})
+	require.NoError(t, err)
+}
+
+func TestAccessTokenHasDefaultExpiryClaims(t *testing.T) {
+	ctx := newContextWithPK()
+	identityId := ksuid.New()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	ctx = runtimectx.WithPrivateKey(ctx, privateKey)
+	require.NoError(t, err)
+
+	jwtToken, lifespan, err := oauth.GenerateAccessToken(ctx, identityId.String())
+	require.NoError(t, err)
+	require.NotEmpty(t, jwtToken)
+
+	claims := &oauth.AccessTokenClaims{}
+	_, err = jwt.ParseWithClaims(jwtToken, claims, func(token *jwt.Token) (interface{}, error) {
+		return &privateKey.PublicKey, nil
+	})
+	require.NoError(t, err)
+
+	issuedAt := claims.IssuedAt.Time
+	expiry := claims.ExpiresAt.Time
+
+	require.Greater(t, expiry, time.Now())
+	require.Equal(t, issuedAt.Add(oauth.DefaultAccessTokenExpiry), expiry)
+	require.Equal(t, oauth.DefaultAccessTokenExpiry, lifespan)
+}
+
+func TestAccessTokenHasCustomClaims(t *testing.T) {
+	ctx := newContextWithPK()
+	identityId := ksuid.New()
+
+	ctx = runtimectx.WithOAuthConfig(ctx, &config.AuthConfig{
+		Tokens: &config.TokensConfig{
+			AccessTokenExpiry: 360,
+		},
+	})
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	ctx = runtimectx.WithPrivateKey(ctx, privateKey)
+	require.NoError(t, err)
+
+	jwtToken, lifespan, err := oauth.GenerateAccessToken(ctx, identityId.String())
+	require.NoError(t, err)
+	require.NotEmpty(t, jwtToken)
+
+	claims := &oauth.IdTokenClaims{}
+	_, err = jwt.ParseWithClaims(jwtToken, claims, func(token *jwt.Token) (interface{}, error) {
+		return &privateKey.PublicKey, nil
+	})
+	require.NoError(t, err)
+
+	issuedAt := claims.IssuedAt.Time
+	expiry := claims.ExpiresAt.Time
+
+	require.Greater(t, expiry, time.Now())
+	require.Equal(t, issuedAt.Add(time.Second*360), expiry)
+	require.Equal(t, time.Second*360, lifespan)
+}
+
+func TestShortExpiredAccessTokenIsInvalid(t *testing.T) {
+	ctx := newContextWithPK()
+	identityId := ksuid.New()
+
+	ctx = runtimectx.WithOAuthConfig(ctx, &config.AuthConfig{
+		Tokens: &config.TokensConfig{
+			AccessTokenExpiry: 1,
+		},
+	})
+
+	bearerJwt, _, err := oauth.GenerateAccessToken(ctx, identityId.String())
+	require.NoError(t, err)
+	require.NotEmpty(t, bearerJwt)
+
+	time.Sleep(1100 * time.Millisecond)
+
+	parsedId, iss, err := oauth.ValidateAccessToken(ctx, bearerJwt)
+	require.ErrorIs(t, oauth.ErrTokenExpired, err)
+	require.Empty(t, parsedId)
+	require.Empty(t, iss)
+}
+
+func TestExpiredAccessTokenIsInvalid(t *testing.T) {
+	ctx := newContextWithPK()
+	identityId := ksuid.New()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	ctx = runtimectx.WithPrivateKey(ctx, privateKey)
+	require.NoError(t, err)
+
+	// Create the jwt 1 second expired.
+	now := time.Now().UTC().Add(-oauth.DefaultAccessTokenExpiry).Add(time.Second * -1)
+	claims := oauth.AccessTokenClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   identityId.String(),
+			ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour * 24)),
+			IssuedAt:  jwt.NewNumericDate(now),
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tokenString, err := token.SignedString(privateKey)
+	require.NoError(t, err)
+
+	parsedId, iss, err := oauth.ValidateAccessToken(ctx, tokenString)
+	require.ErrorIs(t, oauth.ErrTokenExpired, err)
+	require.Empty(t, parsedId)
+	require.Empty(t, iss)
+}
+
+func TestAccessTokenIssueClaimIsKeel(t *testing.T) {
+	ctx := newContextWithPK()
+	identityId := ksuid.New()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	ctx = runtimectx.WithPrivateKey(ctx, privateKey)
+
+	bearerJwt, _, err := oauth.GenerateAccessToken(ctx, identityId.String())
+	require.NoError(t, err)
+	require.NotEmpty(t, bearerJwt)
+
+	claims := &oauth.AccessTokenClaims{}
+	_, err = jwt.ParseWithClaims(bearerJwt, claims, func(token *jwt.Token) (interface{}, error) {
+		return &privateKey.PublicKey, nil
+	})
+	require.NoError(t, err)
+
+	issuedAt := claims.Issuer
+	require.Equal(t, oauth.KeelIssuer, issuedAt)
+}

--- a/runtime/oauth/id_token.go
+++ b/runtime/oauth/id_token.go
@@ -66,7 +66,12 @@ func VerifyIdToken(ctx context.Context, idTokenRaw string) (*oidc.IDToken, error
 		return nil, err
 	}
 
-	if !authConfig.HasOidcIssuer(issuer) {
+	hasIssuer, err := authConfig.HasOidcIssuer(issuer)
+	if err != nil {
+		return nil, err
+	}
+
+	if !hasIssuer {
 		return nil, fmt.Errorf("issuer %s not registered to authenticate on this server", issuer)
 	}
 

--- a/runtime/oauth/id_token.go
+++ b/runtime/oauth/id_token.go
@@ -61,21 +61,12 @@ func VerifyIdToken(ctx context.Context, idTokenRaw string) (*oidc.IDToken, error
 
 	span.SetAttributes(attribute.String("issuer", issuer))
 
-	authConfig, err := runtimectx.GetAuthConfig(ctx)
+	authConfig, err := runtimectx.GetOAuthConfig(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	issuerPermitted := authConfig.AllowAnyIssuers
-	if !issuerPermitted {
-		for _, e := range authConfig.Issuers {
-			if e.Iss == issuer {
-				issuerPermitted = true
-			}
-		}
-	}
-
-	if !issuerPermitted {
+	if !authConfig.HasOidcIssuer(issuer) {
 		return nil, fmt.Errorf("issuer %s not registered to authenticate on this server", issuer)
 	}
 

--- a/runtime/oauth/id_token_test.go
+++ b/runtime/oauth/id_token_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/teamkeel/keel/config"
 	"github.com/teamkeel/keel/runtime/oauth"
 	"github.com/teamkeel/keel/runtime/oauth/oauthtest"
 	"github.com/teamkeel/keel/runtime/runtimectx"
@@ -15,14 +16,20 @@ import (
 func TestIdTokenAuth_Valid(t *testing.T) {
 	ctx := context.Background()
 
-	// Set up auth config
-	ctx = runtimectx.WithAuthConfig(ctx, runtimectx.AuthConfig{
-		AllowAnyIssuers: true,
-	})
-
 	// OIDC test server
 	server, err := oauthtest.NewOIDCServer()
 	require.NoError(t, err)
+
+	// Set up auth config
+	ctx = runtimectx.WithOAuthConfig(ctx, &config.AuthConfig{
+		Providers: []config.Provider{
+			{
+				Type:      config.OpenIdConnectProvider,
+				Name:      "my-oidc",
+				IssuerUrl: server.Issuer,
+			},
+		},
+	})
 
 	server.SetUser("id|285620", &oauth.UserClaims{
 		Email: "keelson@keel.so",
@@ -41,14 +48,20 @@ func TestIdTokenAuth_Valid(t *testing.T) {
 func TestIdTokenAuth_IncorrectlySigned(t *testing.T) {
 	ctx := context.Background()
 
-	// Set up auth config
-	ctx = runtimectx.WithAuthConfig(ctx, runtimectx.AuthConfig{
-		AllowAnyIssuers: true,
-	})
-
 	// OIDC test server
 	server, err := oauthtest.NewOIDCServer()
 	require.NoError(t, err)
+
+	// Set up auth config
+	ctx = runtimectx.WithOAuthConfig(ctx, &config.AuthConfig{
+		Providers: []config.Provider{
+			{
+				Type:      config.OpenIdConnectProvider,
+				Name:      "my-oidc",
+				IssuerUrl: server.Issuer,
+			},
+		},
+	})
 
 	server.SetUser("id|285620", &oauth.UserClaims{
 		Email: "keelson@keel.so",
@@ -72,14 +85,20 @@ func TestIdTokenAuth_IncorrectlySigned(t *testing.T) {
 func TestIdTokenAuth_IssuerMismatch(t *testing.T) {
 	ctx := context.Background()
 
-	// Set up auth config
-	ctx = runtimectx.WithAuthConfig(ctx, runtimectx.AuthConfig{
-		AllowAnyIssuers: true,
-	})
-
 	// OIDC test server
 	server, err := oauthtest.NewOIDCServer()
 	require.NoError(t, err)
+
+	// Set up auth config
+	ctx = runtimectx.WithOAuthConfig(ctx, &config.AuthConfig{
+		Providers: []config.Provider{
+			{
+				Type:      config.OpenIdConnectProvider,
+				Name:      "my-oidc",
+				IssuerUrl: server.Issuer,
+			},
+		},
+	})
 
 	issuer := server.Config["issuer"]
 
@@ -100,17 +119,15 @@ func TestIdTokenAuth_IssuerMismatch(t *testing.T) {
 	require.Nil(t, idToken)
 }
 
-func TestIdTokenAuth_IssuerNotRegistered(t *testing.T) {
+func TestIdTokenAuth_IssuerNotConfigured(t *testing.T) {
 	ctx := context.Background()
-
-	// Set up auth config
-	ctx = runtimectx.WithAuthConfig(ctx, runtimectx.AuthConfig{
-		AllowAnyIssuers: false,
-	})
 
 	// OIDC test server
 	server, err := oauthtest.NewOIDCServer()
 	require.NoError(t, err)
+
+	// Set up auth config with no issuer
+	ctx = runtimectx.WithOAuthConfig(ctx, &config.AuthConfig{})
 
 	server.SetUser("id|285620", &oauth.UserClaims{
 		Email: "keelson@keel.so",
@@ -130,14 +147,20 @@ func TestIdTokenAuth_IssuerNotRegistered(t *testing.T) {
 func TestIdTokenAuth_ExpiredIdToken(t *testing.T) {
 	ctx := context.Background()
 
-	// Set up auth config
-	ctx = runtimectx.WithAuthConfig(ctx, runtimectx.AuthConfig{
-		AllowAnyIssuers: true,
-	})
-
 	// OIDC test server
 	server, err := oauthtest.NewOIDCServer()
 	require.NoError(t, err)
+
+	// Set up auth config
+	ctx = runtimectx.WithOAuthConfig(ctx, &config.AuthConfig{
+		Providers: []config.Provider{
+			{
+				Type:      config.OpenIdConnectProvider,
+				Name:      "my-oidc",
+				IssuerUrl: server.Issuer,
+			},
+		},
+	})
 
 	server.IdTokenLifespan = 0 * time.Second
 

--- a/runtime/oauth/refresh_token_test.go
+++ b/runtime/oauth/refresh_token_test.go
@@ -18,9 +18,6 @@ func TestNewRefreshToken_NotEmpty(t *testing.T) {
 	ctx, database, _ := keeltesting.MakeContext(t, authTestSchema, true)
 	defer database.Close()
 
-	// Set up auth config
-	ctx = runtimectx.WithOAuthConfig(ctx, &config.AuthConfig{})
-
 	refreshToken, err := oauth.NewRefreshToken(ctx, "identity_id")
 	require.NoError(t, err)
 	require.NotEmpty(t, refreshToken)
@@ -29,9 +26,6 @@ func TestNewRefreshToken_NotEmpty(t *testing.T) {
 func TestNewRefreshToken_ErrorOnEmptyIdentityId(t *testing.T) {
 	ctx := context.Background()
 
-	// Set up auth config
-	ctx = runtimectx.WithOAuthConfig(ctx, &config.AuthConfig{})
-
 	_, err := oauth.NewRefreshToken(ctx, "")
 	require.Error(t, err)
 }
@@ -39,9 +33,6 @@ func TestNewRefreshToken_ErrorOnEmptyIdentityId(t *testing.T) {
 func TestRotateRefreshToken_Valid(t *testing.T) {
 	ctx, database, _ := keeltesting.MakeContext(t, authTestSchema, true)
 	defer database.Close()
-
-	// Set up auth config
-	ctx = runtimectx.WithOAuthConfig(ctx, &config.AuthConfig{})
 
 	refreshToken, err := oauth.NewRefreshToken(ctx, "identity_id")
 	require.NoError(t, err)
@@ -87,9 +78,6 @@ func TestRotateRefreshToken_ReuseRefreshTokenNotValid(t *testing.T) {
 	ctx, database, _ := keeltesting.MakeContext(t, authTestSchema, true)
 	defer database.Close()
 
-	// Set up auth config
-	ctx = runtimectx.WithOAuthConfig(ctx, &config.AuthConfig{})
-
 	refreshToken, err := oauth.NewRefreshToken(ctx, "identity_id")
 	require.NoError(t, err)
 
@@ -110,9 +98,6 @@ func TestRevokeRefreshToken_Unauthorised(t *testing.T) {
 	ctx, database, _ := keeltesting.MakeContext(t, authTestSchema, true)
 	defer database.Close()
 
-	// Set up auth config
-	ctx = runtimectx.WithOAuthConfig(ctx, &config.AuthConfig{})
-
 	refreshToken, err := oauth.NewRefreshToken(ctx, "identity_id")
 	require.NoError(t, err)
 
@@ -127,9 +112,6 @@ func TestRevokeRefreshToken_Unauthorised(t *testing.T) {
 func TestRevokeRefreshToken_MultipleForIdentity(t *testing.T) {
 	ctx, database, _ := keeltesting.MakeContext(t, authTestSchema, true)
 	defer database.Close()
-
-	// Set up auth config
-	ctx = runtimectx.WithOAuthConfig(ctx, &config.AuthConfig{})
 
 	refreshToken1, err := oauth.NewRefreshToken(ctx, "identity_id")
 	require.NoError(t, err)

--- a/runtime/runtime_audit_test.go
+++ b/runtime/runtime_audit_test.go
@@ -452,7 +452,7 @@ func TestAuditDatabaseMigration(t *testing.T) {
 	var updatedSchema = `
 		model Person {
 			fields {
-				name Text
+			name Text
 				age Number @default(0)
 				isActive Boolean @default(true)
 			}

--- a/runtime/runtime_audit_test.go
+++ b/runtime/runtime_audit_test.go
@@ -452,7 +452,7 @@ func TestAuditDatabaseMigration(t *testing.T) {
 	var updatedSchema = `
 		model Person {
 			fields {
-			name Text
+				name Text
 				age Number @default(0)
 				isActive Boolean @default(true)
 			}

--- a/runtime/runtimectx/oauth.go
+++ b/runtime/runtimectx/oauth.go
@@ -1,0 +1,33 @@
+package runtimectx
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/teamkeel/keel/config"
+)
+
+const (
+	oauthContextKey contextKey = "oauthConfig"
+)
+
+func WithOAuthConfig(ctx context.Context, config *config.AuthConfig) context.Context {
+	ctx = context.WithValue(ctx, oauthContextKey, config)
+	return ctx
+}
+
+func GetOAuthConfig(ctx context.Context) (*config.AuthConfig, error) {
+
+	v := ctx.Value(oauthContextKey)
+	if v == nil {
+		return nil, fmt.Errorf("context does not have a :%s key", oauthContextKey)
+	}
+
+	config, ok := v.(*config.AuthConfig)
+
+	if !ok {
+		return nil, errors.New("auth config in the context has wrong value type")
+	}
+	return config, nil
+}

--- a/runtime/runtimectx/oauth.go
+++ b/runtime/runtimectx/oauth.go
@@ -3,7 +3,6 @@ package runtimectx
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/teamkeel/keel/config"
 )
@@ -18,10 +17,9 @@ func WithOAuthConfig(ctx context.Context, config *config.AuthConfig) context.Con
 }
 
 func GetOAuthConfig(ctx context.Context) (*config.AuthConfig, error) {
-
 	v := ctx.Value(oauthContextKey)
 	if v == nil {
-		return nil, fmt.Errorf("context does not have a :%s key", oauthContextKey)
+		return &config.AuthConfig{}, nil
 	}
 
 	config, ok := v.(*config.AuthConfig)


### PR DESCRIPTION
## Auth configuration in keelconfig.yaml

The following can be configured:
 - Access and refresh token expiries
 - Built-in providers (`google` supported in this PR)
 - Custom `oidc` providers for ID token and OAuth authentication
 - Custom `oauth` providers for OAuth authentication only

Each type has it's own set of requirements, but all require a `name` and a `clientId`

```yaml
auth:
  tokens:
    # In seconds
    accessTokenExpiry: 3600
    refreshTokenExpiry: 604800
    
  providers:
    # Built-in Google provider
    - type: google
      name: GoogleClient1
      clientId: jjshflsis2ss23

    # Built-in Google provider
    - type: google
      name: GoogleAdmin
      clientId: 23f223twefgwfw

    # Custom OIDC
    - type: oidc
      name: Auth0
      issuerUrl: 'https://dev-skhlutl45lbqkvhv.us.auth0.com'
      clientId: 'kasj28fnq09ak'

    # Custom OAuth
    - type: oauth
      name: Github
      clientId: hfjuw983h1hfsdf
      authorizationUrl: https://github.com/auth
      tokenUrl: https://github.com/token
```

### Telemetry

If a issuer is not registered, then the client will get the standard 401:

```json
{
    "error": "invalid_client",
    "error_description": "possible causes may be that the id token is invalid, has expired, or has insufficient claims"
}
```

But the tracing will capture the underlying reason properly:

<img width="1400" alt="image" src="https://github.com/teamkeel/keel/assets/6212830/2bd63fdd-d3bb-4536-9a02-0df9203a9dde">


### Outstanding

 - Per environment/slug configuration
 - Disable refresh token rotation by config item
 - How we do the client secret thing for OAuth providers