### PR TITLE
feat: sso login authentication flow

### DIFF
--- a/cmd/program/commands.go
+++ b/cmd/program/commands.go
@@ -400,6 +400,8 @@ type RuntimeRequestMsg struct {
 
 func StartRuntimeServer(port string, ch chan tea.Msg) tea.Cmd {
 	return func() tea.Msg {
+		os.Setenv("KEEL_API_URL", fmt.Sprintf("http://localhost:%s", port))
+
 		runtimeServer := http.Server{
 			Addr: fmt.Sprintf(":%s", port),
 			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/config/auth.go
+++ b/config/auth.go
@@ -38,8 +38,9 @@ var (
 )
 
 type AuthConfig struct {
-	Tokens    TokensConfig `yaml:"tokens"`
-	Providers []Provider   `yaml:"providers"`
+	Tokens      TokensConfig `yaml:"tokens"`
+	RedirectUrl *string      `yaml:"redirectUrl,omitempty"`
+	Providers   []Provider   `yaml:"providers"`
 }
 
 type TokensConfig struct {

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -129,6 +130,7 @@ const (
 	ConfigAuthProviderInvalidTypeErrorString         = "auth provider '%s' has invalid type '%s' which must be one of: %s"
 	ConfigAuthProviderDuplicateErrorString           = "auth provider name '%s' has been defined more than once, but must be unique"
 	ConfigAuthProviderInvalidHttpUrlErrorString      = "auth provider '%s' has missing or invalid https url for field: %s"
+	ConfigAuthInvalidRedirectUrlErrorString          = "auth redirectUrl '%s' is not a valid url"
 )
 
 type ConfigErrors struct {
@@ -333,6 +335,16 @@ func Validate(config *ProjectConfig) *ConfigErrors {
 			Type:    "invalid",
 			Message: fmt.Sprintf(ConfigAuthProviderInvalidHttpUrlErrorString, p.Name, "authorizationUrl"),
 		})
+	}
+
+	if config.Auth.RedirectUrl != nil {
+		_, err := url.ParseRequestURI(*config.Auth.RedirectUrl)
+		if err != nil {
+			errors = append(errors, &ConfigError{
+				Type:    "invalid",
+				Message: fmt.Sprintf(ConfigAuthInvalidRedirectUrlErrorString, *config.Auth.RedirectUrl),
+			})
+		}
 	}
 
 	if len(errors) == 0 {

--- a/config/config.go
+++ b/config/config.go
@@ -123,6 +123,7 @@ const (
 	ConfigIncorrectNamingErrorString                 = "%s must be written in upper snakecase"
 	ConfigReservedNameErrorString                    = "environment variable %s cannot start with %s as it is reserved"
 	ConfigAuthTokenExpiryMustBePositive              = "%s token lifespan cannot be negative or zero for field: %s"
+	ConfigAuthProviderInvalidName                    = "auth provider '%s' can only include alphanumeric characters, dashes and underscores"
 	ConfigAuthProviderMissingFieldAtIndexErrorString = "auth provider at index %v is missing field: %s"
 	ConfigAuthProviderMissingFieldErrorString        = "auth provider '%s' is missing field: %s"
 	ConfigAuthProviderInvalidTypeErrorString         = "auth provider '%s' has invalid type '%s' which must be one of: %s"
@@ -249,6 +250,14 @@ func Validate(config *ProjectConfig) *ConfigErrors {
 		errors = append(errors, &ConfigError{
 			Type:    "invalid",
 			Message: fmt.Sprintf(ConfigAuthTokenExpiryMustBePositive, "refresh", "refreshTokenExpiry"),
+		})
+	}
+
+	invalidProviderNames := findAuthProviderInvalidName(config.Auth.Providers)
+	for _, p := range invalidProviderNames {
+		errors = append(errors, &ConfigError{
+			Type:    "invalid",
+			Message: fmt.Sprintf(ConfigAuthProviderInvalidName, p.Name),
 		})
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -173,6 +173,15 @@ func TestAuthProviders(t *testing.T) {
 	assert.Equal(t, "https://github.com/token", config.Auth.Providers[3].TokenUrl)
 }
 
+func TestInvalidProviderName(t *testing.T) {
+	_, err := Load("fixtures/test_auth_invalid_names.yaml")
+
+	assert.Contains(t, err.Error(), "auth provider '12 34' can only include alphanumeric characters, dashes and underscores\n")
+	assert.Contains(t, err.Error(), "auth provider 'Google Client' can only include alphanumeric characters, dashes and underscores\n")
+	assert.Contains(t, err.Error(), "auth provider 'google/' can only include alphanumeric characters, dashes and underscores\n")
+	assert.Contains(t, err.Error(), "auth provider 'google\\client' can only include alphanumeric characters, dashes and underscores\n")
+}
+
 func TestMissingProviderName(t *testing.T) {
 	_, err := Load("fixtures/test_auth_missing_names.yaml")
 
@@ -260,4 +269,10 @@ func TestAddOidcProvider(t *testing.T) {
 	byIssuer, err := config.Auth.GetOidcProvidersByIssuer("https://mycustomoidc.com")
 	assert.NoError(t, err)
 	assert.Len(t, byIssuer, 1)
+}
+
+func TestAddOidcProviderInvalidName(t *testing.T) {
+	auth := &AuthConfig{}
+	err := auth.AddOidcProvider("my client", "https://mycustomoidc.com", "1234")
+	assert.ErrorContains(t, err, "auth provider 'my client' can only include alphanumeric characters, dashes and underscores")
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -129,6 +129,12 @@ func TestAuthTokens(t *testing.T) {
 	assert.Equal(t, false, config.Auth.RefreshTokenRotationEnabled())
 }
 
+func TestAuthInvalidRedirectUrl(t *testing.T) {
+	_, err := Load("fixtures/test_auth_invalid_redirect_url.yaml")
+
+	assert.Contains(t, err.Error(), "auth redirectUrl 'not a url' is not a valid url\n")
+}
+
 func TestAuthDefaults(t *testing.T) {
 	config, err := Load("fixtures/test_auth_empty.yaml")
 	assert.NoError(t, err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -261,7 +261,7 @@ func TestAddOidcProvider(t *testing.T) {
 
 	assert.Len(t, config.Auth.GetOidcProviders(), 1)
 
-	err = config.Auth.AddOidcProvider("Custom Auth", "https://mycustomoidc.com", "1234")
+	err = config.Auth.AddOidcProvider("CustomAuth", "https://mycustomoidc.com", "1234")
 	assert.NoError(t, err)
 
 	assert.Len(t, config.Auth.GetOidcProviders(), 2)

--- a/config/fixtures/test_auth.yaml
+++ b/config/fixtures/test_auth.yaml
@@ -4,6 +4,8 @@ auth:
     refreshTokenExpiry: 604800
     refreshTokenRotationEnabled: false
 
+  redirectUrl: http://localhost:8000/signedin
+
   providers:
     # Built-in Google provider
     - type: google

--- a/config/fixtures/test_auth_invalid_names.yaml
+++ b/config/fixtures/test_auth_invalid_names.yaml
@@ -1,0 +1,20 @@
+auth:
+  providers:
+    - type: google
+      name: 12 34
+      clientId: foo_1
+
+    - type: google
+      name: Google Client
+      clientId: foo_2
+
+    - type: oidc
+      name: google/
+      issuerUrl: 'https://dev-skhlutl45lbqkvhv.us.auth0.com'
+      clientId: 'kasj28fnq09ak'
+
+    - type: oauth
+      name: google\client
+      clientId: hfjuw983h1hfsdf
+      authorizationUrl: https://github.com/auth
+      tokenUrl: https://github.com/token

--- a/config/fixtures/test_auth_invalid_redirect_url.yaml
+++ b/config/fixtures/test_auth_invalid_redirect_url.yaml
@@ -1,0 +1,2 @@
+auth:
+  redirectUrl: not a url

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/charmbracelet/bubbletea v0.24.2
 	github.com/charmbracelet/lipgloss v0.7.1
 	github.com/coreos/go-oidc v2.2.1+incompatible
+	github.com/dchest/uniuri v1.2.0
 	github.com/docker/docker v24.0.5+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/fatih/camelcase v1.0.0
@@ -48,6 +49,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.15.1
 	go.opentelemetry.io/otel/trace v1.16.0
 	golang.org/x/exp v0.0.0-20220907003533-145caa8ea1d0
+	golang.org/x/oauth2 v0.13.0
 	google.golang.org/protobuf v1.31.0
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/postgres v1.5.0
@@ -59,7 +61,6 @@ require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
-	github.com/dchest/uniuri v1.2.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
@@ -99,7 +100,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.15.1 // indirect
 	go.opentelemetry.io/otel/metric v1.16.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
-	golang.org/x/oauth2 v0.13.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/term v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect

--- a/integration/testdata/jobs_permissions/tests.test.ts
+++ b/integration/testdata/jobs_permissions/tests.test.ts
@@ -110,8 +110,6 @@ test("job - authorised domain - permitted", async () => {
     emailVerified: true,
   });
 
-  console.log("created:", identity);
-
   await expect(
     jobs.withIdentity(identity).manualJob({ id })
   ).not.toHaveAuthorizationError();

--- a/migrations/columns.sql
+++ b/migrations/columns.sql
@@ -16,7 +16,7 @@ LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
 LEFT JOIN pg_catalog.pg_index i on i.indexrelid = a.attrelid
 WHERE
 	n.nspname = 'public'
-	AND c.relname not in ('keel_schema', 'keel_refresh_token', 'pg_stat_statements_info', 'pg_stat_statements')
+	AND c.relname not in ('keel_schema', 'keel_refresh_token', 'keel_auth_code', 'pg_stat_statements_info', 'pg_stat_statements')
 	AND a.attnum > 0
 	AND NOT a.attisdropped
 	AND i.indexrelid is null; -- no indexes

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -116,6 +116,9 @@ func (m *Migrations) Apply(ctx context.Context) error {
 	sql.WriteString("CREATE TABLE IF NOT EXISTS keel_refresh_token (token TEXT NOT NULL PRIMARY KEY, identity_id TEXT NOT NULL, created_at TIMESTAMP, expires_at TIMESTAMP);\n")
 	sql.WriteString("\n")
 
+	sql.WriteString("CREATE TABLE IF NOT EXISTS keel_auth_code (code TEXT NOT NULL PRIMARY KEY, identity_id TEXT NOT NULL, created_at TIMESTAMP, expires_at TIMESTAMP);\n")
+	sql.WriteString("\n")
+
 	sql.WriteString(fmt.Sprintf("SELECT set_trace_id('%s');\n", span.SpanContext().TraceID().String()))
 
 	sql.WriteString(m.SQL)

--- a/runtime/apis/authapi/oauth_endpoint.go
+++ b/runtime/apis/authapi/oauth_endpoint.go
@@ -17,39 +17,55 @@ import (
 	"github.com/teamkeel/keel/runtime/common"
 	"github.com/teamkeel/keel/runtime/oauth"
 	"github.com/teamkeel/keel/runtime/runtimectx"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/oauth2"
 )
 
-func OAuthHandler(schema *proto.Schema) common.HandlerFunc {
-	return func(r *http.Request) common.Response {
-		return common.Response{
-			Status: http.StatusNotImplemented,
-		}
-	}
-}
+// Error response types for the authorization endpoint
+// https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1
+const (
+	// The request is missing a required parameter, includes an
+	// invalid parameter value, includes a parameter more than
+	// once, or is otherwise malformed.
+	AuthorizationErrInvalidRequest = "invalid_request"
+	// The client is not authorized to request an authorization
+	// code using this method.
+	AuthorizationErrUnauthorizedClient = "unauthorized_client"
+	// The resource owner or authorization server denied the
+	// request.
+	AuthorizationErrAccessDenied = "access_denied"
+	// The authorization server encountered an unexpected
+	// condition that prevented it from fulfilling the request.
+	// (This error code is needed because a 500 Internal Server
+	// Error HTTP status code cannot be returned to the client
+	// via an HTTP redirect.)
+	AuthorizationErrServerError = "server_error"
+)
 
-// LoginHandler will redirect to the specified provider in order to authenticate with the user
-func LoginHandler(schema *proto.Schema) func(http.ResponseWriter, *http.Request) common.Response {
-	return func(w http.ResponseWriter, r *http.Request) common.Response {
+// LoginHandler will redirect to the specified provider in order to authenticate the user
+func LoginHandler(schema *proto.Schema) common.HandlerFunc {
+	return func(r *http.Request) common.Response {
 		ctx, span := tracer.Start(r.Context(), "Login Endpoint")
 		defer span.End()
 
 		provider, err := providerFromPath(ctx, r.URL)
 		if err != nil {
-			span.RecordError(err, trace.WithStackTrace(true))
-			span.SetStatus(codes.Error, err.Error())
-			return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "login url malformed or provider not found")
+			return jsonErrResponse(ctx, http.StatusBadRequest, AuthorizationErrInvalidRequest, "login url malformed or provider not found", err)
 		}
 
-		secret, hasSecret := provider.GetClientSecret()
+		config, err := runtimectx.GetOAuthConfig(ctx)
+		if err != nil {
+			return common.InternalServerErrorResponse(ctx, err)
+		}
+
+		if config.RedirectUrl == nil {
+			return jsonErrResponse(ctx, http.StatusBadRequest, AuthorizationErrInvalidRequest, "redirectUrl must be specified in keelconfig.yaml", err)
+		}
+
+		// If the secret is not yet, then package this up and send it as an error with the redirectUrl
+		_, hasSecret := provider.GetClientSecret()
 		if !hasSecret {
-			err = fmt.Errorf("client secret not configured for provider: %s", provider.Name)
-			span.RecordError(err, trace.WithStackTrace(true))
-			span.SetStatus(codes.Error, err.Error())
-			return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, err.Error())
+			err := fmt.Errorf("client secret not configured for provider: %s", provider.Name)
+			return jsonErrResponse(ctx, http.StatusBadRequest, AuthorizationErrInvalidRequest, err.Error(), err)
 		}
 
 		issuer, hasIssuer := provider.GetIssuer()
@@ -63,46 +79,69 @@ func LoginHandler(schema *proto.Schema) func(http.ResponseWriter, *http.Request)
 			return common.InternalServerErrorResponse(ctx, err)
 		}
 
-		oauthConfig := &oauth2.Config{
-			ClientID:     provider.ClientId,
-			ClientSecret: secret,
-			Endpoint:     oidcProv.Endpoint(),
-			Scopes:       []string{"openid", "email", "profile"},
-			RedirectURL:  "http://" + r.Host + "/auth/callback/" + strings.ToLower(provider.Name),
+		callbackUrl, err := provider.GetCallbackUrl()
+		if err != nil {
+			return common.InternalServerErrorResponse(ctx, err)
 		}
 
-		url := oauthConfig.AuthCodeURL(uniuri.New())
-		http.Redirect(w, r, url, http.StatusTemporaryRedirect)
+		// RedirectURL is needed for provider to redirect back to Keel
+		// Secret is _not_ required when getting auth code
+		oauthConfig := &oauth2.Config{
+			ClientID:    provider.ClientId,
+			Endpoint:    oidcProv.Endpoint(),
+			Scopes:      []string{"openid", "email", "profile"},
+			RedirectURL: callbackUrl.String(),
+		}
 
-		return common.NewJsonResponse(http.StatusTemporaryRedirect, "login handler redirect", nil)
+		u := oauthConfig.AuthCodeURL(uniuri.New())
+
+		redirectUrl, err := url.Parse(u)
+		if err != nil {
+			return common.InternalServerErrorResponse(ctx, err)
+		}
+
+		return common.NewRedirectResponse(redirectUrl)
 	}
 }
 
 // CallbackHandler is called by the provider after the authentication process is complete
-func CallbackHandler(schema *proto.Schema) func(http.ResponseWriter, *http.Request) common.Response {
-	return func(w http.ResponseWriter, r *http.Request) common.Response {
+//
+// If there is something wrong with the syntax of the request, such as the redirect_uri or client_id is invalid,
+// then it’s important not to redirect the user and instead you should show the error message directly.
+// This is to avoid letting your authorization server be used as an open redirector.
+func CallbackHandler(schema *proto.Schema) common.HandlerFunc {
+	return func(r *http.Request) common.Response {
 		ctx, span := tracer.Start(r.Context(), "Callback Endpoint")
 		defer span.End()
 
-		if callbackError := r.FormValue("error"); callbackError != "" {
-			err := fmt.Errorf("provider could not authenticate due to %s: %s", callbackError, r.FormValue("error_description"))
-			span.RecordError(err, trace.WithStackTrace(true))
-			span.SetStatus(codes.Error, err.Error())
-			return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, err.Error())
-		}
-
 		provider, err := providerFromPath(ctx, r.URL)
 		if err != nil {
-			err = fmt.Errorf("no issuer available for sso login with provider: %s", provider.Name)
-			span.RecordError(err, trace.WithStackTrace(true))
-			span.SetStatus(codes.Error, err.Error())
-			return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "callback url malformed or provider not found")
+			return common.InternalServerErrorResponse(ctx, err)
 		}
 
 		issuer, hasIssuer := provider.GetIssuer()
 		if !hasIssuer {
-			err = fmt.Errorf("no issuer available for sso login with provider: %s", provider.Name)
 			return common.InternalServerErrorResponse(ctx, err)
+		}
+
+		config, err := runtimectx.GetOAuthConfig(ctx)
+		if err != nil {
+			return common.InternalServerErrorResponse(ctx, err)
+		}
+
+		if config.RedirectUrl == nil {
+			return common.InternalServerErrorResponse(ctx, fmt.Errorf("redirectUrl not set"))
+		}
+
+		redirectUrl, err := url.Parse(*config.RedirectUrl)
+		if err != nil {
+			return common.InternalServerErrorResponse(ctx, err)
+		}
+
+		// If the auth provider errored, then package this up and send it as an error with the redirectUrl
+		if callbackError := r.FormValue("error"); callbackError != "" {
+			err := fmt.Errorf("provider error: %s. %s", callbackError, r.FormValue("error_description"))
+			return redirectErrResponse(ctx, redirectUrl, AuthorizationErrAccessDenied, err.Error(), err)
 		}
 
 		oidcProv, err := oidc.NewProvider(ctx, issuer)
@@ -112,15 +151,14 @@ func CallbackHandler(schema *proto.Schema) func(http.ResponseWriter, *http.Reque
 
 		secret, hasSecret := provider.GetClientSecret()
 		if !hasSecret {
-			err := fmt.Errorf("client secret not configured for provider: %s", provider.Name)
 			return common.InternalServerErrorResponse(ctx, err)
 		}
 
+		// Secret is required for token exchange
 		oauthConfig := &oauth2.Config{
 			ClientID:     provider.ClientId,
 			ClientSecret: secret,
 			Endpoint:     oidcProv.Endpoint(),
-			RedirectURL:  "http://" + r.Host + "/auth/callback/" + strings.ToLower(provider.Name),
 		}
 
 		code := r.FormValue("code")
@@ -128,20 +166,22 @@ func CallbackHandler(schema *proto.Schema) func(http.ResponseWriter, *http.Reque
 			return common.InternalServerErrorResponse(ctx, errors.New("code not returned with callback url"))
 		}
 
+		// If the token exchange fails, then package this up and send it as an error with the redirectUrl
 		token, err := oauthConfig.Exchange(ctx, code)
 		if err != nil {
-			// todo parse oauth error message from providers token endpoint
-			return common.InternalServerErrorResponse(ctx, err)
+			return redirectErrResponse(ctx, redirectUrl, AuthorizationErrAccessDenied, "failed to exchange code at provider token endpoint", err)
 		}
 
 		if !token.Valid() {
-			return authErrResponse(ctx, http.StatusUnauthorized, InvalidClient, "access token is not valid or has expired")
+			err := errors.New("access token is not valid or has expired")
+			return redirectErrResponse(ctx, redirectUrl, AuthorizationErrAccessDenied, err.Error(), err)
 		}
 
 		// Extract the ID Token from the OAuth2 request.
 		rawIDToken, ok := token.Extra("id_token").(string)
 		if !ok {
-			return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "provider did not respond with an id token")
+			err := errors.New("provider did not respond with an id token")
+			return redirectErrResponse(ctx, redirectUrl, AuthorizationErrServerError, err.Error(), err)
 		}
 
 		var verifier = oidcProv.Verifier(&oidc.Config{
@@ -151,13 +191,13 @@ func CallbackHandler(schema *proto.Schema) func(http.ResponseWriter, *http.Reque
 		// Verify the ID token with the OIDC provider
 		idToken, err := verifier.Verify(ctx, rawIDToken)
 		if err != nil {
-			return common.InternalServerErrorResponse(ctx, err)
+			return redirectErrResponse(ctx, redirectUrl, AuthorizationErrAccessDenied, "falied to verify ID token with OIDC provider", err)
 		}
 
 		// Extract claims
 		var claims oauth.IdTokenClaims
 		if err := idToken.Claims(&claims); err != nil {
-			return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "insufficient claims on id_token")
+			return redirectErrResponse(ctx, redirectUrl, AuthorizationErrServerError, "insufficient claims on id_token", err)
 		}
 
 		var identity *auth.Identity
@@ -178,22 +218,7 @@ func CallbackHandler(schema *proto.Schema) func(http.ResponseWriter, *http.Reque
 			}
 		}
 
-		config, err := runtimectx.GetOAuthConfig(ctx)
-		if err != nil {
-			return common.InternalServerErrorResponse(ctx, err)
-		}
-
-		if config.RedirectUrl == nil {
-			err := fmt.Errorf("redirectUrl not set")
-			return common.InternalServerErrorResponse(ctx, err)
-		}
-
 		authCode, err := oauth.NewAuthCode(ctx, identity.Id)
-		if err != nil {
-			return common.InternalServerErrorResponse(ctx, err)
-		}
-
-		redirectUrl, err := url.Parse(*config.RedirectUrl)
 		if err != nil {
 			return common.InternalServerErrorResponse(ctx, err)
 		}
@@ -202,9 +227,7 @@ func CallbackHandler(schema *proto.Schema) func(http.ResponseWriter, *http.Reque
 		values.Add("code", authCode)
 		redirectUrl.RawQuery = values.Encode()
 
-		http.Redirect(w, r, redirectUrl.String(), http.StatusFound)
-
-		return common.NewJsonResponse(http.StatusFound, "callback handler redirect", nil)
+		return common.NewRedirectResponse(redirectUrl)
 	}
 
 }
@@ -227,19 +250,4 @@ func providerFromPath(ctx context.Context, url *url.URL) (*config.Provider, erro
 	}
 
 	return provider, nil
-}
-
-func authErrResponse(ctx context.Context, status int, errorType string, errorDescription string) common.Response {
-	span := trace.SpanFromContext(ctx)
-	span.SetStatus(codes.Error, errorType)
-
-	span.SetAttributes(
-		attribute.String("auth.error", errorType),
-		attribute.String("auth.error_description", errorDescription),
-	)
-
-	return common.NewJsonResponse(status, &ErrorResponse{
-		Error:            errorType,
-		ErrorDescription: errorDescription,
-	}, nil)
 }

--- a/runtime/apis/authapi/oauth_endpoint.go
+++ b/runtime/apis/authapi/oauth_endpoint.go
@@ -74,13 +74,13 @@ func LoginHandler(schema *proto.Schema) func(http.ResponseWriter, *http.Request)
 		url := oauthConfig.AuthCodeURL(uniuri.New())
 		http.Redirect(w, r, url, http.StatusTemporaryRedirect)
 
-		return common.NewJsonResponse(http.StatusInternalServerError, "oauth redirect failed", nil)
+		return common.NewJsonResponse(http.StatusTemporaryRedirect, "login handler redirect", nil)
 	}
 }
 
 // CallbackHandler is called by the provider after the authentication process is complete
-func CallbackHandler(schema *proto.Schema) common.HandlerFunc {
-	return func(r *http.Request) common.Response {
+func CallbackHandler(schema *proto.Schema) func(http.ResponseWriter, *http.Request) common.Response {
+	return func(w http.ResponseWriter, r *http.Request) common.Response {
 		ctx, span := tracer.Start(r.Context(), "Callback Endpoint")
 		defer span.End()
 
@@ -178,27 +178,35 @@ func CallbackHandler(schema *proto.Schema) common.HandlerFunc {
 			}
 		}
 
-		// Generate a new access token for this identity.
-		accessTokenRaw, expiresIn, err := oauth.GenerateAccessToken(ctx, identity.Id)
+		config, err := runtimectx.GetOAuthConfig(ctx)
 		if err != nil {
 			return common.InternalServerErrorResponse(ctx, err)
 		}
 
-		// Generate a refresh token.
-		refreshToken, err := oauth.NewRefreshToken(ctx, identity.Id)
+		if config.RedirectUrl == nil {
+			err := fmt.Errorf("redirectUrl not set")
+			return common.InternalServerErrorResponse(ctx, err)
+		}
+
+		authCode, err := oauth.NewAuthCode(ctx, identity.Id)
 		if err != nil {
 			return common.InternalServerErrorResponse(ctx, err)
 		}
 
-		response := &TokenResponse{
-			AccessToken:  accessTokenRaw,
-			TokenType:    TokenType,
-			ExpiresIn:    int(expiresIn.Seconds()),
-			RefreshToken: refreshToken,
+		redirectUrl, err := url.Parse(*config.RedirectUrl)
+		if err != nil {
+			return common.InternalServerErrorResponse(ctx, err)
 		}
 
-		return common.NewJsonResponse(http.StatusOK, response, nil)
+		values := url.Values{}
+		values.Add("code", authCode)
+		redirectUrl.RawQuery = values.Encode()
+
+		http.Redirect(w, r, redirectUrl.String(), http.StatusFound)
+
+		return common.NewJsonResponse(http.StatusFound, "callback handler redirect", nil)
 	}
+
 }
 
 func providerFromPath(ctx context.Context, url *url.URL) (*config.Provider, error) {

--- a/runtime/apis/authapi/oauth_endpoint.go
+++ b/runtime/apis/authapi/oauth_endpoint.go
@@ -1,10 +1,26 @@
 package authapi
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 
+	"github.com/coreos/go-oidc"
+	"github.com/dchest/uniuri"
+	"github.com/teamkeel/keel/config"
 	"github.com/teamkeel/keel/proto"
+	"github.com/teamkeel/keel/runtime/actions"
+	"github.com/teamkeel/keel/runtime/auth"
 	"github.com/teamkeel/keel/runtime/common"
+	"github.com/teamkeel/keel/runtime/oauth"
+	"github.com/teamkeel/keel/runtime/runtimectx"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/oauth2"
 )
 
 func OAuthHandler(schema *proto.Schema) common.HandlerFunc {
@@ -13,4 +29,207 @@ func OAuthHandler(schema *proto.Schema) common.HandlerFunc {
 			Status: http.StatusNotImplemented,
 		}
 	}
+}
+
+// LoginHandler will redirect to the specified provider in order to authenticate with the user
+func LoginHandler(schema *proto.Schema) func(http.ResponseWriter, *http.Request) common.Response {
+	return func(w http.ResponseWriter, r *http.Request) common.Response {
+		ctx, span := tracer.Start(r.Context(), "Login Endpoint")
+		defer span.End()
+
+		provider, err := providerFromPath(ctx, r.URL)
+		if err != nil {
+			span.RecordError(err, trace.WithStackTrace(true))
+			span.SetStatus(codes.Error, err.Error())
+			return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "login url malformed or provider not found")
+		}
+
+		secret, hasSecret := provider.GetClientSecret()
+		if !hasSecret {
+			err = fmt.Errorf("client secret not configured for provider: %s", provider.Name)
+			span.RecordError(err, trace.WithStackTrace(true))
+			span.SetStatus(codes.Error, err.Error())
+			return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, err.Error())
+		}
+
+		issuer, hasIssuer := provider.GetIssuer()
+		if !hasIssuer {
+			err = fmt.Errorf("no issuer available for sso login with provider: %s", provider.Name)
+			return common.InternalServerErrorResponse(ctx, err)
+		}
+
+		oidcProv, err := oidc.NewProvider(ctx, issuer)
+		if err != nil {
+			return common.InternalServerErrorResponse(ctx, err)
+		}
+
+		oauthConfig := &oauth2.Config{
+			ClientID:     provider.ClientId,
+			ClientSecret: secret,
+			Endpoint:     oidcProv.Endpoint(),
+			Scopes:       []string{"openid", "email", "profile"},
+			RedirectURL:  "http://" + r.Host + "/auth/callback/" + strings.ToLower(provider.Name),
+		}
+
+		url := oauthConfig.AuthCodeURL(uniuri.New())
+		http.Redirect(w, r, url, http.StatusTemporaryRedirect)
+
+		return common.NewJsonResponse(http.StatusInternalServerError, "oauth redirect failed", nil)
+	}
+}
+
+func authErrResponse(ctx context.Context, status int, errorType string, errorDescription string) common.Response {
+	span := trace.SpanFromContext(ctx)
+	span.SetStatus(codes.Error, errorType)
+
+	span.SetAttributes(
+		attribute.String("auth.error", errorType),
+		attribute.String("auth.error_description", errorDescription),
+	)
+
+	return common.NewJsonResponse(status, &ErrorResponse{
+		Error:            errorType,
+		ErrorDescription: errorDescription,
+	}, nil)
+}
+
+// CallbackHandler is called by the provider after the authentication process is complete
+func CallbackHandler(schema *proto.Schema) common.HandlerFunc {
+	return func(r *http.Request) common.Response {
+		ctx, span := tracer.Start(r.Context(), "Callback Endpoint")
+		defer span.End()
+
+		if callbackError := r.FormValue("error"); callbackError != "" {
+			err := fmt.Errorf("provider could not authenticate due to %s: %s", callbackError, r.FormValue("error_description"))
+			span.RecordError(err, trace.WithStackTrace(true))
+			span.SetStatus(codes.Error, err.Error())
+			return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, err.Error())
+		}
+
+		provider, err := providerFromPath(ctx, r.URL)
+		if err != nil {
+			err = fmt.Errorf("no issuer available for sso login with provider: %s", provider.Name)
+			span.RecordError(err, trace.WithStackTrace(true))
+			span.SetStatus(codes.Error, err.Error())
+			return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "callback url malformed or provider not found")
+		}
+
+		issuer, hasIssuer := provider.GetIssuer()
+		if !hasIssuer {
+			err = fmt.Errorf("no issuer available for sso login with provider: %s", provider.Name)
+			return common.InternalServerErrorResponse(ctx, err)
+		}
+
+		oidcProv, err := oidc.NewProvider(ctx, issuer)
+		if err != nil {
+			return common.InternalServerErrorResponse(ctx, err)
+		}
+
+		secret, hasSecret := provider.GetClientSecret()
+		if !hasSecret {
+			err := fmt.Errorf("client secret not configured for provider: %s", provider.Name)
+			return common.InternalServerErrorResponse(ctx, err)
+		}
+
+		oauthConfig := &oauth2.Config{
+			ClientID:     provider.ClientId,
+			ClientSecret: secret,
+			Endpoint:     oidcProv.Endpoint(),
+		}
+
+		code := r.FormValue("code")
+		if !r.Form.Has("code") || code == "" {
+			return common.InternalServerErrorResponse(ctx, errors.New("code not returned with callback url"))
+		}
+
+		token, err := oauthConfig.Exchange(ctx, code)
+		if err != nil {
+			return common.InternalServerErrorResponse(ctx, err)
+		}
+
+		if !token.Valid() {
+			return authErrResponse(ctx, http.StatusUnauthorized, InvalidClient, "access token is not valid or has expired")
+		}
+
+		// Extract the ID Token from the OAuth2 request.
+		rawIDToken, ok := token.Extra("id_token").(string)
+		if !ok {
+			return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "provider did not respond with an id token")
+		}
+
+		var verifier = oidcProv.Verifier(&oidc.Config{
+			ClientID: provider.ClientId,
+		})
+
+		// Verify the ID token with the OIDC provider
+		idToken, err := verifier.Verify(ctx, rawIDToken)
+		if err != nil {
+			return common.InternalServerErrorResponse(ctx, err)
+		}
+
+		// Extract claims
+		var claims oauth.IdTokenClaims
+		if err := idToken.Claims(&claims); err != nil {
+			return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "insufficient claims on id_token")
+		}
+
+		var identity *auth.Identity
+		identity, err = actions.FindIdentityByExternalId(ctx, schema, idToken.Subject, idToken.Issuer)
+		if err != nil {
+			return common.InternalServerErrorResponse(ctx, err)
+		}
+
+		if identity == nil {
+			identity, err = actions.CreateIdentityWithIdTokenClaims(ctx, schema, idToken.Subject, idToken.Issuer, claims)
+			if err != nil {
+				return common.InternalServerErrorResponse(ctx, err)
+			}
+		} else {
+			identity, err = actions.UpdateIdentityWithIdTokenClaims(ctx, schema, idToken.Subject, idToken.Issuer, claims)
+			if err != nil {
+				return common.InternalServerErrorResponse(ctx, err)
+			}
+		}
+
+		// Generate a new access token for this identity.
+		accessTokenRaw, expiresIn, err := oauth.GenerateAccessToken(ctx, identity.Id)
+		if err != nil {
+			return common.InternalServerErrorResponse(ctx, err)
+		}
+
+		// Generate a refresh token.
+		refreshToken, err := oauth.NewRefreshToken(ctx, identity.Id)
+		if err != nil {
+			return common.InternalServerErrorResponse(ctx, err)
+		}
+
+		response := &TokenResponse{
+			AccessToken:  accessTokenRaw,
+			TokenType:    TokenType,
+			ExpiresIn:    int(expiresIn.Seconds()),
+			RefreshToken: refreshToken,
+		}
+
+		return common.NewJsonResponse(http.StatusOK, response, nil)
+	}
+}
+
+func providerFromPath(ctx context.Context, url *url.URL) (*config.Provider, error) {
+	config, err := runtimectx.GetOAuthConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	p := strings.Split(strings.Trim(url.Path, "/"), "/")
+
+	if len(p) != 3 {
+		return nil, fmt.Errorf("invalid login path: %s", url.Path)
+	}
+
+	provider := config.GetProvider(p[2])
+	if provider == nil {
+		return nil, fmt.Errorf("no provider with the name '%s' has been configured", p[2])
+	}
+
+	return provider, nil
 }

--- a/runtime/apis/authapi/oauth_endpoint_test.go
+++ b/runtime/apis/authapi/oauth_endpoint_test.go
@@ -80,6 +80,7 @@ func TestSsoLogin_Success(t *testing.T) {
 	require.NotEmpty(t, tokenResponse.RefreshToken)
 	require.Equal(t, "bearer", tokenResponse.TokenType)
 	require.NotEmpty(t, tokenResponse.ExpiresIn)
+	require.True(t, authapi.HasContentType(httpResponse.Header, "application/json"))
 
 	sub, iss, err := oauth.ValidateAccessToken(ctx, tokenResponse.AccessToken)
 	require.NoError(t, err)

--- a/runtime/apis/authapi/oauth_endpoint_test.go
+++ b/runtime/apis/authapi/oauth_endpoint_test.go
@@ -1,0 +1,376 @@
+package authapi_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/teamkeel/keel/config"
+	"github.com/teamkeel/keel/runtime"
+	"github.com/teamkeel/keel/runtime/apis/authapi"
+	"github.com/teamkeel/keel/runtime/oauth"
+	"github.com/teamkeel/keel/runtime/oauth/oauthtest"
+	"github.com/teamkeel/keel/runtime/runtimectx"
+	keeltesting "github.com/teamkeel/keel/testing"
+)
+
+func TestSsoLogin_Success(t *testing.T) {
+	ctx, database, schema := keeltesting.MakeContext(t, authTestSchema, true)
+	defer database.Close()
+
+	// OIDC test server
+	server, err := oauthtest.NewServer()
+	require.NoError(t, err)
+
+	// Set up auth config
+	ctx = runtimectx.WithOAuthConfig(ctx, &config.AuthConfig{
+		Providers: []config.Provider{
+			{
+				Type:      config.OpenIdConnectProvider,
+				Name:      "my-oidc",
+				ClientId:  "oidc-client-id",
+				IssuerUrl: server.Issuer,
+			},
+		},
+	})
+
+	// Set secret for client
+	t.Setenv(fmt.Sprintf("KEEL_AUTH_PROVIDER_SECRET_%s", strings.ToUpper("my-oidc")), "secret")
+
+	httpHandler := func(w http.ResponseWriter, r *http.Request) {
+		h := runtime.NewHttpHandler(schema)
+		r = r.WithContext(ctx)
+		h.ServeHTTP(w, r)
+	}
+	runtime := httptest.NewServer(http.HandlerFunc(httpHandler))
+	require.NoError(t, err)
+
+	server.WithOAuthClient(&oauthtest.OAuthClient{
+		ClientId:     "oidc-client-id",
+		ClientSecret: "secret",
+		RedirectUrl:  runtime.URL + "/auth/callback/my-oidc",
+	})
+
+	server.SetUser("id|285620", &oauth.UserClaims{
+		Email:         "keelson@keel.so",
+		EmailVerified: true,
+	})
+
+	// Make an SSO login request
+	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/login/my-oidc", nil)
+	require.NoError(t, err)
+
+	httpResponse, err := runtime.Client().Do(request)
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(httpResponse.Body)
+	require.NoError(t, err)
+
+	var tokenResponse authapi.TokenResponse
+	err = json.Unmarshal(data, &tokenResponse)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusOK, httpResponse.StatusCode)
+	require.NotEmpty(t, tokenResponse.AccessToken)
+	require.NotEmpty(t, tokenResponse.RefreshToken)
+	require.Equal(t, "bearer", tokenResponse.TokenType)
+	require.NotEmpty(t, tokenResponse.ExpiresIn)
+
+	sub, iss, err := oauth.ValidateAccessToken(ctx, tokenResponse.AccessToken)
+	require.NoError(t, err)
+	require.Equal(t, "https://keel.so", iss)
+
+	var identities []map[string]any
+	database.GetDB().Raw("SELECT * FROM identity").Scan(&identities)
+	require.Len(t, identities, 1)
+
+	id, ok := identities[0]["id"].(string)
+	require.True(t, ok)
+	require.Equal(t, id, sub)
+
+	email, ok := identities[0]["email"].(string)
+	require.True(t, ok)
+	require.Equal(t, email, "keelson@keel.so")
+
+	externalId, ok := identities[0]["external_id"].(string)
+	require.True(t, ok)
+	require.Equal(t, "id|285620", externalId)
+
+	issuer, ok := identities[0]["issuer"].(string)
+	require.True(t, ok)
+	require.Equal(t, issuer, server.Issuer)
+}
+
+func TestSsoLogin_InvalidLoginUrl(t *testing.T) {
+	ctx, database, schema := keeltesting.MakeContext(t, authTestSchema, true)
+	defer database.Close()
+
+	// OIDC test server
+	server, err := oauthtest.NewServer()
+	require.NoError(t, err)
+
+	// Set up auth config
+	ctx = runtimectx.WithOAuthConfig(ctx, &config.AuthConfig{
+		Providers: []config.Provider{
+			{
+				Type:      config.OpenIdConnectProvider,
+				Name:      "my-oidc",
+				ClientId:  "oidc-client-id",
+				IssuerUrl: server.Issuer,
+			},
+		},
+	})
+
+	// Set secret for client
+	t.Setenv(fmt.Sprintf("KEEL_AUTH_PROVIDER_SECRET_%s", strings.ToUpper("my-oidc")), "secret")
+
+	httpHandler := func(w http.ResponseWriter, r *http.Request) {
+		h := runtime.NewHttpHandler(schema)
+		r = r.WithContext(ctx)
+		h.ServeHTTP(w, r)
+	}
+	runtime := httptest.NewServer(http.HandlerFunc(httpHandler))
+	require.NoError(t, err)
+
+	server.WithOAuthClient(&oauthtest.OAuthClient{
+		ClientId:     "oidc-client-id",
+		ClientSecret: "secret",
+		RedirectUrl:  runtime.URL + "/auth/callback/my-oidc",
+	})
+
+	server.SetUser("id|285620", &oauth.UserClaims{
+		Email:         "keelson@keel.so",
+		EmailVerified: true,
+	})
+
+	// Make an SSO login request with an unknown provider
+	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/login/unknown-oidc", nil)
+	require.NoError(t, err)
+
+	httpResponse, err := runtime.Client().Do(request)
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(httpResponse.Body)
+	require.NoError(t, err)
+
+	var errorResponse authapi.ErrorResponse
+	err = json.Unmarshal(data, &errorResponse)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusBadRequest, httpResponse.StatusCode)
+	require.Equal(t, "invalid_request", errorResponse.Error)
+	require.Equal(t, "login url malformed or provider not found", errorResponse.ErrorDescription)
+
+	// Make an SSO login request with additional fragment
+	request, err = http.NewRequest(http.MethodPost, runtime.URL+"/auth/login/my-oidc/oops", nil)
+	require.NoError(t, err)
+
+	httpResponse, err = runtime.Client().Do(request)
+	require.NoError(t, err)
+
+	data, err = io.ReadAll(httpResponse.Body)
+	require.NoError(t, err)
+
+	err = json.Unmarshal(data, &errorResponse)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusBadRequest, httpResponse.StatusCode)
+	require.Equal(t, "invalid_request", errorResponse.Error)
+	require.Equal(t, "login url malformed or provider not found", errorResponse.ErrorDescription)
+
+	// Make an SSO login request without a provider
+	request, err = http.NewRequest(http.MethodPost, runtime.URL+"/auth/login/", nil)
+	require.NoError(t, err)
+
+	httpResponse, err = runtime.Client().Do(request)
+	require.NoError(t, err)
+
+	data, err = io.ReadAll(httpResponse.Body)
+	require.NoError(t, err)
+
+	err = json.Unmarshal(data, &errorResponse)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusBadRequest, httpResponse.StatusCode)
+	require.Equal(t, "invalid_request", errorResponse.Error)
+	require.Equal(t, "login url malformed or provider not found", errorResponse.ErrorDescription)
+}
+
+func TestSsoLogin_MissingSecret(t *testing.T) {
+	ctx, database, schema := keeltesting.MakeContext(t, authTestSchema, true)
+	defer database.Close()
+
+	// OIDC test server
+	server, err := oauthtest.NewServer()
+	require.NoError(t, err)
+
+	// Set up auth config
+	ctx = runtimectx.WithOAuthConfig(ctx, &config.AuthConfig{
+		Providers: []config.Provider{
+			{
+				Type:      config.OpenIdConnectProvider,
+				Name:      "my-oidc",
+				ClientId:  "oidc-client-id",
+				IssuerUrl: server.Issuer,
+			},
+		},
+	})
+
+	httpHandler := func(w http.ResponseWriter, r *http.Request) {
+		h := runtime.NewHttpHandler(schema)
+		r = r.WithContext(ctx)
+		h.ServeHTTP(w, r)
+	}
+	runtime := httptest.NewServer(http.HandlerFunc(httpHandler))
+	require.NoError(t, err)
+
+	server.WithOAuthClient(&oauthtest.OAuthClient{
+		ClientId:     "oidc-client-id",
+		ClientSecret: "secret",
+		RedirectUrl:  runtime.URL + "/auth/callback/my-oidc",
+	})
+
+	server.SetUser("id|285620", &oauth.UserClaims{
+		Email:         "keelson@keel.so",
+		EmailVerified: true,
+	})
+
+	// Make an SSO login request
+	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/login/my-oidc", nil)
+	require.NoError(t, err)
+
+	httpResponse, err := runtime.Client().Do(request)
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(httpResponse.Body)
+	require.NoError(t, err)
+
+	var errorResponse authapi.ErrorResponse
+	err = json.Unmarshal(data, &errorResponse)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusBadRequest, httpResponse.StatusCode)
+	require.Equal(t, "invalid_request", errorResponse.Error)
+	require.Equal(t, "client secret not configured for provider: my-oidc", errorResponse.ErrorDescription)
+}
+
+func TestSsoLogin_ClientIdNotRegistered(t *testing.T) {
+	ctx, database, schema := keeltesting.MakeContext(t, authTestSchema, true)
+	defer database.Close()
+
+	// OIDC test server
+	server, err := oauthtest.NewServer()
+	require.NoError(t, err)
+
+	// Set up auth config
+	ctx = runtimectx.WithOAuthConfig(ctx, &config.AuthConfig{
+		Providers: []config.Provider{
+			{
+				Type:      config.OpenIdConnectProvider,
+				Name:      "my-oidc",
+				ClientId:  "oidc-client-id",
+				IssuerUrl: server.Issuer,
+			},
+		},
+	})
+
+	// Set secret for client
+	t.Setenv(fmt.Sprintf("KEEL_AUTH_PROVIDER_SECRET_%s", strings.ToUpper("my-oidc")), "secret")
+
+	httpHandler := func(w http.ResponseWriter, r *http.Request) {
+		h := runtime.NewHttpHandler(schema)
+		r = r.WithContext(ctx)
+		h.ServeHTTP(w, r)
+	}
+	runtime := httptest.NewServer(http.HandlerFunc(httpHandler))
+	require.NoError(t, err)
+
+	server.SetUser("id|285620", &oauth.UserClaims{
+		Email:         "keelson@keel.so",
+		EmailVerified: true,
+	})
+
+	// Make an SSO login request
+	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/login/my-oidc", nil)
+	require.NoError(t, err)
+
+	httpResponse, err := runtime.Client().Do(request)
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(httpResponse.Body)
+	require.NoError(t, err)
+
+	var errorResponse authapi.ErrorResponse
+	err = json.Unmarshal(data, &errorResponse)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusBadRequest, httpResponse.StatusCode)
+	require.Equal(t, "invalid_request", errorResponse.Error)
+	require.Equal(t, "provider could not authenticate due to invalid_request: client id not registered on server", errorResponse.ErrorDescription)
+}
+
+func TestSsoLogin_RedirectUrlMismatch(t *testing.T) {
+	ctx, database, schema := keeltesting.MakeContext(t, authTestSchema, true)
+	defer database.Close()
+
+	// OIDC test server
+	server, err := oauthtest.NewServer()
+	require.NoError(t, err)
+
+	// Set up auth config
+	ctx = runtimectx.WithOAuthConfig(ctx, &config.AuthConfig{
+		Providers: []config.Provider{
+			{
+				Type:      config.OpenIdConnectProvider,
+				Name:      "my-oidc",
+				ClientId:  "oidc-client-id",
+				IssuerUrl: server.Issuer,
+			},
+		},
+	})
+
+	// Set secret for client
+	t.Setenv(fmt.Sprintf("KEEL_AUTH_PROVIDER_SECRET_%s", strings.ToUpper("my-oidc")), "secret")
+
+	httpHandler := func(w http.ResponseWriter, r *http.Request) {
+		h := runtime.NewHttpHandler(schema)
+		r = r.WithContext(ctx)
+		h.ServeHTTP(w, r)
+	}
+	runtime := httptest.NewServer(http.HandlerFunc(httpHandler))
+	require.NoError(t, err)
+
+	server.WithOAuthClient(&oauthtest.OAuthClient{
+		ClientId:     "oidc-client-id",
+		ClientSecret: "secret",
+		RedirectUrl:  runtime.URL + "/auth/callback/mismatch",
+	})
+
+	server.SetUser("id|285620", &oauth.UserClaims{
+		Email:         "keelson@keel.so",
+		EmailVerified: true,
+	})
+
+	// Make an SSO login request
+	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/login/my-oidc", nil)
+	require.NoError(t, err)
+
+	httpResponse, err := runtime.Client().Do(request)
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(httpResponse.Body)
+	require.NoError(t, err)
+
+	var errorResponse authapi.ErrorResponse
+	err = json.Unmarshal(data, &errorResponse)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusBadRequest, httpResponse.StatusCode)
+	require.Equal(t, "invalid_request", errorResponse.Error)
+	require.Equal(t, "redirect uri does not match", errorResponse.ErrorDescription)
+}

--- a/runtime/apis/authapi/response.go
+++ b/runtime/apis/authapi/response.go
@@ -1,0 +1,60 @@
+package authapi
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/teamkeel/keel/runtime/common"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// https://openid.net/specs/openid-connect-standard-1_0-21_orig.html#AccessTokenErrorResponse
+// https://datatracker.ietf.org/doc/html/rfc7009#section-2.2
+type ErrorResponse struct {
+	Error            string `json:"error,omitempty"`
+	ErrorDescription string `json:"error_description,omitempty"`
+}
+
+// Errors which are returned in the body as JSON.
+func jsonErrResponse(ctx context.Context, status int, errorType string, errorDescription string, err error) common.Response {
+	span := trace.SpanFromContext(ctx)
+	span.SetStatus(codes.Error, errorType)
+
+	if err != nil {
+		span.RecordError(err, trace.WithStackTrace(true))
+	}
+
+	span.SetAttributes(
+		attribute.String("auth.error", errorType),
+		attribute.String("auth.error_description", errorDescription),
+	)
+
+	return common.NewJsonResponse(status, &ErrorResponse{
+		Error:            errorType,
+		ErrorDescription: errorDescription,
+	}, nil)
+}
+
+// Errors which are captured in the redirect query.
+func redirectErrResponse(ctx context.Context, redirectUrl *url.URL, errorType string, errorDescription string, err error) common.Response {
+	span := trace.SpanFromContext(ctx)
+	span.SetStatus(codes.Error, errorType)
+
+	if err != nil {
+		span.RecordError(err, trace.WithStackTrace(true))
+	}
+
+	span.SetAttributes(
+		attribute.String("auth.error", errorType),
+		attribute.String("auth.error_description", errorDescription),
+	)
+
+	values := url.Values{}
+	values.Add("error", errorType)
+	values.Add("error_description", errorDescription)
+	redirectUrl.RawQuery = values.Encode()
+
+	return common.NewRedirectResponse(redirectUrl)
+}

--- a/runtime/apis/authapi/revoke_endpoint.go
+++ b/runtime/apis/authapi/revoke_endpoint.go
@@ -21,14 +21,14 @@ func RevokeHandler(schema *proto.Schema) common.HandlerFunc {
 
 		if r.Method != http.MethodPost {
 			return common.NewJsonResponse(http.StatusMethodNotAllowed, &ErrorResponse{
-				Error:            InvalidRequest,
+				Error:            TokenErrInvalidRequest,
 				ErrorDescription: "the revoke endpoint only accepts POST",
 			}, nil)
 		}
 
 		if !HasContentType(r.Header, "application/x-www-form-urlencoded") {
 			return common.NewJsonResponse(http.StatusBadRequest, &ErrorResponse{
-				Error:            InvalidRequest,
+				Error:            TokenErrInvalidRequest,
 				ErrorDescription: "the request must be an encoded form with Content-Type application/x-www-form-urlencoded",
 			}, nil)
 		}
@@ -37,7 +37,7 @@ func RevokeHandler(schema *proto.Schema) common.HandlerFunc {
 
 		if refreshTokenRaw == "" {
 			return common.NewJsonResponse(http.StatusBadRequest, &ErrorResponse{
-				Error:            InvalidRequest,
+				Error:            TokenErrInvalidRequest,
 				ErrorDescription: "the refresh token must be provided in the token field",
 			}, nil)
 		}
@@ -47,7 +47,7 @@ func RevokeHandler(schema *proto.Schema) common.HandlerFunc {
 		if err != nil {
 			span.RecordError(err, trace.WithStackTrace(true))
 			return common.NewJsonResponse(http.StatusUnauthorized, &ErrorResponse{
-				Error:            InvalidClient,
+				Error:            TokenErrInvalidClient,
 				ErrorDescription: "possible causes may be that the id token is invalid, has expired, or has insufficient claims",
 			}, nil)
 		}

--- a/runtime/apis/authapi/revoke_endpoint_test.go
+++ b/runtime/apis/authapi/revoke_endpoint_test.go
@@ -21,7 +21,7 @@ func TestRevokeToken_Success(t *testing.T) {
 	defer database.Close()
 
 	// OIDC test server
-	server, err := oauthtest.NewOIDCServer()
+	server, err := oauthtest.NewServer()
 	require.NoError(t, err)
 
 	// Set up auth config

--- a/runtime/apis/authapi/token_endpoint.go
+++ b/runtime/apis/authapi/token_endpoint.go
@@ -12,7 +12,6 @@ import (
 	"github.com/teamkeel/keel/runtime/runtimectx"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 )
 
 var tracer = otel.Tracer("github.com/teamkeel/keel/runtime")
@@ -41,18 +40,11 @@ type TokenResponse struct {
 	RefreshToken string `json:"refresh_token,omitempty"`
 }
 
-// https://openid.net/specs/openid-connect-standard-1_0-21_orig.html#AccessTokenErrorResponse
-// https://datatracker.ietf.org/doc/html/rfc7009#section-2.2
-type ErrorResponse struct {
-	Error            string `json:"error,omitempty"`
-	ErrorDescription string `json:"error_description,omitempty"`
-}
-
 // https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
 const (
-	UnsupportedGrantType = "unsupported_grant_type"
-	InvalidClient        = "invalid_client"
-	InvalidRequest       = "invalid_request"
+	TokenErrUnsupportedGrantType = "unsupported_grant_type"
+	TokenErrInvalidClient        = "invalid_client"
+	TokenErrInvalidRequest       = "invalid_request"
 )
 
 const (
@@ -81,16 +73,16 @@ func TokenEndpointHandler(schema *proto.Schema) common.HandlerFunc {
 		}
 
 		if r.Method != http.MethodPost {
-			return authErrResponse(ctx, http.StatusMethodNotAllowed, InvalidRequest, "the token endpoint only accepts POST")
+			return jsonErrResponse(ctx, http.StatusMethodNotAllowed, TokenErrInvalidRequest, "the token endpoint only accepts POST", nil)
 		}
 
 		if !HasContentType(r.Header, "application/x-www-form-urlencoded") {
-			return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "the request must be an encoded form with Content-Type application/x-www-form-urlencoded")
+			return jsonErrResponse(ctx, http.StatusBadRequest, TokenErrInvalidRequest, "the request must be an encoded form with Content-Type application/x-www-form-urlencoded", nil)
 		}
 
 		grantType := r.FormValue(ArgGrantType)
 		if grantType == "" {
-			return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "the grant-type field is required with either 'refresh_token' or 'token_exchange'")
+			return jsonErrResponse(ctx, http.StatusBadRequest, TokenErrInvalidRequest, "the grant-type field is required with either 'refresh_token', 'token_exchange' or 'authorization_code'", nil)
 		}
 
 		span.SetAttributes(
@@ -100,12 +92,12 @@ func TokenEndpointHandler(schema *proto.Schema) common.HandlerFunc {
 		switch grantType {
 		case GrantTypeRefreshToken:
 			if !r.Form.Has(ArgRefreshToken) {
-				return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "the refresh token must be provided in the refresh_token field")
+				return jsonErrResponse(ctx, http.StatusBadRequest, TokenErrInvalidRequest, "the refresh token must be provided in the refresh_token field", nil)
 			}
 
 			refreshTokenRaw := r.FormValue(ArgRefreshToken)
 			if refreshTokenRaw == "" {
-				return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "the refresh token in the refresh_token field cannot be an empty string")
+				return jsonErrResponse(ctx, http.StatusBadRequest, TokenErrInvalidRequest, "the refresh token in the refresh_token field cannot be an empty string", nil)
 			}
 
 			var isValid bool
@@ -127,17 +119,17 @@ func TokenEndpointHandler(schema *proto.Schema) common.HandlerFunc {
 			}
 
 			if !isValid {
-				return authErrResponse(ctx, http.StatusUnauthorized, InvalidClient, "possible causes may be that the refresh token has been revoked or has expired")
+				return jsonErrResponse(ctx, http.StatusUnauthorized, TokenErrInvalidClient, "possible causes may be that the refresh token has been revoked or has expired", nil)
 			}
 
 		case GrantTypeAuthCode:
 			if !r.Form.Has(ArgCode) {
-				return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "the authorization code must be provided in the code field")
+				return jsonErrResponse(ctx, http.StatusBadRequest, TokenErrInvalidRequest, "the authorization code must be provided in the code field", nil)
 			}
 
 			authCode := r.FormValue(ArgCode)
 			if authCode == "" {
-				return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "the authorization code in the code field cannot be an empty string")
+				return jsonErrResponse(ctx, http.StatusBadRequest, TokenErrInvalidRequest, "the authorization code in the code field cannot be an empty string", nil)
 			}
 
 			// Consume the auth code
@@ -148,7 +140,7 @@ func TokenEndpointHandler(schema *proto.Schema) common.HandlerFunc {
 			}
 
 			if !isValid {
-				return authErrResponse(ctx, http.StatusUnauthorized, InvalidClient, "possible causes may be that the auth code has been consumed or has expired")
+				return jsonErrResponse(ctx, http.StatusUnauthorized, TokenErrInvalidClient, "possible causes may be that the auth code has been consumed or has expired", nil)
 			}
 
 			// Generate a refresh token.
@@ -159,22 +151,22 @@ func TokenEndpointHandler(schema *proto.Schema) common.HandlerFunc {
 
 		case GrantTypeTokenExchange:
 			if !r.Form.Has(ArgSubjectToken) {
-				return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "the ID token must be provided in the subject_token field")
+				return jsonErrResponse(ctx, http.StatusBadRequest, TokenErrInvalidRequest, "the ID token must be provided in the subject_token field", nil)
 			}
 
 			// We do not require subject_token_type, but if provided we only support 'id_token'
 			if r.Form.Has(ArgSubjectTokenType) && r.Form.Get(ArgSubjectTokenType) != "id_token" {
-				return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "the only supported subject_token_type is 'id_token'")
+				return jsonErrResponse(ctx, http.StatusBadRequest, TokenErrInvalidRequest, "the only supported subject_token_type is 'id_token'", nil)
 			}
 
 			// We do not require requested_token_type, but if provided we only support 'access_token'
 			if r.Form.Has(ArgRequestedTokeType) && (r.Form.Get(ArgRequestedTokeType) != "urn:ietf:params:oauth:token-type:access_token" && r.Form.Get("requested_token_type") != "access_token") {
-				return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "the only supported requested_token_type is 'access_token'")
+				return jsonErrResponse(ctx, http.StatusBadRequest, TokenErrInvalidRequest, "the only supported requested_token_type is 'access_token'", nil)
 			}
 
 			idTokenRaw := r.Form.Get(ArgSubjectToken)
 			if idTokenRaw == "" {
-				return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "the ID token in the subject_token field cannot be an empty string")
+				return jsonErrResponse(ctx, http.StatusBadRequest, TokenErrInvalidRequest, "the ID token in the subject_token field cannot be an empty string", nil)
 			}
 
 			span.SetAttributes(
@@ -185,15 +177,13 @@ func TokenEndpointHandler(schema *proto.Schema) common.HandlerFunc {
 			// Verify the ID token with the OIDC provider
 			idToken, err := oauth.VerifyIdToken(ctx, idTokenRaw)
 			if err != nil {
-				span.RecordError(err, trace.WithStackTrace(true))
-				return authErrResponse(ctx, http.StatusUnauthorized, InvalidClient, "possible causes may be that the id token is invalid, has expired, or has insufficient claims")
+				return jsonErrResponse(ctx, http.StatusUnauthorized, TokenErrInvalidClient, "possible causes may be that the id token is invalid, has expired, or has insufficient claims", err)
 			}
 
 			// Extract claims
 			var claims oauth.IdTokenClaims
 			if err := idToken.Claims(&claims); err != nil {
-				span.RecordError(err, trace.WithStackTrace(true))
-				return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "insufficient claims on id_token")
+				return jsonErrResponse(ctx, http.StatusBadRequest, TokenErrInvalidRequest, "insufficient claims on id_token", err)
 			}
 
 			identity, err := actions.FindIdentityByExternalId(ctx, schema, idToken.Subject, idToken.Issuer)
@@ -222,7 +212,7 @@ func TokenEndpointHandler(schema *proto.Schema) common.HandlerFunc {
 			identityId = identity.Id
 
 		default:
-			return authErrResponse(ctx, http.StatusBadRequest, UnsupportedGrantType, "the only supported grants are 'refresh_token' and 'token_exchange'")
+			return jsonErrResponse(ctx, http.StatusBadRequest, TokenErrUnsupportedGrantType, "the only supported grants are 'refresh_token', 'token_exchange' or 'authorization_code'", nil)
 		}
 
 		// Generate a new access token for this identity.

--- a/runtime/apis/authapi/token_endpoint.go
+++ b/runtime/apis/authapi/token_endpoint.go
@@ -24,6 +24,7 @@ const (
 	ArgSubjectToken      = "subject_token"
 	ArgSubjectTokenType  = "subject_token_type"
 	ArgRequestedTokeType = "requested_token_type"
+	ArgCode              = "code"
 	ArgRefreshToken      = "refresh_token"
 	ArgToken             = "token"
 )
@@ -127,6 +128,33 @@ func TokenEndpointHandler(schema *proto.Schema) common.HandlerFunc {
 
 			if !isValid {
 				return authErrResponse(ctx, http.StatusUnauthorized, InvalidClient, "possible causes may be that the refresh token has been revoked or has expired")
+			}
+
+		case GrantTypeAuthCode:
+			if !r.Form.Has(ArgCode) {
+				return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "the authorization code must be provided in the code field")
+			}
+
+			authCode := r.FormValue(ArgCode)
+			if authCode == "" {
+				return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "the authorization code in the code field cannot be an empty string")
+			}
+
+			// Consume the auth code
+			var isValid bool
+			isValid, identityId, err = oauth.ConsumeAuthCode(ctx, authCode)
+			if err != nil {
+				return common.InternalServerErrorResponse(ctx, err)
+			}
+
+			if !isValid {
+				return authErrResponse(ctx, http.StatusUnauthorized, InvalidClient, "possible causes may be that the auth code has been consumed or has expired")
+			}
+
+			// Generate a refresh token.
+			refreshToken, err = oauth.NewRefreshToken(ctx, identityId)
+			if err != nil {
+				return common.InternalServerErrorResponse(ctx, err)
 			}
 
 		case GrantTypeTokenExchange:

--- a/runtime/apis/authapi/token_endpoint.go
+++ b/runtime/apis/authapi/token_endpoint.go
@@ -12,7 +12,6 @@ import (
 	"github.com/teamkeel/keel/runtime/runtimectx"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -77,32 +76,20 @@ func TokenEndpointHandler(schema *proto.Schema) common.HandlerFunc {
 
 		config, err := runtimectx.GetOAuthConfig(ctx)
 		if err != nil {
-			span.RecordError(err, trace.WithStackTrace(true))
-			span.SetStatus(codes.Error, err.Error())
-			return common.NewJsonResponse(http.StatusInternalServerError, nil, nil)
+			return common.InternalServerErrorResponse(ctx, err)
 		}
 
 		if r.Method != http.MethodPost {
-			return common.NewJsonResponse(http.StatusMethodNotAllowed, &ErrorResponse{
-				Error:            InvalidRequest,
-				ErrorDescription: "the token endpoint only accepts POST",
-			}, nil)
+			return authErrResponse(ctx, http.StatusMethodNotAllowed, InvalidRequest, "the token endpoint only accepts POST")
 		}
 
 		if !HasContentType(r.Header, "application/x-www-form-urlencoded") {
-			return common.NewJsonResponse(http.StatusBadRequest, &ErrorResponse{
-				Error:            InvalidRequest,
-				ErrorDescription: "the request must be an encoded form with Content-Type application/x-www-form-urlencoded",
-			}, nil)
+			return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "the request must be an encoded form with Content-Type application/x-www-form-urlencoded")
 		}
 
 		grantType := r.FormValue(ArgGrantType)
-
 		if grantType == "" {
-			return common.NewJsonResponse(http.StatusBadRequest, &ErrorResponse{
-				Error:            InvalidRequest,
-				ErrorDescription: "the grant-type field is required with either 'refresh_token' or 'token_exchange'",
-			}, nil)
+			return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "the grant-type field is required with either 'refresh_token' or 'token_exchange'")
 		}
 
 		span.SetAttributes(
@@ -112,19 +99,12 @@ func TokenEndpointHandler(schema *proto.Schema) common.HandlerFunc {
 		switch grantType {
 		case GrantTypeRefreshToken:
 			if !r.Form.Has(ArgRefreshToken) {
-				return common.NewJsonResponse(http.StatusBadRequest, &ErrorResponse{
-					Error:            InvalidRequest,
-					ErrorDescription: "the refresh token must be provided in the refresh_token field",
-				}, nil)
+				return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "the refresh token must be provided in the refresh_token field")
 			}
 
 			refreshTokenRaw := r.FormValue(ArgRefreshToken)
-
 			if refreshTokenRaw == "" {
-				return common.NewJsonResponse(http.StatusBadRequest, &ErrorResponse{
-					Error:            InvalidRequest,
-					ErrorDescription: "the refresh token in the refresh_token field cannot be an empty string",
-				}, nil)
+				return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "the refresh token in the refresh_token field cannot be an empty string")
 			}
 
 			var isValid bool
@@ -132,9 +112,7 @@ func TokenEndpointHandler(schema *proto.Schema) common.HandlerFunc {
 				// Rotate and revoke this refresh token, and mint a new one.
 				isValid, refreshToken, identityId, err = oauth.RotateRefreshToken(ctx, refreshTokenRaw)
 				if err != nil {
-					span.RecordError(err, trace.WithStackTrace(true))
-					span.SetStatus(codes.Error, err.Error())
-					return common.NewJsonResponse(http.StatusInternalServerError, nil, nil)
+					return common.InternalServerErrorResponse(ctx, err)
 				}
 			} else {
 				// Response with the same refresh token when refresh token rotation is disabled
@@ -143,50 +121,32 @@ func TokenEndpointHandler(schema *proto.Schema) common.HandlerFunc {
 				// Check that the refresh token exists and has not expired.
 				isValid, identityId, err = oauth.ValidateRefreshToken(ctx, refreshToken)
 				if err != nil {
-					span.RecordError(err, trace.WithStackTrace(true))
-					span.SetStatus(codes.Error, err.Error())
-					return common.NewJsonResponse(http.StatusInternalServerError, nil, nil)
+					return common.InternalServerErrorResponse(ctx, err)
 				}
 			}
 
 			if !isValid {
-				return common.NewJsonResponse(http.StatusUnauthorized, &ErrorResponse{
-					Error:            InvalidClient,
-					ErrorDescription: "possible causes may be that the refresh token has been revoked or has expired",
-				}, nil)
+				return authErrResponse(ctx, http.StatusUnauthorized, InvalidClient, "possible causes may be that the refresh token has been revoked or has expired")
 			}
 
 		case GrantTypeTokenExchange:
 			if !r.Form.Has(ArgSubjectToken) {
-				return common.NewJsonResponse(http.StatusBadRequest, &ErrorResponse{
-					Error:            InvalidRequest,
-					ErrorDescription: "the ID token must be provided in the subject_token field",
-				}, nil)
+				return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "the ID token must be provided in the subject_token field")
 			}
 
 			// We do not require subject_token_type, but if provided we only support 'id_token'
 			if r.Form.Has(ArgSubjectTokenType) && r.Form.Get(ArgSubjectTokenType) != "id_token" {
-				return common.NewJsonResponse(http.StatusBadRequest, &ErrorResponse{
-					Error:            InvalidRequest,
-					ErrorDescription: "the only supported subject_token_type is 'id_token'",
-				}, nil)
+				return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "the only supported subject_token_type is 'id_token'")
 			}
 
 			// We do not require requested_token_type, but if provided we only support 'access_token'
 			if r.Form.Has(ArgRequestedTokeType) && (r.Form.Get(ArgRequestedTokeType) != "urn:ietf:params:oauth:token-type:access_token" && r.Form.Get("requested_token_type") != "access_token") {
-				return common.NewJsonResponse(http.StatusBadRequest, &ErrorResponse{
-					Error:            InvalidRequest,
-					ErrorDescription: "the only supported requested_token_type is 'access_token'",
-				}, nil)
+				return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "the only supported requested_token_type is 'access_token'")
 			}
 
 			idTokenRaw := r.Form.Get(ArgSubjectToken)
-
 			if idTokenRaw == "" {
-				return common.NewJsonResponse(http.StatusBadRequest, &ErrorResponse{
-					Error:            InvalidRequest,
-					ErrorDescription: "the ID token in the subject_token field cannot be an empty string",
-				}, nil)
+				return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "the ID token in the subject_token field cannot be an empty string")
 			}
 
 			span.SetAttributes(
@@ -198,68 +158,49 @@ func TokenEndpointHandler(schema *proto.Schema) common.HandlerFunc {
 			idToken, err := oauth.VerifyIdToken(ctx, idTokenRaw)
 			if err != nil {
 				span.RecordError(err, trace.WithStackTrace(true))
-				return common.NewJsonResponse(http.StatusUnauthorized, &ErrorResponse{
-					Error:            InvalidClient,
-					ErrorDescription: "possible causes may be that the id token is invalid, has expired, or has insufficient claims",
-				}, nil)
+				return authErrResponse(ctx, http.StatusUnauthorized, InvalidClient, "possible causes may be that the id token is invalid, has expired, or has insufficient claims")
 			}
 
 			// Extract claims
 			var claims oauth.IdTokenClaims
 			if err := idToken.Claims(&claims); err != nil {
 				span.RecordError(err, trace.WithStackTrace(true))
-				return common.NewJsonResponse(http.StatusBadRequest, &ErrorResponse{
-					Error:            InvalidRequest,
-					ErrorDescription: "insufficient claims on id_token",
-				}, nil)
+				return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "insufficient claims on id_token")
 			}
 
 			identity, err := actions.FindIdentityByExternalId(ctx, schema, idToken.Subject, idToken.Issuer)
 			if err != nil {
-				span.RecordError(err, trace.WithStackTrace(true))
-				span.SetStatus(codes.Error, err.Error())
-				return common.NewJsonResponse(http.StatusInternalServerError, nil, nil)
+				return common.InternalServerErrorResponse(ctx, err)
 			}
 
 			if identity == nil {
 				identity, err = actions.CreateIdentityWithIdTokenClaims(ctx, schema, idToken.Subject, idToken.Issuer, claims)
 				if err != nil {
-					span.RecordError(err, trace.WithStackTrace(true))
-					span.SetStatus(codes.Error, err.Error())
-					return common.NewJsonResponse(http.StatusInternalServerError, nil, nil)
+					return common.InternalServerErrorResponse(ctx, err)
 				}
 			} else {
 				identity, err = actions.UpdateIdentityWithIdTokenClaims(ctx, schema, idToken.Subject, idToken.Issuer, claims)
 				if err != nil {
-					span.RecordError(err, trace.WithStackTrace(true))
-					span.SetStatus(codes.Error, err.Error())
-					return common.NewJsonResponse(http.StatusInternalServerError, nil, nil)
+					return common.InternalServerErrorResponse(ctx, err)
 				}
 			}
 
 			// Generate a refresh token.
 			refreshToken, err = oauth.NewRefreshToken(ctx, identity.Id)
 			if err != nil {
-				span.RecordError(err, trace.WithStackTrace(true))
-				span.SetStatus(codes.Error, err.Error())
-				return common.NewJsonResponse(http.StatusInternalServerError, nil, nil)
+				return common.InternalServerErrorResponse(ctx, err)
 			}
 
 			identityId = identity.Id
 
 		default:
-			return common.NewJsonResponse(http.StatusBadRequest, &ErrorResponse{
-				Error:            UnsupportedGrantType,
-				ErrorDescription: "the only supported grants are 'refresh_token' and 'token_exchange'",
-			}, nil)
+			return authErrResponse(ctx, http.StatusBadRequest, UnsupportedGrantType, "the only supported grants are 'refresh_token' and 'token_exchange'")
 		}
 
 		// Generate a new access token for this identity.
 		accessTokenRaw, expiresIn, err := oauth.GenerateAccessToken(ctx, identityId)
 		if err != nil {
-			span.RecordError(err, trace.WithStackTrace(true))
-			span.SetStatus(codes.Error, err.Error())
-			return common.NewJsonResponse(http.StatusInternalServerError, nil, nil)
+			return common.InternalServerErrorResponse(ctx, err)
 		}
 
 		response := &TokenResponse{

--- a/runtime/common/common.go
+++ b/runtime/common/common.go
@@ -28,18 +28,10 @@ type ResponseMetadata struct {
 func NewJsonResponse(status int, body any, meta *ResponseMetadata) Response {
 	b, _ := json.Marshal(body)
 
-	if headers == nil {
-		headers = map[string][]string{}
-	}
-
-	// Content-Type must only be a single value
-	// https://www.rfc-editor.org/rfc/rfc7230#section-3.2.2
-	headers["Content-Type"] = []string{"application/json"}
-
-	return Response{
+	r := Response{
 		Status:  status,
 		Body:    b,
-		Headers: headers,
+		Headers: map[string][]string{},
 	}
 
 	if meta != nil {
@@ -49,6 +41,10 @@ func NewJsonResponse(status int, body any, meta *ResponseMetadata) Response {
 			r.Status = meta.Status
 		}
 	}
+
+	// Content-Type must only be a single value
+	// https://www.rfc-editor.org/rfc/rfc7230#section-3.2.2
+	r.Headers["Content-Type"] = []string{"application/json"}
 
 	return r
 }

--- a/runtime/common/common.go
+++ b/runtime/common/common.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/samber/lo"
@@ -47,6 +48,23 @@ func NewJsonResponse(status int, body any, meta *ResponseMetadata) Response {
 	r.Headers["Content-Type"] = []string{"application/json"}
 
 	return r
+}
+
+func NewRedirectResponse(url *url.URL) Response {
+	// This response code means that the URI of requested resource has been changed temporarily.
+	// Further changes in the URI might be made in the future.
+	code := http.StatusFound
+
+	// The body content for a 302 usually contains a short hypertext note with a hyperlink to the different URI(s).
+	// https://www.rfc-editor.org/rfc/rfc9110.html#name-302-found
+	return Response{
+		Status: code,
+		Body:   []byte("<a href=\"" + url.String() + "\">" + http.StatusText(code) + "</a>.\n"),
+		Headers: map[string][]string{
+			"Location":     {url.String()},
+			"Content-Type": {"text/html; charset=utf-8"},
+		},
+	}
 }
 
 func InternalServerErrorResponse(ctx context.Context, err error) Response {

--- a/runtime/oauth/auth_code.go
+++ b/runtime/oauth/auth_code.go
@@ -1,0 +1,102 @@
+package oauth
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/dchest/uniuri"
+	"github.com/teamkeel/keel/db"
+)
+
+const (
+	// Character length of crypo-generated auth code
+	authCodeLength = 32
+	authCodeExpiry = time.Duration(10) * time.Minute
+)
+
+// NewAuthCode generates a new auth code for the identity using the
+// configured or default expiry time.
+func NewAuthCode(ctx context.Context, identityId string) (string, error) {
+	ctx, span := tracer.Start(ctx, "New Auth Code")
+	defer span.End()
+
+	if identityId == "" {
+		return "", errors.New("identity ID cannot be empty when generating new auth code")
+	}
+
+	code := uniuri.NewLen(authCodeLength)
+	hash, err := hashToken(code)
+	if err != nil {
+		return "", err
+	}
+
+	database, err := db.GetDatabase(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	now := time.Now().UTC()
+	expiresAt := now.Add(authCodeExpiry)
+
+	sql := `
+		INSERT INTO 
+			keel_auth_code (code, identity_id, expires_at, created_at) 
+		VALUES 
+			(?, ?, ?, ?)`
+
+	db := database.GetDB().Exec(sql, hash, identityId, expiresAt, now)
+	if db.Error != nil {
+		return "", db.Error
+	}
+
+	if db.RowsAffected != 1 {
+		return "", errors.New("failed to insert auth code token into database")
+	}
+
+	return code, nil
+}
+
+// ConsumeAuthCode checks that the provided auth code has not expired,
+// consumes it (making it unusable again), and returning the identity it is associated with.
+func ConsumeAuthCode(ctx context.Context, code string) (isValid bool, identityId string, err error) {
+	ctx, span := tracer.Start(ctx, "Consume Auth Code")
+	defer span.End()
+
+	codeHash, err := hashToken(code)
+	if err != nil {
+		return false, "", err
+	}
+
+	database, err := db.GetDatabase(ctx)
+	if err != nil {
+		return false, "", err
+	}
+
+	sql := `
+		DELETE FROM 
+			keel_auth_code
+		WHERE 
+			code = ? AND
+			expires_at >= now()
+		RETURNING 
+			code, identity_id, expires_at, now()`
+
+	rows := []map[string]any{}
+	err = database.GetDB().Raw(sql, codeHash).Scan(&rows).Error
+	if err != nil {
+		return false, "", err
+	}
+
+	// There was no auth code found, and thus it is not valid
+	if len(rows) != 1 {
+		return false, "", nil
+	}
+
+	identityId, ok := rows[0]["identity_id"].(string)
+	if !ok {
+		return false, "", errors.New("could not parse identity_id from database result")
+	}
+
+	return true, identityId, nil
+}

--- a/runtime/oauth/auth_code.go
+++ b/runtime/oauth/auth_code.go
@@ -12,7 +12,7 @@ import (
 const (
 	// Character length of crypo-generated auth code
 	authCodeLength = 32
-	authCodeExpiry = time.Duration(10) * time.Minute
+	authCodeExpiry = time.Duration(60) * time.Second
 )
 
 // NewAuthCode generates a new auth code for the identity using the

--- a/runtime/oauth/auth_code_test.go
+++ b/runtime/oauth/auth_code_test.go
@@ -1,0 +1,67 @@
+package oauth_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/teamkeel/keel/runtime/oauth"
+	keeltesting "github.com/teamkeel/keel/testing"
+)
+
+func TestNewAuthCode_NotEmpty(t *testing.T) {
+	ctx, database, _ := keeltesting.MakeContext(t, authTestSchema, true)
+	defer database.Close()
+
+	code, err := oauth.NewAuthCode(ctx, "identity_id")
+	require.NoError(t, err)
+	require.Len(t, code, 32)
+}
+
+func TestNewAuthCode_ErrorOnEmptyIdentityId(t *testing.T) {
+	ctx := context.Background()
+
+	_, err := oauth.NewAuthCode(ctx, "")
+	require.Error(t, err)
+}
+
+func TestConsumeAuthCode_Success(t *testing.T) {
+	ctx, database, _ := keeltesting.MakeContext(t, authTestSchema, true)
+	defer database.Close()
+
+	code, err := oauth.NewAuthCode(ctx, "identity_id")
+	require.NoError(t, err)
+
+	isValid, identityId, err := oauth.ConsumeAuthCode(ctx, code)
+	require.NoError(t, err)
+	require.True(t, isValid)
+	require.Equal(t, "identity_id", identityId)
+}
+
+func TestConsumeAuthCode_DoesNotExist(t *testing.T) {
+	ctx, database, _ := keeltesting.MakeContext(t, authTestSchema, true)
+	defer database.Close()
+
+	isValid, identityId, err := oauth.ConsumeAuthCode(ctx, "notexists")
+	require.NoError(t, err)
+	require.False(t, isValid)
+	require.Empty(t, identityId)
+}
+
+func TestConsumeAuthCode_AlreadyConsumed(t *testing.T) {
+	ctx, database, _ := keeltesting.MakeContext(t, authTestSchema, true)
+	defer database.Close()
+
+	code, err := oauth.NewAuthCode(ctx, "identity_id")
+	require.NoError(t, err)
+
+	isValid, identityId, err := oauth.ConsumeAuthCode(ctx, code)
+	require.NoError(t, err)
+	require.True(t, isValid)
+	require.Equal(t, "identity_id", identityId)
+
+	isValid, identityId, err = oauth.ConsumeAuthCode(ctx, code)
+	require.NoError(t, err)
+	require.False(t, isValid)
+	require.Empty(t, identityId)
+}

--- a/runtime/oauth/id_token_test.go
+++ b/runtime/oauth/id_token_test.go
@@ -17,7 +17,7 @@ func TestIdTokenAuth_Valid(t *testing.T) {
 	ctx := context.Background()
 
 	// OIDC test server
-	server, err := oauthtest.NewOIDCServer()
+	server, err := oauthtest.NewServer()
 	require.NoError(t, err)
 
 	// Set up auth config
@@ -50,7 +50,7 @@ func TestIdTokenAuthMultipleIssuers_Valid(t *testing.T) {
 	ctx := context.Background()
 
 	// OIDC test server
-	server, err := oauthtest.NewOIDCServer()
+	server, err := oauthtest.NewServer()
 	require.NoError(t, err)
 
 	// Set up auth config
@@ -95,7 +95,7 @@ func TestIdTokenAuth_IncorrectlySigned(t *testing.T) {
 	ctx := context.Background()
 
 	// OIDC test server
-	server, err := oauthtest.NewOIDCServer()
+	server, err := oauthtest.NewServer()
 	require.NoError(t, err)
 
 	// Set up auth config
@@ -133,7 +133,7 @@ func TestIdTokenAuth_IssuerMismatch(t *testing.T) {
 	ctx := context.Background()
 
 	// OIDC test server
-	server, err := oauthtest.NewOIDCServer()
+	server, err := oauthtest.NewServer()
 	require.NoError(t, err)
 
 	// Set up auth config
@@ -171,7 +171,7 @@ func TestIdTokenAuth_ClientIdMismatch(t *testing.T) {
 	ctx := context.Background()
 
 	// OIDC test server
-	server, err := oauthtest.NewOIDCServer()
+	server, err := oauthtest.NewServer()
 	require.NoError(t, err)
 
 	// Set up auth config
@@ -226,7 +226,7 @@ func TestIdTokenAuth_IssuerNotConfigured(t *testing.T) {
 	ctx := context.Background()
 
 	// OIDC test server
-	server, err := oauthtest.NewOIDCServer()
+	server, err := oauthtest.NewServer()
 	require.NoError(t, err)
 
 	// Set up auth config with no issuer
@@ -251,7 +251,7 @@ func TestIdTokenAuth_ExpiredIdToken(t *testing.T) {
 	ctx := context.Background()
 
 	// OIDC test server
-	server, err := oauthtest.NewOIDCServer()
+	server, err := oauthtest.NewServer()
 	require.NoError(t, err)
 
 	// Set up auth config

--- a/runtime/oauth/oauthtest/oidc_test_server.go
+++ b/runtime/oauth/oauthtest/oidc_test_server.go
@@ -133,7 +133,7 @@ func NewServer() (*OidcServer, error) {
 			if !r.URL.Query().Has("redirect_uri") {
 				res.StatusCode = http.StatusNotFound
 				response := &authapi.ErrorResponse{
-					Error:            authapi.InvalidRequest,
+					Error:            authapi.TokenErrInvalidRequest,
 					ErrorDescription: "redirect uri missing",
 				}
 
@@ -148,7 +148,7 @@ func NewServer() (*OidcServer, error) {
 			if err != nil {
 				res.StatusCode = http.StatusNotFound
 				response := &authapi.ErrorResponse{
-					Error:            authapi.InvalidRequest,
+					Error:            authapi.TokenErrInvalidRequest,
 					ErrorDescription: "redirect uri invalid",
 				}
 
@@ -163,7 +163,7 @@ func NewServer() (*OidcServer, error) {
 				values.Add("error", "unsupported_response_type")
 				values.Add("error_description", "only 'code' response_type supported")
 				redirectUrl.RawQuery = values.Encode()
-				http.Redirect(w, r, redirectUrl.String(), http.StatusTemporaryRedirect)
+				http.Redirect(w, r, redirectUrl.String(), http.StatusFound)
 				break
 			}
 
@@ -180,7 +180,7 @@ func NewServer() (*OidcServer, error) {
 				values.Add("error", "invalid_request")
 				values.Add("error_description", "client id not registered on server")
 				redirectUrl.RawQuery = values.Encode()
-				http.Redirect(w, r, redirectUrl.String(), http.StatusTemporaryRedirect)
+				http.Redirect(w, r, redirectUrl.String(), http.StatusFound)
 				break
 			}
 
@@ -189,7 +189,7 @@ func NewServer() (*OidcServer, error) {
 			if client.RedirectUrl != redirectUrl.String() {
 				res.StatusCode = http.StatusNotFound
 				response := &authapi.ErrorResponse{
-					Error:            authapi.InvalidRequest,
+					Error:            authapi.TokenErrInvalidRequest,
 					ErrorDescription: "redirect uri does not match",
 				}
 
@@ -206,10 +206,48 @@ func NewServer() (*OidcServer, error) {
 
 			// If the end-user denies the login request or if the request fails for reasons other than an
 			// invalid client_id or redirect_uri, the OIDC server will pass any errors onto the redirect_uri.
-			http.Redirect(w, r, redirectUrl.String(), http.StatusTemporaryRedirect)
+			http.Redirect(w, r, redirectUrl.String(), http.StatusFound)
 
 		case "/oauth2/token":
 			idToken, _ := oidcServer.FetchIdToken("id|285620", []string{oidcServer.clients[0].ClientId})
+
+			clientId := r.FormValue("client_id")
+			var client *OAuthClient
+			for _, v := range oidcServer.clients {
+				if v.ClientId == clientId {
+					client = v
+				}
+			}
+
+			// Client not found on the server
+			if client == nil {
+				res.StatusCode = http.StatusNotFound
+				response := &authapi.ErrorResponse{
+					Error:            authapi.TokenErrInvalidClient,
+					ErrorDescription: "client id not registered on server",
+				}
+
+				b, _ := json.Marshal(response)
+				res.Body = io.NopCloser(bytes.NewReader(b))
+				res.Body.Close()
+				w.WriteHeader(http.StatusBadRequest)
+				break
+			}
+
+			// Client secret incorrect
+			if client.ClientSecret != r.FormValue("client_secret") {
+				res.StatusCode = http.StatusNotFound
+				response := &authapi.ErrorResponse{
+					Error:            authapi.TokenErrInvalidRequest,
+					ErrorDescription: "client credentials are incorrect",
+				}
+
+				b, _ := json.Marshal(response)
+				res.Body = io.NopCloser(bytes.NewReader(b))
+				res.Body.Close()
+				w.WriteHeader(http.StatusBadRequest)
+				break
+			}
 
 			tokenResponse := &IodcTokenResponse{
 				IdToken: idToken,

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -93,7 +93,6 @@ func NewHttpHandler(currSchema *proto.Schema) http.Handler {
 // NewAuthHandler handles requests to the authentication endpoints
 func NewAuthHandler(schema *proto.Schema) func(http.ResponseWriter, *http.Request) common.Response {
 	handleToken := authapi.TokenEndpointHandler(schema)
-	handleOAuth := authapi.OAuthHandler(schema)
 	handleRevoke := authapi.RevokeHandler(schema)
 	handleLogin := authapi.LoginHandler(schema)
 	handleCallback := authapi.CallbackHandler(schema)
@@ -102,14 +101,12 @@ func NewAuthHandler(schema *proto.Schema) func(http.ResponseWriter, *http.Reques
 		switch {
 		case r.URL.Path == "/auth/token":
 			return handleToken(r)
-		case strings.HasPrefix(r.URL.Path, "/auth/oauth"):
-			return handleOAuth(r)
 		case r.URL.Path == "/auth/revoke":
 			return handleRevoke(r)
 		case strings.HasPrefix(r.URL.Path, "/auth/login"):
-			return handleLogin(w, r)
+			return handleLogin(r)
 		case strings.HasPrefix(r.URL.Path, "/auth/callback"):
-			return handleCallback(w, r)
+			return handleCallback(r)
 		default:
 			return common.Response{
 				Status: http.StatusNotFound,

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -109,7 +109,7 @@ func NewAuthHandler(schema *proto.Schema) func(http.ResponseWriter, *http.Reques
 		case strings.HasPrefix(r.URL.Path, "/auth/login"):
 			return handleLogin(w, r)
 		case strings.HasPrefix(r.URL.Path, "/auth/callback"):
-			return handleCallback(r)
+			return handleCallback(w, r)
 		default:
 			return common.Response{
 				Status: http.StatusNotFound,

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -39,7 +39,7 @@ func GetVersion() string {
 
 func NewHttpHandler(currSchema *proto.Schema) http.Handler {
 	var apiHandler common.HandlerFunc
-	var authHandler common.HandlerFunc
+	var authHandler func(http.ResponseWriter, *http.Request) common.Response
 	if currSchema != nil {
 		apiHandler = NewApiHandler(currSchema)
 		authHandler = NewAuthHandler(currSchema)
@@ -66,10 +66,8 @@ func NewHttpHandler(currSchema *proto.Schema) http.Handler {
 		path := r.URL.Path
 		switch {
 		case strings.HasPrefix(path, "/auth"):
-			w.Header().Add("Content-Type", "application/json")
-			response = authHandler(r)
+			response = authHandler(w, r)
 		default:
-			w.Header().Add("Content-Type", "application/json")
 			response = apiHandler(r)
 		}
 
@@ -93,12 +91,14 @@ func NewHttpHandler(currSchema *proto.Schema) http.Handler {
 }
 
 // NewAuthHandler handles requests to the authentication endpoints
-func NewAuthHandler(schema *proto.Schema) common.HandlerFunc {
+func NewAuthHandler(schema *proto.Schema) func(http.ResponseWriter, *http.Request) common.Response {
 	handleToken := authapi.TokenEndpointHandler(schema)
 	handleOAuth := authapi.OAuthHandler(schema)
 	handleRevoke := authapi.RevokeHandler(schema)
+	handleLogin := authapi.LoginHandler(schema)
+	handleCallback := authapi.CallbackHandler(schema)
 
-	return func(r *http.Request) common.Response {
+	return func(w http.ResponseWriter, r *http.Request) common.Response {
 		switch {
 		case r.URL.Path == "/auth/token":
 			return handleToken(r)
@@ -106,6 +106,10 @@ func NewAuthHandler(schema *proto.Schema) common.HandlerFunc {
 			return handleOAuth(r)
 		case r.URL.Path == "/auth/revoke":
 			return handleRevoke(r)
+		case strings.HasPrefix(r.URL.Path, "/auth/login"):
+			return handleLogin(w, r)
+		case strings.HasPrefix(r.URL.Path, "/auth/callback"):
+			return handleCallback(r)
 		default:
 			return common.Response{
 				Status: http.StatusNotFound,

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -61,6 +61,7 @@ func SetupDatabaseForTestCase(ctx context.Context, dbConnInfo *db.ConnectionInfo
 	if err != nil {
 		return nil, err
 	}
+	defer mainDB.Close()
 
 	_, err = mainDB.Exec("select pg_terminate_backend(pg_stat_activity.pid) from pg_stat_activity where datname = '" + dbName + "' and pg_stat_activity.pid <> pg_backend_pid();")
 	if err != nil {
@@ -86,7 +87,7 @@ func SetupDatabaseForTestCase(ctx context.Context, dbConnInfo *db.ConnectionInfo
 	// at the end of the test. We need to explicitly close the connection
 	// so the mainDB connection can drop the database.
 	testDBConnInfo := dbConnInfo.WithDatabase(dbName)
-
+	fmt.Println(testDBConnInfo.String())
 	database, err := db.New(ctx, testDBConnInfo.String())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# "SSO Login" Authentication Flow

3rd-party "done for you" authentication with our built-in auth providers and any custom OpenID Connect provider.  

In a nutshell:
 1. The provider is configured in `keelconfig.yaml` and the client secret added as an env var to the host.
 2. The `/auth/login/mygoogleclient` endpoint kicks off the authentication process with the provider named "mygoogleclient" in the keelconfig.yaml.
 3. The provider will then request the user authenticate through the necessary means (for example, a username and password page).
 4. Upon successful authentication, the provider will callback to Keel, and the handshake will be complete.
 5. The identity will be created or updated.
 6. The response will be our standard token response (see below).

## Response

The response has an identical structure to the token endpoint.  A Keel `access_token` is returned, which is then used as a bearer token to access Keel actions.  This token can be refreshed using `refresh_token` and the refresh grant.

```json
{
  "access_token": "eyJhbGciOiJSUzI1...",
  "token_type": "bearer",
  "expires_in": 300,
  "refresh_token": "ujnzOSplWfLUW..."
}
```

## Configuration

As with OIDC Token authentication, providers are configured in just the same way in `keelconfig.yaml`.  When configured, a provided will support the SSO Login flow by default.  For example:

```yaml
auth:
  tokens:
    accessTokenExpiry: 30
    refreshTokenExpiry: 60

  providers:
    - type: google
      name: mygoogleclient
      issuerUrl: https://dev-myapp.us.auth0.com/
      clientId: s23tggGssSA5qdsF22gSSdsbwq
```

The client secret must then be added to each host as an *environment variable*.  This can be done either through shell (on local) or with the Console for hosted environments.  The template pattern for the environment variable name is based on the name of the provider:

```
KEEL_AUTH_PROVIDER_SECRET_{providername}
```

For example, `KEEL_AUTH_PROVIDER_SECRET_MYGOOGLECLIENT`

## Still to do

 - REAL WORLD TESTING as there is some uncertainty here
 - Discuss: what do we call this flow?  "OAuth" might be a bit misleading.
 - Discuss: are we happy with the secrets being dynamic env var names?
 - Dynamic `redirect_url` which can be configured from the Backend
 - Remove `oauth` type from keelconfig.yaml - we will only be supporting custom oidc.  We will continue to add on new built-in providers though.
 - On startup, check that all provider secrets exist.