### PR TITLE
chore: refactor some of the sdk codegen for functions

### DIFF
--- a/node/codegen_test.go
+++ b/node/codegen_test.go
@@ -410,7 +410,8 @@ function createModelAPI() {
 function createPermissionApi() {
 	return new runtime.Permissions();
 };
-module.exports.models = createModelAPI();
+const models = createModelAPI();
+module.exports.models = models;
 module.exports.permissions = createPermissionApi();
 module.exports.createContextAPI = createContextAPI;
 module.exports.createJobContextAPI = createJobContextAPI;

--- a/node/templates/functions/create.js
+++ b/node/templates/functions/create.js
@@ -1,0 +1,31 @@
+function createFunction({ model, valueInputs }) {
+  return function (hooks = {}) {
+    return async function (ctx, inputs) {
+      let values = {};
+      for (const key of valueInputs) {
+        if (key in inputs) {
+          values[key] = inputs[key];
+        }
+      }
+
+      if (hooks.beforeWrite) {
+        values = await runtime.tracing.withSpan("beforeWrite", () => {
+          return hooks.beforeWrite(ctx, inputs, values);
+        });
+      }
+
+      let data = await model.create(values);
+
+      if (hooks.afterWrite) {
+        const v = await runtime.tracing.withSpan("afterWrite", () => {
+          return hooks.afterWrite(ctx, inputs, data);
+        });
+        if (v !== undefined) {
+          data = v;
+        }
+      }
+
+      return data;
+    };
+  };
+}

--- a/node/templates/functions/delete.js
+++ b/node/templates/functions/delete.js
@@ -1,0 +1,45 @@
+function deleteFunction({ model, whereInputs }) {
+  return function (hooks = {}) {
+    return async function (ctx, inputs) {
+      let wheres = {};
+      for (const key of whereInputs) {
+        if (key in inputs) {
+          wheres[key] = inputs[key];
+        }
+      }
+
+      let data = model.where(wheres);
+
+      if (hooks.beforeQuery) {
+        data = await runtime.tracing.withSpan("beforeQuery", () => {
+          return hooks.beforeQuery(ctx, inputs, data);
+        });
+      }
+
+      const constructor = data?.constructor?.name;
+      if (constructor === "QueryBuilder") {
+        data = await data.findOne();
+      }
+
+      if (data === null) {
+        throw new NoResultError();
+      }
+
+      if (hooks.beforeWrite) {
+        await runtime.tracing.withSpan("beforeWrite", () => {
+          return hooks.beforeWrite(ctx, inputs, data);
+        });
+      }
+
+      await model.delete({ id: data.id });
+
+      if (hooks.afterWrite) {
+        await runtime.tracing.withSpan("afterWrite", () => {
+          return hooks.afterWrite(ctx, inputs, data);
+        });
+      }
+
+      return data.id;
+    };
+  };
+}

--- a/node/templates/functions/get.js
+++ b/node/templates/functions/get.js
@@ -1,0 +1,37 @@
+function getFunction({ model, whereInputs }) {
+  return function (hooks = {}) {
+    return async function (ctx, inputs) {
+      let wheres = {};
+      for (const key of whereInputs) {
+        if (key in inputs) {
+          wheres[key] = inputs[key];
+        }
+      }
+
+      let data = model.where(wheres);
+
+      if (hooks.beforeQuery) {
+        data = await runtime.tracing.withSpan("beforeQuery", () => {
+          return hooks.beforeQuery(ctx, inputs, data);
+        });
+      }
+
+      const constructor = data?.constructor?.name;
+      if (constructor === "QueryBuilder") {
+        data = await data.findOne();
+      }
+
+      if (data === null) {
+        return null;
+      }
+
+      if (hooks.afterQuery) {
+        data = await runtime.tracing.withSpan("afterQuery", () => {
+          return hooks.afterQuery(ctx, inputs, data);
+        });
+      }
+
+      return data;
+    };
+  };
+}

--- a/node/templates/functions/list.js
+++ b/node/templates/functions/list.js
@@ -1,0 +1,33 @@
+function listFunction({ model, whereInputs }) {
+  return function (hooks = {}) {
+    return async function (ctx, inputs) {
+      let wheres = {};
+      for (const key of whereInputs) {
+        if (inputs.where && key in inputs.where) {
+          wheres[key] = inputs.where[key];
+        }
+      }
+
+      let data = model.where(wheres);
+
+      if (hooks.beforeQuery) {
+        data = await runtime.tracing.withSpan("beforeQuery", () => {
+          return hooks.beforeQuery(ctx, inputs, data);
+        });
+      }
+
+      const constructor = data?.constructor?.name;
+      if (constructor === "QueryBuilder") {
+        data = await data.findMany({ limit: inputs.first });
+      }
+
+      if (hooks.afterQuery) {
+        data = await runtime.tracing.withSpan("afterQuery", () => {
+          return hooks.afterQuery(ctx, inputs, data);
+        });
+      }
+
+      return data;
+    };
+  };
+}

--- a/node/templates/functions/types.d.ts
+++ b/node/templates/functions/types.d.ts
@@ -1,0 +1,91 @@
+/**
+ * The available hooks for a 'get' function
+ * @typeParam M - The Model this function is declared in
+ * @typeParam QB - The QueryBuilder type for the model
+ * @typeParam I - The function inputs
+ */
+type GetFunctionHooks<M, QB, I> = {
+  beforeQuery?: (
+    ctx: ContextAPI,
+    inputs: I,
+    query: QB
+  ) => Promise<QB | M | null> | QB | M | null;
+  afterQuery?: (ctx: ContextAPI, inputs: I, record: M) => Promise<M> | M;
+};
+
+/**
+ * The available hooks for a 'list' function
+ * @typeParam M - The Model this function is declared in
+ * @typeParam QB - The QueryBuilder type for the model
+ * @typeParam I - The function inputs
+ */
+type ListFunctionHooks<M, QB, I> = {
+  beforeQuery?: (
+    ctx: ContextAPI,
+    inputs: I,
+    query: QB
+  ) => Promise<QB | Array<M>> | QB | Array<M>;
+  afterQuery?: (
+    ctx: ContextAPI,
+    inputs: I,
+    records: Array<M>
+  ) => Promise<Array<M>> | Array<M>;
+};
+
+/**
+ * The available hooks for a 'create' function
+ * @typeParam M - The Model this function is declared in
+ * @typeParam QB - The QueryBuilder type for the model
+ * @typeParam I - The function inputs
+ * @typeParam C - The values that can be used to create an M record
+ */
+type CreateFunctionHooks<M, QB, I, C> = {
+  beforeWrite?: (ctx: ContextAPI, inputs: I, values: C) => Promise<C> | C;
+  afterWrite?: (
+    ctx: ContextAPI,
+    inputs: I,
+    data: M
+  ) => Promise<M | void> | M | void;
+};
+
+/**
+ * The available hooks for a 'create' function
+ * @typeParam M - The Model this function is declared in
+ * @typeParam QB - The QueryBuilder type for the model
+ * @typeParam I - The function inputs
+ * @typeParam C - The values that can be used to update an M record
+ */
+type UpdateFunctionHooks<M, QB, I, V> = {
+  beforeQuery?: (
+    ctx: ContextAPI,
+    inputs: I,
+    query: QB
+  ) => Promise<M | QB> | M | QB;
+  beforeWrite?: (
+    ctx: ContextAPI,
+    inputs: I,
+    values: V,
+    record: M
+  ) => Promise<Partial<M>> | Partial<M>;
+  afterWrite?: (
+    ctx: ContextAPI,
+    inputs: I,
+    data: M
+  ) => Promise<M | void> | M | void;
+};
+
+/**
+ * The available hooks for a 'delete' function
+ * @typeParam M - The Model this function is declared in
+ * @typeParam QB - The QueryBuilder type for the model
+ * @typeParam I - The function inputs
+ */
+type DeleteFunctionHooks<M, QB, I> = {
+  beforeQuery?: (
+    ctx: ContextAPI,
+    inputs: I,
+    query: QB
+  ) => Promise<M | QB> | M | QB;
+  beforeWrite?: (ctx: ContextAPI, inputs: I, record: M) => Promise<void> | void;
+  afterWrite?: (ctx: ContextAPI, inputs: I, data: M) => Promise<void> | void;
+};

--- a/node/templates/functions/update.js
+++ b/node/templates/functions/update.js
@@ -1,0 +1,54 @@
+function updateFunction({ model, whereInputs, valueInputs }) {
+  return function (hooks = {}) {
+    return async function (ctx, inputs) {
+      let wheres = {};
+      let values = {};
+      for (const key of whereInputs) {
+        if (inputs.where && key in inputs.where) {
+          wheres[key] = inputs.where[key];
+        }
+      }
+      for (const key of valueInputs) {
+        if (inputs.values && key in inputs.values) {
+          values[key] = inputs.values[key];
+        }
+      }
+
+      let data = model.where(wheres);
+
+      if (hooks.beforeQuery) {
+        data = await runtime.tracing.withSpan("beforeQuery", () => {
+          return hooks.beforeQuery(ctx, inputs, data);
+        });
+      }
+
+      const constructor = data?.constructor?.name;
+      if (constructor === "QueryBuilder") {
+        data = await data.findOne();
+      }
+
+      if (data === null) {
+        throw new NoResultError();
+      }
+
+      if (hooks.beforeWrite) {
+        values = await runtime.tracing.withSpan("beforeWrite", () => {
+          return hooks.beforeWrite(ctx, inputs, values, data);
+        });
+      }
+
+      data = await model.update({ id: data.id }, values);
+
+      if (hooks.afterWrite) {
+        const v = await runtime.tracing.withSpan("afterWrite", () => {
+          return hooks.afterWrite(ctx, inputs, data);
+        });
+        if (v !== undefined) {
+          data = v;
+        }
+      }
+
+      return data;
+    };
+  };
+}


### PR DESCRIPTION
I see this is as a stepping stone to moving most of the function hooks stuff into the functions-runtime package, but I think until the API is 100% stable it's better in codegen as that avoids any issues with version drift between the codegen and the npm package.

