### PR TITLE
feat: google, facebook and gitlab support & providers endpoints

### DIFF
--- a/config/auth.go
+++ b/config/auth.go
@@ -35,7 +35,6 @@ var (
 		FacebookProvider,
 		GitLabProvider,
 		OpenIdConnectProvider,
-		OAuthProvider,
 	}
 )
 
@@ -199,8 +198,6 @@ func (c *AuthConfig) GetProvider(name string) *Provider {
 
 func (p *Provider) GetTokenUrl() (string, error) {
 	switch p.Type {
-	case GoogleProvider:
-		return "https://accounts.google.com/o/oauth2/token", nil
 	case OAuthProvider:
 		return p.TokenUrl, nil
 	default:
@@ -210,8 +207,6 @@ func (p *Provider) GetTokenUrl() (string, error) {
 
 func (p *Provider) GetAuthorizationUrl() (string, error) {
 	switch p.Type {
-	case GoogleProvider:
-		return "https://accounts.google.com/o/oauth2/auth", nil
 	case OAuthProvider:
 		return p.AuthorizationUrl, nil
 	default:
@@ -322,7 +317,7 @@ func findAuthProviderMissingOrInvalidAuthorizationUrl(providers []Provider) []Pr
 }
 
 func invalidName(name string) bool {
-	return !regexp.MustCompile(`^[A-Za-z0-9_-]*$`).MatchString(name)
+	return !regexp.MustCompile(`^[A-Za-z_]\w*$`).MatchString(name)
 }
 
 func invalidUrl(u string) bool {

--- a/config/auth.go
+++ b/config/auth.go
@@ -130,7 +130,7 @@ func (c *AuthConfig) GetOidcProvidersByIssuer(issuer string) ([]Provider, error)
 			continue
 		}
 
-		issuerUrl, hasIssuer := p.GetIssuer()
+		issuerUrl, hasIssuer := p.GetIssuerUrl()
 		if !hasIssuer {
 			return nil, fmt.Errorf("issuer url has not been configured: %s", issuer)
 		}
@@ -143,27 +143,21 @@ func (c *AuthConfig) GetOidcProvidersByIssuer(issuer string) ([]Provider, error)
 	return providers, nil
 }
 
-// GetIssuer retrieves the issuer URL for the provider
-func (c *Provider) GetIssuer() (string, bool) {
-	switch c.Type {
-	case GoogleProvider:
-		return "https://accounts.google.com", true
-	case FacebookProvider:
-		return "https://www.facebook.com", true
-	case GitLabProvider:
-		return "https://gitlab.com", true
-	case OpenIdConnectProvider:
-		return c.IssuerUrl, true
-	default:
-		return "", false
-	}
-}
-
 // GetClientSecret retrieves the client secret from the host's env vars
 func (p *Provider) GetClientSecret() (string, bool) {
 	envName := fmt.Sprintf("%s%s", ProviderSecretPrefix, strings.ToUpper(p.Name))
 	clientSecret := os.Getenv(envName)
 	return clientSecret, clientSecret != ""
+}
+
+// GetAuthorizeUrl retrieves the authorize URL for this provider
+func (p *Provider) GetAuthorizeUrl() (*url.URL, error) {
+	apiUrl, err := url.ParseRequestURI(os.Getenv("KEEL_API_URL"))
+	if err != nil {
+		return nil, err
+	}
+
+	return apiUrl.JoinPath("/auth/authorize/" + strings.ToLower(p.Name)), nil
 }
 
 // GetCallbackUrl retrieves the callback URL for this provider
@@ -196,21 +190,53 @@ func (c *AuthConfig) GetProvider(name string) *Provider {
 	return nil
 }
 
-func (p *Provider) GetTokenUrl() (string, error) {
+// GetIssuerUrl retrieves the issuer URL for the provider
+func (p *Provider) GetIssuerUrl() (string, bool) {
 	switch p.Type {
-	case OAuthProvider:
-		return p.TokenUrl, nil
+	case GoogleProvider:
+		return "https://accounts.google.com", true
+	case FacebookProvider:
+		return "https://www.facebook.com", true
+	case GitLabProvider:
+		return "https://gitlab.com", true
+	case OpenIdConnectProvider:
+		return p.IssuerUrl, true
 	default:
-		return "", fmt.Errorf("the provider type '%s' should not have a token url configured", p.Type)
+		return "", false
 	}
 }
 
-func (p *Provider) GetAuthorizationUrl() (string, error) {
+func (p *Provider) GetTokenUrl() (string, bool) {
 	switch p.Type {
+	case GoogleProvider:
+		return "https://oauth2.googleapis.com/token", true
+	case FacebookProvider:
+		return "https://graph.facebook.com/v11.0/oauth/access_token", true
+	case GitLabProvider:
+		return "https://gitlab.com/oauth/token", true
+	case OpenIdConnectProvider:
+		return p.TokenUrl, true
 	case OAuthProvider:
-		return p.AuthorizationUrl, nil
+		return p.TokenUrl, true
 	default:
-		return "", fmt.Errorf("the provider type '%s' should not have a token url configured", p.Type)
+		return "", false
+	}
+}
+
+func (p *Provider) GetAuthorizationUrl() (string, bool) {
+	switch p.Type {
+	case GoogleProvider:
+		return "https://accounts.google.com/o/oauth2/auth", true
+	case FacebookProvider:
+		return "https://www.facebook.com/v11.0/dialog/oauth", true
+	case GitLabProvider:
+		return "https://gitlab.com/oauth/authorize", true
+	case OpenIdConnectProvider:
+		return p.AuthorizationUrl, true
+	case OAuthProvider:
+		return p.AuthorizationUrl, true
+	default:
+		return "", false
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -124,7 +124,7 @@ const (
 	ConfigIncorrectNamingErrorString                 = "%s must be written in upper snakecase"
 	ConfigReservedNameErrorString                    = "environment variable %s cannot start with %s as it is reserved"
 	ConfigAuthTokenExpiryMustBePositive              = "%s token lifespan cannot be negative or zero for field: %s"
-	ConfigAuthProviderInvalidName                    = "auth provider '%s' can only include alphanumeric characters, dashes and underscores"
+	ConfigAuthProviderInvalidName                    = "auth provider name '%s' must only include alphanumeric characters and underscores, and cannot start with a number"
 	ConfigAuthProviderMissingFieldAtIndexErrorString = "auth provider at index %v is missing field: %s"
 	ConfigAuthProviderMissingFieldErrorString        = "auth provider '%s' is missing field: %s"
 	ConfigAuthProviderInvalidTypeErrorString         = "auth provider '%s' has invalid type '%s' which must be one of: %s"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -160,7 +160,7 @@ func TestAuthProviders(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, "google", config.Auth.Providers[0].Type)
-	assert.Equal(t, "google-1", config.Auth.Providers[0].Name)
+	assert.Equal(t, "_Google_Client", config.Auth.Providers[0].Name)
 	assert.Equal(t, "foo_1", config.Auth.Providers[0].ClientId)
 
 	assert.Equal(t, "google", config.Auth.Providers[1].Type)
@@ -171,21 +171,17 @@ func TestAuthProviders(t *testing.T) {
 	assert.Equal(t, "Baidu", config.Auth.Providers[2].Name)
 	assert.Equal(t, "https://dev-skhlutl45lbqkvhv.us.auth0.com", config.Auth.Providers[2].IssuerUrl)
 	assert.Equal(t, "kasj28fnq09ak", config.Auth.Providers[2].ClientId)
-
-	assert.Equal(t, "oauth", config.Auth.Providers[3].Type)
-	assert.Equal(t, "Github", config.Auth.Providers[3].Name)
-	assert.Equal(t, "hfjuw983h1hfsdf", config.Auth.Providers[3].ClientId)
-	assert.Equal(t, "https://github.com/auth", config.Auth.Providers[3].AuthorizationUrl)
-	assert.Equal(t, "https://github.com/token", config.Auth.Providers[3].TokenUrl)
 }
 
 func TestInvalidProviderName(t *testing.T) {
 	_, err := Load("fixtures/test_auth_invalid_names.yaml")
 
-	assert.Contains(t, err.Error(), "auth provider '12 34' can only include alphanumeric characters, dashes and underscores\n")
-	assert.Contains(t, err.Error(), "auth provider 'Google Client' can only include alphanumeric characters, dashes and underscores\n")
-	assert.Contains(t, err.Error(), "auth provider 'google/' can only include alphanumeric characters, dashes and underscores\n")
-	assert.Contains(t, err.Error(), "auth provider 'google\\client' can only include alphanumeric characters, dashes and underscores\n")
+	assert.Contains(t, err.Error(), "auth provider name '12 34' must only include alphanumeric characters and underscores, and cannot start with a number\n")
+	assert.Contains(t, err.Error(), "auth provider name 'Google Client' must only include alphanumeric characters and underscores, and cannot start with a number\n")
+	assert.Contains(t, err.Error(), "auth provider name 'google/' must only include alphanumeric characters and underscores, and cannot start with a number\n")
+	assert.Contains(t, err.Error(), "auth provider name 'google\\client' must only include alphanumeric characters and underscores, and cannot start with a number\n")
+	assert.Contains(t, err.Error(), "auth provider name '1google' must only include alphanumeric characters and underscores, and cannot start with a number\n")
+	assert.Contains(t, err.Error(), "auth provider name 'Google-Client' must only include alphanumeric characters and underscores, and cannot start with a number\n")
 }
 
 func TestMissingProviderName(t *testing.T) {
@@ -205,9 +201,10 @@ func TestDuplicateProviderName(t *testing.T) {
 func TestInvalidProviderTypes(t *testing.T) {
 	_, err := Load("fixtures/test_auth_invalid_types.yaml")
 
-	assert.Contains(t, err.Error(), "auth provider 'google_1' has invalid type 'google_1' which must be one of: google, facebook, gitlab, oidc, oauth\n")
-	assert.Contains(t, err.Error(), "auth provider 'google_2' has invalid type 'Google' which must be one of: google, facebook, gitlab, oidc, oauth\n")
-	assert.Contains(t, err.Error(), "auth provider 'Baidu' has invalid type 'whoops' which must be one of: google, facebook, gitlab, oidc, oauth\n")
+	assert.Contains(t, err.Error(), "auth provider 'google_1' has invalid type 'google_1' which must be one of: google, facebook, gitlab, oidc\n")
+	assert.Contains(t, err.Error(), "auth provider 'google_2' has invalid type 'Google' which must be one of: google, facebook, gitlab, oidc\n")
+	assert.Contains(t, err.Error(), "auth provider 'Github' has invalid type 'oauth' which must be one of: google, facebook, gitlab, oidc\n")
+	assert.Contains(t, err.Error(), "auth provider 'Baidu' has invalid type 'whoops' which must be one of: google, facebook, gitlab, oidc\n")
 }
 
 func TestMissingClientId(t *testing.T) {
@@ -280,7 +277,7 @@ func TestAddOidcProvider(t *testing.T) {
 func TestAddOidcProviderInvalidName(t *testing.T) {
 	auth := &AuthConfig{}
 	err := auth.AddOidcProvider("my client", "https://mycustomoidc.com", "1234")
-	assert.ErrorContains(t, err, "auth provider 'my client' can only include alphanumeric characters, dashes and underscores")
+	assert.ErrorContains(t, err, "auth provider name 'my client' must only include alphanumeric characters and underscores, and cannot start with a number")
 }
 
 func TestGetClientSecret(t *testing.T) {

--- a/config/fixtures/test_auth.yaml
+++ b/config/fixtures/test_auth.yaml
@@ -9,7 +9,7 @@ auth:
   providers:
     # Built-in Google provider
     - type: google
-      name: google-1
+      name: _Google_Client
       clientId: foo_1
 
     # Built-in Google provider
@@ -22,10 +22,3 @@ auth:
       name: Baidu
       issuerUrl: 'https://dev-skhlutl45lbqkvhv.us.auth0.com'
       clientId: 'kasj28fnq09ak'
-
-    # Custom OAuth
-    - type: oauth
-      name: Github
-      clientId: hfjuw983h1hfsdf
-      authorizationUrl: https://github.com/auth
-      tokenUrl: https://github.com/token

--- a/config/fixtures/test_auth_duplicate_names.yaml
+++ b/config/fixtures/test_auth_duplicate_names.yaml
@@ -10,8 +10,7 @@ auth:
       clientId: 'kasj28fnq09ak'
 
     # Duplicate name
-    - type: oauth
+    - type: oidc
       name: my_google
-      clientId: hfjuw983h1hfsdf
-      authorizationUrl: https://github.com/auth
-      tokenUrl: https://github.com/token
+      issuerUrl: 'https://dev-232351356.us.auth0.com'
+      clientId: '3jdfh92h2'

--- a/config/fixtures/test_auth_invalid_names.yaml
+++ b/config/fixtures/test_auth_invalid_names.yaml
@@ -8,13 +8,19 @@ auth:
       name: Google Client
       clientId: foo_2
 
+    - type: google
+      name: google\client
+      clientId: foo_2
+
     - type: oidc
       name: google/
       issuerUrl: 'https://dev-skhlutl45lbqkvhv.us.auth0.com'
       clientId: 'kasj28fnq09ak'
 
-    - type: oauth
-      name: google\client
-      clientId: hfjuw983h1hfsdf
-      authorizationUrl: https://github.com/auth
-      tokenUrl: https://github.com/token
+    - type: google
+      name: 1google
+      clientId: foo_1
+
+    - type: google
+      name: Google-Client
+      clientId: foo_2

--- a/runtime/apis/authapi/authorize_endpoint.go
+++ b/runtime/apis/authapi/authorize_endpoint.go
@@ -41,8 +41,8 @@ const (
 	AuthorizationErrServerError = "server_error"
 )
 
-// LoginHandler will redirect to the specified provider in order to authenticate the user
-func LoginHandler(schema *proto.Schema) common.HandlerFunc {
+// AuthorizeHandler is a redirection endpoint that will redirect to the provider's sign-in/auth page
+func AuthorizeHandler(schema *proto.Schema) common.HandlerFunc {
 	return func(r *http.Request) common.Response {
 		ctx, span := tracer.Start(r.Context(), "Login Endpoint")
 		defer span.End()

--- a/runtime/apis/authapi/authorize_endpoint_test.go
+++ b/runtime/apis/authapi/authorize_endpoint_test.go
@@ -33,16 +33,18 @@ func TestSsoLogin_Success(t *testing.T) {
 		RedirectUrl: &redirectUrl,
 		Providers: []config.Provider{
 			{
-				Type:      config.OpenIdConnectProvider,
-				Name:      "my-oidc",
-				ClientId:  "oidc-client-id",
-				IssuerUrl: server.Issuer,
+				Type:             config.OpenIdConnectProvider,
+				Name:             "myoidc",
+				ClientId:         "oidc-client-id",
+				IssuerUrl:        server.Issuer,
+				TokenUrl:         server.TokenUrl,
+				AuthorizationUrl: server.AuthorizeUrl,
 			},
 		},
 	})
 
 	// Set secret for client
-	t.Setenv(fmt.Sprintf("KEEL_AUTH_PROVIDER_SECRET_%s", strings.ToUpper("my-oidc")), "secret")
+	t.Setenv(fmt.Sprintf("KEEL_AUTH_PROVIDER_SECRET_%s", strings.ToUpper("myoidc")), "secret")
 
 	httpHandler := func(w http.ResponseWriter, r *http.Request) {
 		h := runtime.NewHttpHandler(schema)
@@ -57,7 +59,7 @@ func TestSsoLogin_Success(t *testing.T) {
 	server.WithOAuthClient(&oauthtest.OAuthClient{
 		ClientId:     "oidc-client-id",
 		ClientSecret: "secret",
-		RedirectUrl:  runtime.URL + "/auth/callback/my-oidc",
+		RedirectUrl:  runtime.URL + "/auth/callback/myoidc",
 	})
 
 	server.SetUser("id|285620", &oauth.UserClaims{
@@ -66,7 +68,7 @@ func TestSsoLogin_Success(t *testing.T) {
 	})
 
 	// Make an SSO login request
-	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/authorize/my-oidc", nil)
+	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/authorize/myoidc", nil)
 	require.NoError(t, err)
 
 	httpResponse, err := runtime.Client().Do(request)
@@ -76,7 +78,7 @@ func TestSsoLogin_Success(t *testing.T) {
 	require.Contains(t, httpResponse.Request.Header["Referer"][0], "https://myapp.com/signedup?code=")
 	require.Equal(t, http.StatusMovedPermanently, httpResponse.Request.Response.StatusCode)
 
-	require.Contains(t, httpResponse.Request.Response.Request.Header["Referer"][0], runtime.URL+"/auth/callback/my-oidc?code=")
+	require.Contains(t, httpResponse.Request.Response.Request.Header["Referer"][0], runtime.URL+"/auth/callback/myoidc?code=")
 	require.Equal(t, http.StatusFound, httpResponse.Request.Response.Request.Response.StatusCode)
 
 	var identities []map[string]any
@@ -113,16 +115,18 @@ func TestSsoLogin_WrongSecret(t *testing.T) {
 		RedirectUrl: &redirectUrl,
 		Providers: []config.Provider{
 			{
-				Type:      config.OpenIdConnectProvider,
-				Name:      "my-oidc",
-				ClientId:  "oidc-client-id",
-				IssuerUrl: server.Issuer,
+				Type:             config.OpenIdConnectProvider,
+				Name:             "myoidc",
+				ClientId:         "oidc-client-id",
+				IssuerUrl:        server.Issuer,
+				TokenUrl:         server.TokenUrl,
+				AuthorizationUrl: server.AuthorizeUrl,
 			},
 		},
 	})
 
 	// Set secret for client
-	t.Setenv(fmt.Sprintf("KEEL_AUTH_PROVIDER_SECRET_%s", strings.ToUpper("my-oidc")), "wrong-secret")
+	t.Setenv(fmt.Sprintf("KEEL_AUTH_PROVIDER_SECRET_%s", strings.ToUpper("myoidc")), "wrong-secret")
 
 	httpHandler := func(w http.ResponseWriter, r *http.Request) {
 		h := runtime.NewHttpHandler(schema)
@@ -137,7 +141,7 @@ func TestSsoLogin_WrongSecret(t *testing.T) {
 	server.WithOAuthClient(&oauthtest.OAuthClient{
 		ClientId:     "oidc-client-id",
 		ClientSecret: "secret",
-		RedirectUrl:  runtime.URL + "/auth/callback/my-oidc",
+		RedirectUrl:  runtime.URL + "/auth/callback/myoidc",
 	})
 
 	server.SetUser("id|285620", &oauth.UserClaims{
@@ -146,7 +150,7 @@ func TestSsoLogin_WrongSecret(t *testing.T) {
 	})
 
 	// Make an SSO login request
-	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/authorize/my-oidc", nil)
+	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/authorize/myoidc", nil)
 	require.NoError(t, err)
 
 	httpResponse, err := runtime.Client().Do(request)
@@ -156,7 +160,7 @@ func TestSsoLogin_WrongSecret(t *testing.T) {
 	require.Contains(t, httpResponse.Request.Header["Referer"][0], "https://myapp.com/signedup?error=access_denied&error_description=failed+to+exchange+code+at+provider+token+endpoint")
 	require.Equal(t, http.StatusMovedPermanently, httpResponse.Request.Response.StatusCode)
 
-	require.Contains(t, httpResponse.Request.Response.Request.Header["Referer"][0], runtime.URL+"/auth/callback/my-oidc?code=")
+	require.Contains(t, httpResponse.Request.Response.Request.Header["Referer"][0], runtime.URL+"/auth/callback/myoidc?code=")
 	require.Equal(t, http.StatusFound, httpResponse.Request.Response.Request.Response.StatusCode)
 
 	var identities []map[string]any
@@ -178,16 +182,18 @@ func TestSsoLogin_InvalidLoginUrl(t *testing.T) {
 		RedirectUrl: &redirectUrl,
 		Providers: []config.Provider{
 			{
-				Type:      config.OpenIdConnectProvider,
-				Name:      "my-oidc",
-				ClientId:  "oidc-client-id",
-				IssuerUrl: server.Issuer,
+				Type:             config.OpenIdConnectProvider,
+				Name:             "myoidc",
+				ClientId:         "oidc-client-id",
+				IssuerUrl:        server.Issuer,
+				TokenUrl:         server.TokenUrl,
+				AuthorizationUrl: server.AuthorizeUrl,
 			},
 		},
 	})
 
 	// Set secret for client
-	t.Setenv(fmt.Sprintf("KEEL_AUTH_PROVIDER_SECRET_%s", strings.ToUpper("my-oidc")), "secret")
+	t.Setenv(fmt.Sprintf("KEEL_AUTH_PROVIDER_SECRET_%s", strings.ToUpper("myoidc")), "secret")
 
 	httpHandler := func(w http.ResponseWriter, r *http.Request) {
 		h := runtime.NewHttpHandler(schema)
@@ -202,7 +208,7 @@ func TestSsoLogin_InvalidLoginUrl(t *testing.T) {
 	server.WithOAuthClient(&oauthtest.OAuthClient{
 		ClientId:     "oidc-client-id",
 		ClientSecret: "secret",
-		RedirectUrl:  runtime.URL + "/auth/callback/my-oidc",
+		RedirectUrl:  runtime.URL + "/auth/callback/myoidc",
 	})
 
 	server.SetUser("id|285620", &oauth.UserClaims{
@@ -229,7 +235,7 @@ func TestSsoLogin_InvalidLoginUrl(t *testing.T) {
 	require.Equal(t, "login url malformed or provider not found", errorResponse.ErrorDescription)
 
 	// Make an SSO login request with additional fragment
-	request, err = http.NewRequest(http.MethodPost, runtime.URL+"/auth/authorize/my-oidc/oops", nil)
+	request, err = http.NewRequest(http.MethodPost, runtime.URL+"/auth/authorize/myoidc/oops", nil)
 	require.NoError(t, err)
 
 	httpResponse, err = runtime.Client().Do(request)
@@ -281,10 +287,12 @@ func TestSsoLogin_MissingSecret(t *testing.T) {
 		RedirectUrl: &redirectUrl,
 		Providers: []config.Provider{
 			{
-				Type:      config.OpenIdConnectProvider,
-				Name:      "my-oidc",
-				ClientId:  "oidc-client-id",
-				IssuerUrl: server.Issuer,
+				Type:             config.OpenIdConnectProvider,
+				Name:             "myoidc",
+				ClientId:         "oidc-client-id",
+				IssuerUrl:        server.Issuer,
+				TokenUrl:         server.TokenUrl,
+				AuthorizationUrl: server.AuthorizeUrl,
 			},
 		},
 	})
@@ -302,7 +310,7 @@ func TestSsoLogin_MissingSecret(t *testing.T) {
 	server.WithOAuthClient(&oauthtest.OAuthClient{
 		ClientId:     "oidc-client-id",
 		ClientSecret: "secret",
-		RedirectUrl:  runtime.URL + "/auth/callback/my-oidc",
+		RedirectUrl:  runtime.URL + "/auth/callback/myoidc",
 	})
 
 	server.SetUser("id|285620", &oauth.UserClaims{
@@ -311,7 +319,7 @@ func TestSsoLogin_MissingSecret(t *testing.T) {
 	})
 
 	// Make an SSO login request
-	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/authorize/my-oidc", nil)
+	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/authorize/myoidc", nil)
 	require.NoError(t, err)
 
 	httpResponse, err := runtime.Client().Do(request)
@@ -326,7 +334,7 @@ func TestSsoLogin_MissingSecret(t *testing.T) {
 
 	require.Equal(t, http.StatusBadRequest, httpResponse.StatusCode)
 	require.Equal(t, "invalid_request", errorResponse.Error)
-	require.Equal(t, "client secret not configured for provider: my-oidc", errorResponse.ErrorDescription)
+	require.Equal(t, "client secret not configured for provider: myoidc", errorResponse.ErrorDescription)
 
 	var identities []map[string]any
 	database.GetDB().Raw("SELECT * FROM identity").Scan(&identities)
@@ -347,16 +355,18 @@ func TestSsoLogin_ClientIdNotRegistered(t *testing.T) {
 		RedirectUrl: &redirectUrl,
 		Providers: []config.Provider{
 			{
-				Type:      config.OpenIdConnectProvider,
-				Name:      "my-oidc",
-				ClientId:  "oidc-client-id",
-				IssuerUrl: server.Issuer,
+				Type:             config.OpenIdConnectProvider,
+				Name:             "myoidc",
+				ClientId:         "oidc-client-id",
+				IssuerUrl:        server.Issuer,
+				TokenUrl:         server.TokenUrl,
+				AuthorizationUrl: server.AuthorizeUrl,
 			},
 		},
 	})
 
 	// Set secret for client
-	t.Setenv(fmt.Sprintf("KEEL_AUTH_PROVIDER_SECRET_%s", strings.ToUpper("my-oidc")), "secret")
+	t.Setenv(fmt.Sprintf("KEEL_AUTH_PROVIDER_SECRET_%s", strings.ToUpper("myoidc")), "secret")
 
 	httpHandler := func(w http.ResponseWriter, r *http.Request) {
 		h := runtime.NewHttpHandler(schema)
@@ -374,7 +384,7 @@ func TestSsoLogin_ClientIdNotRegistered(t *testing.T) {
 	})
 
 	// Make an SSO login request
-	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/authorize/my-oidc", nil)
+	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/authorize/myoidc", nil)
 	require.NoError(t, err)
 
 	httpResponse, err := runtime.Client().Do(request)
@@ -403,16 +413,18 @@ func TestSsoLogin_RedirectUrlMismatch(t *testing.T) {
 		RedirectUrl: &redirectUrl,
 		Providers: []config.Provider{
 			{
-				Type:      config.OpenIdConnectProvider,
-				Name:      "my-oidc",
-				ClientId:  "oidc-client-id",
-				IssuerUrl: server.Issuer,
+				Type:             config.OpenIdConnectProvider,
+				Name:             "myoidc",
+				ClientId:         "oidc-client-id",
+				IssuerUrl:        server.Issuer,
+				TokenUrl:         server.TokenUrl,
+				AuthorizationUrl: server.AuthorizeUrl,
 			},
 		},
 	})
 
 	// Set secret for client
-	t.Setenv(fmt.Sprintf("KEEL_AUTH_PROVIDER_SECRET_%s", strings.ToUpper("my-oidc")), "secret")
+	t.Setenv(fmt.Sprintf("KEEL_AUTH_PROVIDER_SECRET_%s", strings.ToUpper("myoidc")), "secret")
 
 	httpHandler := func(w http.ResponseWriter, r *http.Request) {
 		h := runtime.NewHttpHandler(schema)
@@ -436,7 +448,7 @@ func TestSsoLogin_RedirectUrlMismatch(t *testing.T) {
 	})
 
 	// Make an SSO login request
-	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/authorize/my-oidc", nil)
+	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/authorize/myoidc", nil)
 	require.NoError(t, err)
 
 	httpResponse, err := runtime.Client().Do(request)
@@ -470,16 +482,18 @@ func TestSsoLogin_NoRedirectUrlInConfig(t *testing.T) {
 	ctx = runtimectx.WithOAuthConfig(ctx, &config.AuthConfig{
 		Providers: []config.Provider{
 			{
-				Type:      config.OpenIdConnectProvider,
-				Name:      "my-oidc",
-				ClientId:  "oidc-client-id",
-				IssuerUrl: server.Issuer,
+				Type:             config.OpenIdConnectProvider,
+				Name:             "myoidc",
+				ClientId:         "oidc-client-id",
+				IssuerUrl:        server.Issuer,
+				TokenUrl:         server.TokenUrl,
+				AuthorizationUrl: server.AuthorizeUrl,
 			},
 		},
 	})
 
 	// Set secret for client
-	t.Setenv(fmt.Sprintf("KEEL_AUTH_PROVIDER_SECRET_%s", strings.ToUpper("my-oidc")), "secret")
+	t.Setenv(fmt.Sprintf("KEEL_AUTH_PROVIDER_SECRET_%s", strings.ToUpper("myoidc")), "secret")
 
 	httpHandler := func(w http.ResponseWriter, r *http.Request) {
 		h := runtime.NewHttpHandler(schema)
@@ -503,7 +517,7 @@ func TestSsoLogin_NoRedirectUrlInConfig(t *testing.T) {
 	})
 
 	// Make an SSO login request
-	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/authorize/my-oidc", nil)
+	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/authorize/myoidc", nil)
 	require.NoError(t, err)
 
 	httpResponse, err := runtime.Client().Do(request)

--- a/runtime/apis/authapi/authorize_endpoint_test.go
+++ b/runtime/apis/authapi/authorize_endpoint_test.go
@@ -66,7 +66,7 @@ func TestSsoLogin_Success(t *testing.T) {
 	})
 
 	// Make an SSO login request
-	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/login/my-oidc", nil)
+	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/authorize/my-oidc", nil)
 	require.NoError(t, err)
 
 	httpResponse, err := runtime.Client().Do(request)
@@ -146,7 +146,7 @@ func TestSsoLogin_WrongSecret(t *testing.T) {
 	})
 
 	// Make an SSO login request
-	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/login/my-oidc", nil)
+	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/authorize/my-oidc", nil)
 	require.NoError(t, err)
 
 	httpResponse, err := runtime.Client().Do(request)
@@ -211,7 +211,7 @@ func TestSsoLogin_InvalidLoginUrl(t *testing.T) {
 	})
 
 	// Make an SSO login request with an unknown provider
-	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/login/unknown-oidc", nil)
+	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/authorize/unknown-oidc", nil)
 	require.NoError(t, err)
 
 	httpResponse, err := runtime.Client().Do(request)
@@ -229,7 +229,7 @@ func TestSsoLogin_InvalidLoginUrl(t *testing.T) {
 	require.Equal(t, "login url malformed or provider not found", errorResponse.ErrorDescription)
 
 	// Make an SSO login request with additional fragment
-	request, err = http.NewRequest(http.MethodPost, runtime.URL+"/auth/login/my-oidc/oops", nil)
+	request, err = http.NewRequest(http.MethodPost, runtime.URL+"/auth/authorize/my-oidc/oops", nil)
 	require.NoError(t, err)
 
 	httpResponse, err = runtime.Client().Do(request)
@@ -246,7 +246,7 @@ func TestSsoLogin_InvalidLoginUrl(t *testing.T) {
 	require.Equal(t, "login url malformed or provider not found", errorResponse.ErrorDescription)
 
 	// Make an SSO login request without a provider
-	request, err = http.NewRequest(http.MethodPost, runtime.URL+"/auth/login/", nil)
+	request, err = http.NewRequest(http.MethodPost, runtime.URL+"/auth/authorize/", nil)
 	require.NoError(t, err)
 
 	httpResponse, err = runtime.Client().Do(request)
@@ -311,7 +311,7 @@ func TestSsoLogin_MissingSecret(t *testing.T) {
 	})
 
 	// Make an SSO login request
-	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/login/my-oidc", nil)
+	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/authorize/my-oidc", nil)
 	require.NoError(t, err)
 
 	httpResponse, err := runtime.Client().Do(request)
@@ -374,7 +374,7 @@ func TestSsoLogin_ClientIdNotRegistered(t *testing.T) {
 	})
 
 	// Make an SSO login request
-	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/login/my-oidc", nil)
+	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/authorize/my-oidc", nil)
 	require.NoError(t, err)
 
 	httpResponse, err := runtime.Client().Do(request)
@@ -436,7 +436,7 @@ func TestSsoLogin_RedirectUrlMismatch(t *testing.T) {
 	})
 
 	// Make an SSO login request
-	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/login/my-oidc", nil)
+	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/authorize/my-oidc", nil)
 	require.NoError(t, err)
 
 	httpResponse, err := runtime.Client().Do(request)
@@ -503,7 +503,7 @@ func TestSsoLogin_NoRedirectUrlInConfig(t *testing.T) {
 	})
 
 	// Make an SSO login request
-	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/login/my-oidc", nil)
+	request, err := http.NewRequest(http.MethodPost, runtime.URL+"/auth/authorize/my-oidc", nil)
 	require.NoError(t, err)
 
 	httpResponse, err := runtime.Client().Do(request)

--- a/runtime/apis/authapi/providers_endpoint.go
+++ b/runtime/apis/authapi/providers_endpoint.go
@@ -1,0 +1,51 @@
+package authapi
+
+import (
+	"net/http"
+
+	"github.com/teamkeel/keel/proto"
+	"github.com/teamkeel/keel/runtime/common"
+	"github.com/teamkeel/keel/runtime/runtimectx"
+)
+
+type ProviderResponse struct {
+	Name         string `json:"name"`
+	Type         string `json:"type"`
+	AuthorizeUrl string `json:"authorizeUrl"`
+	CallbackUrl  string `json:"callbackUrl"`
+}
+
+func ProvidersHandler(schema *proto.Schema) common.HandlerFunc {
+	return func(r *http.Request) common.Response {
+		ctx, span := tracer.Start(r.Context(), "Providers")
+		defer span.End()
+
+		config, err := runtimectx.GetOAuthConfig(ctx)
+		if err != nil {
+			return common.InternalServerErrorResponse(ctx, err)
+		}
+
+		providers := []ProviderResponse{}
+
+		for _, p := range config.Providers {
+			authUrl, err := p.GetAuthorizeUrl()
+			if err != nil {
+				return common.InternalServerErrorResponse(ctx, err)
+			}
+
+			callbackUrl, err := p.GetCallbackUrl()
+			if err != nil {
+				return common.InternalServerErrorResponse(ctx, err)
+			}
+
+			providers = append(providers, ProviderResponse{
+				Type:         p.Type,
+				Name:         p.Name,
+				AuthorizeUrl: authUrl.String(),
+				CallbackUrl:  callbackUrl.String(),
+			})
+		}
+
+		return common.NewJsonResponse(http.StatusOK, providers, nil)
+	}
+}

--- a/runtime/oauth/oauthtest/oidc_test_server.go
+++ b/runtime/oauth/oauthtest/oidc_test_server.go
@@ -39,6 +39,8 @@ type OidcServer struct {
 	PrivateKey      *rsa.PrivateKey
 	Users           map[string]*oauth.UserClaims
 	clients         []*OAuthClient
+	TokenUrl        string
+	AuthorizeUrl    string
 }
 
 func (o *OidcServer) SetUser(sub string, claims *oauth.UserClaims) {
@@ -297,6 +299,9 @@ func NewServer() (*OidcServer, error) {
 		"code_challenge_methods_supported":      []string{"plain", "S256"},
 		"introspection_endpoint":                fmt.Sprintf("%s/oauth2/introspect", oidcServer.Issuer),
 	}
+
+	oidcServer.AuthorizeUrl = oidcServer.Config["authorization_endpoint"].(string)
+	oidcServer.TokenUrl = oidcServer.Config["token_endpoint"].(string)
 
 	return oidcServer, nil
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -92,6 +92,7 @@ func NewHttpHandler(currSchema *proto.Schema) http.Handler {
 
 // NewAuthHandler handles requests to the authentication endpoints
 func NewAuthHandler(schema *proto.Schema) func(http.ResponseWriter, *http.Request) common.Response {
+	handleProviders := authapi.ProvidersHandler(schema)
 	handleToken := authapi.TokenEndpointHandler(schema)
 	handleRevoke := authapi.RevokeHandler(schema)
 	handleAuthorize := authapi.AuthorizeHandler(schema)
@@ -99,6 +100,8 @@ func NewAuthHandler(schema *proto.Schema) func(http.ResponseWriter, *http.Reques
 
 	return func(w http.ResponseWriter, r *http.Request) common.Response {
 		switch {
+		case r.URL.Path == "/auth/providers":
+			return handleProviders(r)
 		case r.URL.Path == "/auth/token":
 			return handleToken(r)
 		case r.URL.Path == "/auth/revoke":
@@ -115,7 +118,7 @@ func NewAuthHandler(schema *proto.Schema) func(http.ResponseWriter, *http.Reques
 	}
 }
 
-// NewApiHandler handles requests to the customers APIs
+// NewApiHandler handles requests to the customer APIs
 func NewApiHandler(s *proto.Schema) common.HandlerFunc {
 	handlers := map[string]common.HandlerFunc{}
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -94,7 +94,7 @@ func NewHttpHandler(currSchema *proto.Schema) http.Handler {
 func NewAuthHandler(schema *proto.Schema) func(http.ResponseWriter, *http.Request) common.Response {
 	handleToken := authapi.TokenEndpointHandler(schema)
 	handleRevoke := authapi.RevokeHandler(schema)
-	handleLogin := authapi.LoginHandler(schema)
+	handleAuthorize := authapi.AuthorizeHandler(schema)
 	handleCallback := authapi.CallbackHandler(schema)
 
 	return func(w http.ResponseWriter, r *http.Request) common.Response {
@@ -103,8 +103,8 @@ func NewAuthHandler(schema *proto.Schema) func(http.ResponseWriter, *http.Reques
 			return handleToken(r)
 		case r.URL.Path == "/auth/revoke":
 			return handleRevoke(r)
-		case strings.HasPrefix(r.URL.Path, "/auth/login"):
-			return handleLogin(r)
+		case strings.HasPrefix(r.URL.Path, "/auth/authorize"):
+			return handleAuthorize(r)
 		case strings.HasPrefix(r.URL.Path, "/auth/callback"):
 			return handleCallback(r)
 		default:

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -87,7 +87,6 @@ func SetupDatabaseForTestCase(ctx context.Context, dbConnInfo *db.ConnectionInfo
 	// at the end of the test. We need to explicitly close the connection
 	// so the mainDB connection can drop the database.
 	testDBConnInfo := dbConnInfo.WithDatabase(dbName)
-	fmt.Println(testDBConnInfo.String())
 	database, err := db.New(ctx, testDBConnInfo.String())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## General improvements and support for 3rd party authentication

 - Google, Facebook and GitLab built-in support for both flows 🙌
 - Reamed `/auth/login` to `auth/authorize` which is far more standard.
 - Config provider names with stricter validation as they become a part of URLs and env var names.
 - Removed custom `oauth` type.  We will only support custom OpenID Connect for now.
 - Not relying on OIDC discovery for endpoints with built-in providers.  Facebook doesn't seem to follow the standard.

## `/auth/providers` endpoint

```yaml
[
  {
    "name": "Auth0",
    "type": "oidc",
    "authorizeUrl": "http://localhost:8000/auth/authorize/auth0",
    "callbackUrl": "http://localhost:8000/auth/callback/auth0"
  },
  {
    "name": "google",
    "type": "google",
    "authorizeUrl": "http://localhost:8000/auth/authorize/google",
    "callbackUrl": "http://localhost:8000/auth/callback/google"
  },
  {
    "name": "fb",
    "type": "facebook",
    "authorizeUrl": "http://localhost:8000/auth/authorize/fb",
    "callbackUrl": "http://localhost:8000/auth/callback/fb"
  },
  {
    "name": "gitlab",
    "type": "gitlab",
    "authorizeUrl": "http://localhost:8000/auth/authorize/gitlab",
    "callbackUrl": "http://localhost:8000/auth/callback/gitlab"
  }
]
```