### PR TITLE
feat: support setting http response status in functions

### DIFF
--- a/functions/functions.go
+++ b/functions/functions.go
@@ -70,6 +70,7 @@ type FunctionsRuntimeResponse struct {
 
 type FunctionsRuntimeMeta struct {
 	Headers map[string][]string `json:"headers"`
+	Status  int                 `json:"status"`
 }
 
 // FunctionsRuntimeError follows the error object specification
@@ -91,7 +92,7 @@ func WithFunctionsTransport(ctx context.Context, transport Transport) context.Co
 }
 
 // CallFunction will invoke the custom function on the runtime node server.
-func CallFunction(ctx context.Context, actionName string, body any, permissionState *common.PermissionState) (any, map[string][]string, error) {
+func CallFunction(ctx context.Context, actionName string, body any, permissionState *common.PermissionState) (any, *FunctionsRuntimeMeta, error) {
 	span := trace.SpanFromContext(ctx)
 
 	transport, ok := ctx.Value(contextKey).(Transport)
@@ -156,7 +157,7 @@ func CallFunction(ctx context.Context, actionName string, body any, permissionSt
 		return nil, nil, toRuntimeError(resp.Error)
 	}
 
-	return resp.Result, resp.Meta.Headers, nil
+	return resp.Result, resp.Meta, nil
 }
 
 // CallJob will invoke the job function on the runtime node server.

--- a/integration/testdata/functions_http/functions/withHeaders.ts
+++ b/integration/testdata/functions_http/functions/withHeaders.ts
@@ -1,0 +1,10 @@
+import { WithHeaders, permissions } from "@teamkeel/sdk";
+
+export default WithHeaders(async (ctx, inputs) => {
+  permissions.allow();
+
+  const value = ctx.headers.get("X-MyRequestHeader");
+  ctx.response.headers.set("X-MyResponseHeader", value || "");
+
+  return {};
+});

--- a/integration/testdata/functions_http/functions/withQueryParams.ts
+++ b/integration/testdata/functions_http/functions/withQueryParams.ts
@@ -1,0 +1,7 @@
+import { WithQueryParams, permissions } from "@teamkeel/sdk";
+
+export default WithQueryParams(async (ctx, inputs) => {
+  permissions.allow();
+
+  return inputs;
+});

--- a/integration/testdata/functions_http/functions/withStatus.ts
+++ b/integration/testdata/functions_http/functions/withStatus.ts
@@ -1,0 +1,10 @@
+import { WithStatus, permissions } from "@teamkeel/sdk";
+export default WithStatus(async (ctx, inputs) => {
+  permissions.allow();
+
+  const { response } = ctx;
+  response.headers.set("Location", "https://some.url");
+  response.status = 301;
+
+  return null;
+});

--- a/integration/testdata/functions_http/schema.keel
+++ b/integration/testdata/functions_http/schema.keel
@@ -1,0 +1,7 @@
+model TestModel {
+    actions {
+        read withQueryParams(Any) returns (Any)
+        read withHeaders(Any) returns (Any)
+        read withStatus(Any) returns (Any)
+    }
+}

--- a/integration/testdata/functions_http/tests.test.ts
+++ b/integration/testdata/functions_http/tests.test.ts
@@ -1,0 +1,50 @@
+import { test, expect } from "vitest";
+
+test("headers", async () => {
+  const response = await fetch(
+    process.env.KEEL_TESTING_ACTIONS_API_URL + "/withHeaders",
+    {
+      body: "{}",
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-MyRequestHeader": "my-header-value",
+      },
+    }
+  );
+
+  expect(response.status).toEqual(200);
+  expect(response.headers.get("X-MyResponseHeader")).toEqual("my-header-value");
+});
+
+test("status", async () => {
+  const response = await fetch(
+    process.env.KEEL_TESTING_ACTIONS_API_URL + "/withStatus",
+    {
+      body: "{}",
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      redirect: "manual",
+    }
+  );
+
+  expect(response.status).toEqual(301);
+  expect(response.headers.get("Location")).toEqual("https://some.url");
+});
+
+test("query params", async () => {
+  const response = await fetch(
+    process.env.KEEL_TESTING_ACTIONS_API_URL +
+      "/withQueryParams?a=1&b=foo&c=true"
+  );
+
+  const body = await response.json();
+
+  expect(body).toEqual({
+    a: "1",
+    b: "foo",
+    c: "true",
+  });
+});

--- a/node/bootstrap.go
+++ b/node/bootstrap.go
@@ -158,7 +158,7 @@ func Bootstrap(dir string, opts ...BootstrapOption) error {
 		options.logger("Creating tsconfig.json")
 		tsConfig := map[string]any{
 			"compilerOptions": map[string]any{
-				"lib":               []string{"ES2016"},
+				"lib":               []string{"ES2016", "DOM"},
 				"target":            "ES2016",
 				"esModuleInterop":   true,
 				"moduleResolution":  "node",

--- a/node/codegen.go
+++ b/node/codegen.go
@@ -609,7 +609,7 @@ func writeAPIDeclarations(w *codegen.Writer, schema *proto.Schema) {
 func writeAPIFactory(w *codegen.Writer, schema *proto.Schema) {
 	w.Writeln("function createContextAPI({ responseHeaders, meta }) {")
 	w.Indent()
-	w.Writeln("const headers = new runtime.RequestHeaders(meta.headers);")
+	w.Writeln("const headers = new Headers(meta.headers);")
 	w.Writeln("const response = { headers: responseHeaders }")
 	w.Writeln("const now = () => { return new Date(); };")
 	w.Writeln("const { identity } = meta;")

--- a/node/codegen_test.go
+++ b/node/codegen_test.go
@@ -366,7 +366,7 @@ job BatchPosts {
 func TestWriteAPIFactory(t *testing.T) {
 	expected := `
 function createContextAPI({ responseHeaders, meta }) {
-	const headers = new runtime.RequestHeaders(meta.headers);
+	const headers = new Headers(meta.headers);
 	const response = { headers: responseHeaders }
 	const now = () => { return new Date(); };
 	const { identity } = meta;

--- a/packages/functions-runtime/src/handleRequest.js
+++ b/packages/functions-runtime/src/handleRequest.js
@@ -88,7 +88,10 @@ async function handleRequest(request, config) {
         for (const pair of headers.entries()) {
           responseHeaders[pair[0]] = pair[1].split(", ");
         }
-        response.meta = { headers: responseHeaders };
+        response.meta = {
+          headers: responseHeaders,
+          status: ctx.response.status,
+        };
 
         return response;
       } catch (e) {

--- a/packages/functions-runtime/src/handleRequest.test.js
+++ b/packages/functions-runtime/src/handleRequest.test.js
@@ -23,7 +23,13 @@ test("when the custom function returns expected value", async () => {
     actionTypes: {
       createPost: PROTO_ACTION_TYPES.CREATE,
     },
-    createContextAPI: () => {},
+    createContextAPI: () => {
+      return {
+        response: {
+          headers: new Headers(),
+        },
+      };
+    },
   };
 
   const rpcReq = createJSONRPCRequest("123", "createPost", { title: "a post" });
@@ -52,7 +58,13 @@ test("when the custom function doesnt return a value", async () => {
     actionTypes: {
       createPost: PROTO_ACTION_TYPES.CREATE,
     },
-    createContextAPI: () => {},
+    createContextAPI: () => {
+      return {
+        response: {
+          headers: new Headers(),
+        },
+      };
+    },
   };
 
   const rpcReq = createJSONRPCRequest("123", "createPost", { title: "a post" });
@@ -75,7 +87,13 @@ test("when there is no matching function for the path", async () => {
     actionTypes: {
       createPost: PROTO_ACTION_TYPES.CREATE,
     },
-    createContextAPI: () => {},
+    createContextAPI: () => {
+      return {
+        response: {
+          headers: new Headers(),
+        },
+      };
+    },
   };
 
   const rpcReq = createJSONRPCRequest("123", "unknown", { title: "a post" });
@@ -100,7 +118,13 @@ test("when there is an unexpected error in the custom function", async () => {
     actionTypes: {
       createPost: PROTO_ACTION_TYPES.CREATE,
     },
-    createContextAPI: () => {},
+    createContextAPI: () => {
+      return {
+        response: {
+          headers: new Headers(),
+        },
+      };
+    },
   };
 
   const rpcReq = createJSONRPCRequest("123", "createPost", { title: "a post" });
@@ -128,7 +152,13 @@ test("when a role based permission has already been granted by the main runtime"
       createPost: PROTO_ACTION_TYPES.CREATE,
     },
     createModelAPI: () => {},
-    createContextAPI: () => {},
+    createContextAPI: () => {
+      return {
+        response: {
+          headers: new Headers(),
+        },
+      };
+    },
   };
 
   let rpcReq = createJSONRPCRequest("123", "createPost", { title: "a post" });
@@ -159,7 +189,13 @@ test("when there is an unexpected object thrown in the custom function", async (
     actionTypes: {
       createPost: PROTO_ACTION_TYPES.CREATE,
     },
-    createContextAPI: () => {},
+    createContextAPI: () => {
+      return {
+        response: {
+          headers: new Headers(),
+        },
+      };
+    },
   };
 
   const rpcReq = createJSONRPCRequest("123", "createPost", { title: "a post" });
@@ -244,7 +280,13 @@ describe("ModelAPI error handling", () => {
           return deleted;
         },
       },
-      createContextAPI: () => ({}),
+      createContextAPI: () => {
+        return {
+          response: {
+            headers: new Headers(),
+          },
+        };
+      },
     };
   });
 

--- a/packages/functions-runtime/src/index.d.ts
+++ b/packages/functions-runtime/src/index.d.ts
@@ -59,6 +59,7 @@ export type ContextAPI = {
 
 export type Response = {
   headers: Headers;
+  status?: number;
 };
 
 export type PageInfo = {
@@ -69,11 +70,8 @@ export type PageInfo = {
   count: number;
 };
 
-// Request headers query API
-export type RequestHeaders = {
-  get(name: string): string;
-  has(name: string): boolean;
-};
+// Request headers cannot be mutated, so remove any methods that mutate
+export type RequestHeaders = Omit<Headers, "append" | "delete" | "set">;
 
 export declare class Permissions {
   constructor();

--- a/runtime/apis/graphql/graphql.go
+++ b/runtime/apis/graphql/graphql.go
@@ -148,7 +148,9 @@ func NewHandler(s *proto.Schema, api *proto.Api) common.HandlerFunc {
 			span.SetStatus(codes.Error, strings.Join(messages, ", "))
 		}
 
-		return common.NewJsonResponse(http.StatusOK, result, headers)
+		return common.NewJsonResponse(http.StatusOK, result, &common.ResponseMetadata{
+			Headers: headers,
+		})
 	}
 }
 

--- a/runtime/apis/graphql/resolvers.go
+++ b/runtime/apis/graphql/resolvers.go
@@ -16,7 +16,7 @@ func ActionFunc(schema *proto.Schema, action *proto.Action) func(p graphql.Resol
 		scope := actions.NewScope(p.Context, action, schema)
 		input := p.Args["input"]
 
-		res, headers, err := actions.Execute(scope, input)
+		res, meta, err := actions.Execute(scope, input)
 		if err != nil {
 			var runtimeErr common.RuntimeError
 			if !errors.As(err, &runtimeErr) {
@@ -31,8 +31,11 @@ func ActionFunc(schema *proto.Schema, action *proto.Action) func(p graphql.Resol
 
 		rootValue := p.Info.RootValue.(map[string]interface{})
 		headersValue := rootValue["headers"].(map[string][]string)
-		for k, v := range headers {
-			headersValue[k] = v
+
+		if meta != nil {
+			for k, v := range meta.Headers {
+				headersValue[k] = v
+			}
 		}
 
 		if action.Type == proto.ActionType_ACTION_TYPE_LIST {

--- a/runtime/apis/httpjson/httpjson.go
+++ b/runtime/apis/httpjson/httpjson.go
@@ -100,12 +100,12 @@ func NewHandler(p *proto.Schema, api *proto.Api) common.HandlerFunc {
 
 		scope := actions.NewScope(ctx, action, p)
 
-		response, headers, err := actions.Execute(scope, inputs)
+		response, meta, err := actions.Execute(scope, inputs)
 		if err != nil {
 			return NewErrorResponse(ctx, err, nil)
 		}
 
-		return common.NewJsonResponse(http.StatusOK, response, headers)
+		return common.NewJsonResponse(http.StatusOK, response, meta)
 	}
 }
 

--- a/runtime/apis/jsonrpc/jsonrpc.go
+++ b/runtime/apis/jsonrpc/jsonrpc.go
@@ -76,12 +76,12 @@ func NewHandler(p *proto.Schema, api *proto.Api) common.HandlerFunc {
 
 		scope := actions.NewScope(ctx, action, p)
 
-		response, headers, err := actions.Execute(scope, inputs)
+		response, meta, err := actions.Execute(scope, inputs)
 		if err != nil {
 			return NewErrorResponse(ctx, &req.ID, err)
 		}
 
-		return NewSuccessResponse(ctx, req.ID, response, headers)
+		return NewSuccessResponse(ctx, req.ID, response, meta)
 	}
 }
 
@@ -114,12 +114,12 @@ type JsonRpcError struct {
 	Detail  any    `json:"detail,omitempty"`
 }
 
-func NewSuccessResponse(ctx context.Context, requestId string, response any, headers map[string][]string) common.Response {
+func NewSuccessResponse(ctx context.Context, requestId string, response any, meta *common.ResponseMetadata) common.Response {
 	return common.NewJsonResponse(http.StatusOK, JsonRpcSuccessResponse{
 		JsonRpc: "2.0",
 		ID:      requestId,
 		Result:  response,
-	}, headers)
+	}, meta)
 }
 
 func NewErrorResponse(ctx context.Context, requestId *string, err error) common.Response {

--- a/runtime/common/common.go
+++ b/runtime/common/common.go
@@ -17,13 +17,28 @@ type Response struct {
 	Headers map[string][]string
 }
 
-func NewJsonResponse(status int, body any, headers map[string][]string) Response {
+type ResponseMetadata struct {
+	Headers http.Header
+	Status  int
+}
+
+func NewJsonResponse(status int, body any, meta *ResponseMetadata) Response {
 	b, _ := json.Marshal(body)
-	return Response{
-		Status:  status,
-		Body:    b,
-		Headers: headers,
+
+	r := Response{
+		Status: status,
+		Body:   b,
 	}
+
+	if meta != nil {
+		r.Headers = meta.Headers
+
+		if meta.Status != 0 {
+			r.Status = meta.Status
+		}
+	}
+
+	return r
 }
 
 type HandlerFunc func(r *http.Request) Response


### PR DESCRIPTION
This makes it possible to set the HTTP response status from a function. This only has an effect on the HTTP JSON API, for GraphQL and JSON RPC the response status will always be `200`.

#### Simple example
```ts
import { MyFunction, permissions } from "@teamkeel/sdk";

export default MyFunction(async (ctx) => {
  permissions.allow();

  const { response } = ctx;
  response.headers.set("Location", "https://some.url");
  response.status = 301;

  return null;
});
```

#### Request Headers
In this change I've also dropped the `RequestHeaders` class as I don't think it's necessary. Instead I've updated the types to be a `Headers` object with the mutating methods dropped.