### PR TITLE
chore: add oidc provider method

### DIFF
--- a/config/auth.go
+++ b/config/auth.go
@@ -83,15 +83,15 @@ func (c *AuthConfig) RefreshTokenRotationEnabled() bool {
 }
 
 // AddOidcProvider adds a OpenID Connect provider to the list of supported authentication providers
-func (c *AuthConfig) AddOidcProvider(name string, issuerUrl string, clientId string) error {
+func (c *AuthConfig) AddOidcProvider(name string, issuerUrl string, clientId string) (*AuthConfig, error) {
 	if name == "" {
-		return errors.New("provider name cannot be empty")
+		return nil, errors.New("provider name cannot be empty")
 	}
 	if invalidUrl(issuerUrl) {
-		return fmt.Errorf("invalid issuerUrl: %s", issuerUrl)
+		return nil, fmt.Errorf("invalid issuerUrl: %s", issuerUrl)
 	}
 	if clientId == "" {
-		return errors.New("provider clientId cannot be empty")
+		return nil, errors.New("provider clientId cannot be empty")
 	}
 
 	provider := Provider{
@@ -103,7 +103,7 @@ func (c *AuthConfig) AddOidcProvider(name string, issuerUrl string, clientId str
 
 	c.Providers = append(c.Providers, provider)
 
-	return nil
+	return c, nil
 }
 
 func (c *AuthConfig) GetOidcProviders() []Provider {

--- a/config/auth.go
+++ b/config/auth.go
@@ -82,16 +82,16 @@ func (c *AuthConfig) RefreshTokenRotationEnabled() bool {
 	}
 }
 
-// AddOidcProvider adds a OpenID Connect provider to the list of supported authentication providers
-func (c *AuthConfig) AddOidcProvider(name string, issuerUrl string, clientId string) (*AuthConfig, error) {
+// AddOidcProvider adds an OpenID Connect provider to the list of supported authentication providers
+func (c *AuthConfig) AddOidcProvider(name string, issuerUrl string, clientId string) error {
 	if name == "" {
-		return nil, errors.New("provider name cannot be empty")
+		return errors.New("provider name cannot be empty")
 	}
 	if invalidUrl(issuerUrl) {
-		return nil, fmt.Errorf("invalid issuerUrl: %s", issuerUrl)
+		return fmt.Errorf("invalid issuerUrl: %s", issuerUrl)
 	}
 	if clientId == "" {
-		return nil, errors.New("provider clientId cannot be empty")
+		return errors.New("provider clientId cannot be empty")
 	}
 
 	provider := Provider{
@@ -102,10 +102,10 @@ func (c *AuthConfig) AddOidcProvider(name string, issuerUrl string, clientId str
 	}
 
 	c.Providers = append(c.Providers, provider)
-
-	return c, nil
+	return nil
 }
 
+// GetOidcProviders returns all OpenID Connect compatible authentication providers
 func (c *AuthConfig) GetOidcProviders() []Provider {
 	oidcProviders := []Provider{}
 	for _, p := range c.Providers {
@@ -138,6 +138,7 @@ func (c *AuthConfig) GetOidcProvidersByIssuer(issuer string) ([]Provider, error)
 	return providers, nil
 }
 
+// GetIssuer retrieves the issuer URL for the provider
 func (c *Provider) GetIssuer() (string, error) {
 	switch c.Type {
 	case GoogleProvider:

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -252,12 +252,12 @@ func TestAddOidcProvider(t *testing.T) {
 
 	assert.Len(t, config.Auth.GetOidcProviders(), 1)
 
-	err = config.Auth.AddOidcProvider("custom-auth", "https://mycustomoidc.com", "1234")
+	auth, err := config.Auth.AddOidcProvider("custom-auth", "https://mycustomoidc.com", "1234")
 	assert.NoError(t, err)
 
-	assert.Len(t, config.Auth.GetOidcProviders(), 2)
+	assert.Len(t, auth.GetOidcProviders(), 2)
 
-	byIssuer, err := config.Auth.GetOidcProvidersByIssuer("https://mycustomoidc.com")
+	byIssuer, err := auth.GetOidcProvidersByIssuer("https://mycustomoidc.com")
 	assert.NoError(t, err)
 	assert.Len(t, byIssuer, 1)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -245,3 +245,19 @@ func TestGetOidcSameIssuers(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, googleIssuer, 3)
 }
+
+func TestAddOidcProvider(t *testing.T) {
+	config, err := Load("fixtures/test_auth.yaml")
+	assert.NoError(t, err)
+
+	assert.Len(t, config.Auth.GetOidcProviders(), 1)
+
+	err = config.Auth.AddOidcProvider("custom-auth", "https://mycustomoidc.com", "1234")
+	assert.NoError(t, err)
+
+	assert.Len(t, config.Auth.GetOidcProviders(), 2)
+
+	byIssuer, err := config.Auth.GetOidcProvidersByIssuer("https://mycustomoidc.com")
+	assert.NoError(t, err)
+	assert.Len(t, byIssuer, 1)
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -252,12 +252,12 @@ func TestAddOidcProvider(t *testing.T) {
 
 	assert.Len(t, config.Auth.GetOidcProviders(), 1)
 
-	auth, err := config.Auth.AddOidcProvider("custom-auth", "https://mycustomoidc.com", "1234")
+	err = config.Auth.AddOidcProvider("Custom Auth", "https://mycustomoidc.com", "1234")
 	assert.NoError(t, err)
 
-	assert.Len(t, auth.GetOidcProviders(), 2)
+	assert.Len(t, config.Auth.GetOidcProviders(), 2)
 
-	byIssuer, err := auth.GetOidcProvidersByIssuer("https://mycustomoidc.com")
+	byIssuer, err := config.Auth.GetOidcProvidersByIssuer("https://mycustomoidc.com")
 	assert.NoError(t, err)
 	assert.Len(t, byIssuer, 1)
 }

--- a/runtime/auth/auth_test.go
+++ b/runtime/auth/auth_test.go
@@ -491,7 +491,7 @@ func TestAllowAllIssuers(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestEnVarFallback(t *testing.T) {
+func TestEnvVarFallback(t *testing.T) {
 
 	ctx := newContext()
 


### PR DESCRIPTION
Purely a convenience for the backend to add its auth provider (Auth0) when instantiated the runtime.