### PR TITLE
chore: using auth code flow

### DIFF
--- a/config/auth.go
+++ b/config/auth.go
@@ -39,7 +39,7 @@ var (
 
 type AuthConfig struct {
 	Tokens      TokensConfig `yaml:"tokens"`
-	RedirectUrl string       `yaml:"redirectUrl"`
+	RedirectUrl *string      `yaml:"redirectUrl,omitempty"`
 	Providers   []Provider   `yaml:"providers"`
 }
 

--- a/config/auth.go
+++ b/config/auth.go
@@ -38,8 +38,9 @@ var (
 )
 
 type AuthConfig struct {
-	Tokens    TokensConfig `yaml:"tokens"`
-	Providers []Provider   `yaml:"providers"`
+	Tokens      TokensConfig `yaml:"tokens"`
+	RedirectUrl string       `yaml:"redirectUrl"`
+	Providers   []Provider   `yaml:"providers"`
 }
 
 type TokensConfig struct {

--- a/config/config.go
+++ b/config/config.go
@@ -129,6 +129,7 @@ const (
 	ConfigAuthProviderInvalidTypeErrorString         = "auth provider '%s' has invalid type '%s' which must be one of: %s"
 	ConfigAuthProviderDuplicateErrorString           = "auth provider name '%s' has been defined more than once, but must be unique"
 	ConfigAuthProviderInvalidHttpUrlErrorString      = "auth provider '%s' has missing or invalid https url for field: %s"
+	ConfigAuthInvalidRedirectUrlErrorString          = "auth redirectUrl '%s' is not a valid url"
 )
 
 type ConfigErrors struct {
@@ -332,6 +333,14 @@ func Validate(config *ProjectConfig) *ConfigErrors {
 		errors = append(errors, &ConfigError{
 			Type:    "invalid",
 			Message: fmt.Sprintf(ConfigAuthProviderInvalidHttpUrlErrorString, p.Name, "authorizationUrl"),
+		})
+	}
+
+	redirectUrlInvalid := invalidUrl(config.Auth.RedirectUrl)
+	if redirectUrlInvalid {
+		errors = append(errors, &ConfigError{
+			Type:    "invalid",
+			Message: fmt.Sprintf(ConfigAuthInvalidRedirectUrlErrorString, config.Auth.RedirectUrl),
 		})
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -336,12 +337,14 @@ func Validate(config *ProjectConfig) *ConfigErrors {
 		})
 	}
 
-	redirectUrlInvalid := invalidUrl(config.Auth.RedirectUrl)
-	if redirectUrlInvalid {
-		errors = append(errors, &ConfigError{
-			Type:    "invalid",
-			Message: fmt.Sprintf(ConfigAuthInvalidRedirectUrlErrorString, config.Auth.RedirectUrl),
-		})
+	if config.Auth.RedirectUrl != nil {
+		_, err := url.ParseRequestURI(*config.Auth.RedirectUrl)
+		if err != nil {
+			errors = append(errors, &ConfigError{
+				Type:    "invalid",
+				Message: fmt.Sprintf(ConfigAuthInvalidRedirectUrlErrorString, *config.Auth.RedirectUrl),
+			})
+		}
 	}
 
 	if len(errors) == 0 {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -129,6 +129,12 @@ func TestAuthTokens(t *testing.T) {
 	assert.Equal(t, false, config.Auth.RefreshTokenRotationEnabled())
 }
 
+func TestAuthInvalidRedirectUrl(t *testing.T) {
+	_, err := Load("fixtures/test_auth_invalid_redirect_url.yaml")
+
+	assert.Contains(t, err.Error(), "auth redirectUrl 'not-a-url' is not a valid url\n")
+}
+
 func TestAuthDefaults(t *testing.T) {
 	config, err := Load("fixtures/test_auth_empty.yaml")
 	assert.NoError(t, err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -132,7 +132,7 @@ func TestAuthTokens(t *testing.T) {
 func TestAuthInvalidRedirectUrl(t *testing.T) {
 	_, err := Load("fixtures/test_auth_invalid_redirect_url.yaml")
 
-	assert.Contains(t, err.Error(), "auth redirectUrl 'not-a-url' is not a valid url\n")
+	assert.Contains(t, err.Error(), "auth redirectUrl 'not a url' is not a valid url\n")
 }
 
 func TestAuthDefaults(t *testing.T) {

--- a/config/fixtures/test_auth.yaml
+++ b/config/fixtures/test_auth.yaml
@@ -4,6 +4,8 @@ auth:
     refreshTokenExpiry: 604800
     refreshTokenRotationEnabled: false
 
+  callbackUrl: http://localhost:8000/signedin
+
   providers:
     # Built-in Google provider
     - type: google

--- a/config/fixtures/test_auth.yaml
+++ b/config/fixtures/test_auth.yaml
@@ -4,7 +4,7 @@ auth:
     refreshTokenExpiry: 604800
     refreshTokenRotationEnabled: false
 
-  callbackUrl: http://localhost:8000/signedin
+  redirectUrl: http://localhost:8000/signedin
 
   providers:
     # Built-in Google provider

--- a/config/fixtures/test_auth_invalid_redirect_url.yaml
+++ b/config/fixtures/test_auth_invalid_redirect_url.yaml
@@ -1,0 +1,2 @@
+auth:
+  redirectUrl: not-a-url

--- a/config/fixtures/test_auth_invalid_redirect_url.yaml
+++ b/config/fixtures/test_auth_invalid_redirect_url.yaml
@@ -1,2 +1,2 @@
 auth:
-  redirectUrl: not-a-url
+  redirectUrl: not a url

--- a/migrations/columns.sql
+++ b/migrations/columns.sql
@@ -16,7 +16,7 @@ LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
 LEFT JOIN pg_catalog.pg_index i on i.indexrelid = a.attrelid
 WHERE
 	n.nspname = 'public'
-	AND c.relname not in ('keel_schema', 'keel_refresh_token', 'pg_stat_statements_info', 'pg_stat_statements')
+	AND c.relname not in ('keel_schema', 'keel_refresh_token', 'keel_auth_code', 'pg_stat_statements_info', 'pg_stat_statements')
 	AND a.attnum > 0
 	AND NOT a.attisdropped
 	AND i.indexrelid is null; -- no indexes

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -116,6 +116,9 @@ func (m *Migrations) Apply(ctx context.Context) error {
 	sql.WriteString("CREATE TABLE IF NOT EXISTS keel_refresh_token (token TEXT NOT NULL PRIMARY KEY, identity_id TEXT NOT NULL, created_at TIMESTAMP, expires_at TIMESTAMP);\n")
 	sql.WriteString("\n")
 
+	sql.WriteString("CREATE TABLE IF NOT EXISTS keel_auth_code (code TEXT NOT NULL PRIMARY KEY, identity_id TEXT NOT NULL, created_at TIMESTAMP, expires_at TIMESTAMP);\n")
+	sql.WriteString("\n")
+
 	sql.WriteString(fmt.Sprintf("SELECT set_trace_id('%s');\n", span.SpanContext().TraceID().String()))
 
 	sql.WriteString(m.SQL)

--- a/runtime/apis/authapi/oauth_endpoint.go
+++ b/runtime/apis/authapi/oauth_endpoint.go
@@ -183,7 +183,7 @@ func CallbackHandler(schema *proto.Schema) func(http.ResponseWriter, *http.Reque
 			return common.InternalServerErrorResponse(ctx, err)
 		}
 
-		if config.RedirectUrl == "" {
+		if config.RedirectUrl == nil {
 			err := fmt.Errorf("redirectUrl not set")
 			return common.InternalServerErrorResponse(ctx, err)
 		}
@@ -193,7 +193,7 @@ func CallbackHandler(schema *proto.Schema) func(http.ResponseWriter, *http.Reque
 			return common.InternalServerErrorResponse(ctx, err)
 		}
 
-		redirectUrl, err := url.Parse(config.RedirectUrl)
+		redirectUrl, err := url.Parse(*config.RedirectUrl)
 		if err != nil {
 			return common.InternalServerErrorResponse(ctx, err)
 		}

--- a/runtime/apis/authapi/oauth_endpoint.go
+++ b/runtime/apis/authapi/oauth_endpoint.go
@@ -184,7 +184,7 @@ func CallbackHandler(schema *proto.Schema) func(http.ResponseWriter, *http.Reque
 		}
 
 		if config.RedirectUrl == "" {
-			err := fmt.Errorf("callbackUrl not set")
+			err := fmt.Errorf("redirectUrl not set")
 			return common.InternalServerErrorResponse(ctx, err)
 		}
 
@@ -202,9 +202,9 @@ func CallbackHandler(schema *proto.Schema) func(http.ResponseWriter, *http.Reque
 		values.Add("code", authCode)
 		redirectUrl.RawQuery = values.Encode()
 
-		http.Redirect(w, r, redirectUrl.String(), http.StatusTemporaryRedirect)
+		http.Redirect(w, r, redirectUrl.String(), http.StatusFound)
 
-		return common.NewJsonResponse(http.StatusOK, nil, nil)
+		return common.NewJsonResponse(http.StatusFound, "callback handler redirect", nil)
 	}
 
 }

--- a/runtime/apis/authapi/token_endpoint.go
+++ b/runtime/apis/authapi/token_endpoint.go
@@ -140,7 +140,7 @@ func TokenEndpointHandler(schema *proto.Schema) common.HandlerFunc {
 				return authErrResponse(ctx, http.StatusBadRequest, InvalidRequest, "the authorization code in the code field cannot be an empty string")
 			}
 
-			// Consume the auth token
+			// Consume the auth code
 			var isValid bool
 			isValid, identityId, err = oauth.ConsumeAuthCode(ctx, authCode)
 			if err != nil {

--- a/runtime/common/common.go
+++ b/runtime/common/common.go
@@ -49,28 +49,6 @@ func NewJsonResponse(status int, body any, meta *ResponseMetadata) Response {
 	return r
 }
 
-// func NewRedirectResponse(w http.ResponseWriter, r *http.Request, url string) Response {
-
-// 	r := Response{
-// 		// Status code 303 will ensure the redirect uses HTTP GET
-// 		Status:  http.StatusSeeOther,
-// 	}
-
-// 	if meta != nil {
-// 		r.Headers = meta.Headers
-
-// 		if meta.Status != 0 {
-// 			r.Status = meta.Status
-// 		}
-// 	}
-
-// 	// Content-Type must only be a single value
-// 	// https://www.rfc-editor.org/rfc/rfc7230#section-3.2.2
-// 	r.Headers["Content-Type"] = []string{"application/json"}
-
-// 	return r
-// }
-
 func InternalServerErrorResponse(ctx context.Context, err error) Response {
 	span := trace.SpanFromContext(ctx)
 

--- a/runtime/common/common.go
+++ b/runtime/common/common.go
@@ -49,6 +49,28 @@ func NewJsonResponse(status int, body any, meta *ResponseMetadata) Response {
 	return r
 }
 
+// func NewRedirectResponse(w http.ResponseWriter, r *http.Request, url string) Response {
+
+// 	r := Response{
+// 		// Status code 303 will ensure the redirect uses HTTP GET
+// 		Status:  http.StatusSeeOther,
+// 	}
+
+// 	if meta != nil {
+// 		r.Headers = meta.Headers
+
+// 		if meta.Status != 0 {
+// 			r.Status = meta.Status
+// 		}
+// 	}
+
+// 	// Content-Type must only be a single value
+// 	// https://www.rfc-editor.org/rfc/rfc7230#section-3.2.2
+// 	r.Headers["Content-Type"] = []string{"application/json"}
+
+// 	return r
+// }
+
 func InternalServerErrorResponse(ctx context.Context, err error) Response {
 	span := trace.SpanFromContext(ctx)
 

--- a/runtime/oauth/auth_code.go
+++ b/runtime/oauth/auth_code.go
@@ -1,0 +1,102 @@
+package oauth
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/dchest/uniuri"
+	"github.com/teamkeel/keel/db"
+)
+
+const (
+	// Character length of crypo-generated auth code
+	authCodeLength = 32
+	authCodeExpiry = time.Duration(10) * time.Minute
+)
+
+// NewAuthCode generates a new auth code for the identity using the
+// configured or default expiry time.
+func NewAuthCode(ctx context.Context, identityId string) (string, error) {
+	ctx, span := tracer.Start(ctx, "New Auth Code")
+	defer span.End()
+
+	if identityId == "" {
+		return "", errors.New("identity ID cannot be empty when generating new auth code")
+	}
+
+	code := uniuri.NewLen(authCodeLength)
+	hash, err := hashToken(code)
+	if err != nil {
+		return "", err
+	}
+
+	database, err := db.GetDatabase(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	now := time.Now().UTC()
+	expiresAt := now.Add(authCodeExpiry)
+
+	sql := `
+		INSERT INTO 
+			keel_auth_code (code, identity_id, expires_at, created_at) 
+		VALUES 
+			(?, ?, ?, ?)`
+
+	db := database.GetDB().Exec(sql, hash, identityId, expiresAt, now)
+	if db.Error != nil {
+		return "", db.Error
+	}
+
+	if db.RowsAffected != 1 {
+		return "", errors.New("failed to insert auth code token into database")
+	}
+
+	return code, nil
+}
+
+// ConsumeAuthCode checks that the provided auth code has not expired,
+// consumes it (making it unusable again), and returning the identity it is associated with.
+func ConsumeAuthCode(ctx context.Context, code string) (isValid bool, identityId string, err error) {
+	ctx, span := tracer.Start(ctx, "Consume Auth Code")
+	defer span.End()
+
+	codeHash, err := hashToken(code)
+	if err != nil {
+		return false, "", err
+	}
+
+	database, err := db.GetDatabase(ctx)
+	if err != nil {
+		return false, "", err
+	}
+
+	sql := `
+		DELETE FROM 
+			keel_auth_code
+		WHERE 
+			code = ? AND
+			expires_at >= now()
+		RETURNING 
+			code, identity_id, expires_at, now()`
+
+	rows := []map[string]any{}
+	err = database.GetDB().Raw(sql, codeHash).Scan(&rows).Error
+	if err != nil {
+		return false, "", err
+	}
+
+	// There was no auth code found, and thus it is not valid
+	if len(rows) != 1 {
+		return false, "", nil
+	}
+
+	identityId, ok := rows[0]["identity_id"].(string)
+	if !ok {
+		return false, "", errors.New("could not parse identity_id from database result")
+	}
+
+	return true, identityId, nil
+}

--- a/runtime/oauth/auth_code_test.go
+++ b/runtime/oauth/auth_code_test.go
@@ -1,0 +1,67 @@
+package oauth_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/teamkeel/keel/runtime/oauth"
+	keeltesting "github.com/teamkeel/keel/testing"
+)
+
+func TestNewAuthCode_NotEmpty(t *testing.T) {
+	ctx, database, _ := keeltesting.MakeContext(t, authTestSchema, true)
+	defer database.Close()
+
+	code, err := oauth.NewAuthCode(ctx, "identity_id")
+	require.NoError(t, err)
+	require.Len(t, code, 32)
+}
+
+func TestNewAuthCode_ErrorOnEmptyIdentityId(t *testing.T) {
+	ctx := context.Background()
+
+	_, err := oauth.NewAuthCode(ctx, "")
+	require.Error(t, err)
+}
+
+func TestConsumeAuthCode_Success(t *testing.T) {
+	ctx, database, _ := keeltesting.MakeContext(t, authTestSchema, true)
+	defer database.Close()
+
+	code, err := oauth.NewAuthCode(ctx, "identity_id")
+	require.NoError(t, err)
+
+	isValid, identityId, err := oauth.ConsumeAuthCode(ctx, code)
+	require.NoError(t, err)
+	require.True(t, isValid)
+	require.Equal(t, "identity_id", identityId)
+}
+
+func TestConsumeAuthCode_DoesNotExist(t *testing.T) {
+	ctx, database, _ := keeltesting.MakeContext(t, authTestSchema, true)
+	defer database.Close()
+
+	isValid, identityId, err := oauth.ConsumeAuthCode(ctx, "notexists")
+	require.NoError(t, err)
+	require.False(t, isValid)
+	require.Empty(t, identityId)
+}
+
+func TestConsumeAuthCode_AlreadyConsumed(t *testing.T) {
+	ctx, database, _ := keeltesting.MakeContext(t, authTestSchema, true)
+	defer database.Close()
+
+	code, err := oauth.NewAuthCode(ctx, "identity_id")
+	require.NoError(t, err)
+
+	isValid, identityId, err := oauth.ConsumeAuthCode(ctx, code)
+	require.NoError(t, err)
+	require.True(t, isValid)
+	require.Equal(t, "identity_id", identityId)
+
+	isValid, identityId, err = oauth.ConsumeAuthCode(ctx, code)
+	require.NoError(t, err)
+	require.False(t, isValid)
+	require.Empty(t, identityId)
+}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -83,8 +83,13 @@ func NewHttpHandler(currSchema *proto.Schema) http.Handler {
 			attribute.Int("response.status", response.Status),
 		)
 
-		w.WriteHeader(response.Status)
-		_, _ = w.Write(response.Body)
+		if response.Status != 0 {
+			w.WriteHeader(response.Status)
+		}
+
+		if response.Body != nil {
+			_, _ = w.Write(response.Body)
+		}
 	}
 
 	return http.HandlerFunc(httpHandler)
@@ -109,7 +114,7 @@ func NewAuthHandler(schema *proto.Schema) func(http.ResponseWriter, *http.Reques
 		case strings.HasPrefix(r.URL.Path, "/auth/login"):
 			return handleLogin(w, r)
 		case strings.HasPrefix(r.URL.Path, "/auth/callback"):
-			return handleCallback(r)
+			return handleCallback(w, r)
 		default:
 			return common.Response{
 				Status: http.StatusNotFound,

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -83,13 +83,8 @@ func NewHttpHandler(currSchema *proto.Schema) http.Handler {
 			attribute.Int("response.status", response.Status),
 		)
 
-		if response.Status != 0 {
-			w.WriteHeader(response.Status)
-		}
-
-		if response.Body != nil {
-			_, _ = w.Write(response.Body)
-		}
+		w.WriteHeader(response.Status)
+		_, _ = w.Write(response.Body)
 	}
 
 	return http.HandlerFunc(httpHandler)


### PR DESCRIPTION
# Using Auth Code Flow

The better thing to do is to redirect from our SSO Login with an authorization code (and not the actual tokens, aka. Implicit Flow, [which is problematic](https://www.taithienbo.com/why-the-implicit-flow-is-no-longer-recommended-for-protecting-a-public-client/)), which can then be traded with access & refresh tokens at the token endpoint - this is standard Authorization Code Flow.  We can also easily extend this with PKCE for customers who need it for their SPA and mobile apps.

## Configuration

In order to use SSO Login, a `redirectUrl` must be configured in `keelconfig.yaml`.

```yaml
auth:
  redirectUrl: https://my-keel-application.com/signedin

  providers:
    - type: google
      name: google
      clientId: 1234567
```

## Example

After authenticating:

<img width="546" alt="image" src="https://github.com/teamkeel/keel/assets/6212830/b91c944f-5eae-48c6-9840-e02064ab0b7c">

Using that code to access tokens:

<img width="1073" alt="image" src="https://github.com/teamkeel/keel/assets/6212830/196a0a93-9cb6-4169-b6a5-13efc80868e2">


## To do

Needs more tests.  The SSO callback also needs to have his error responses reworked so that we are returning errors in the redirect URL query - see https://www.oauth.com/oauth2-servers/authorization/the-authorization-response/