### PR TITLE
fix: types for model API with compound unique and findOne

### DIFF
--- a/integration/testdata/audit_logs/tests.test.ts
+++ b/integration/testdata/audit_logs/tests.test.ts
@@ -722,7 +722,10 @@ test("identity model - audit table populated", async () => {
   });
   expect(identityCreated).toEqual(true);
 
-  const identity = await models.identity.findOne({ email: "user@keel.xyz" });
+  const identity = await models.identity.findOne({
+    email: "user@keel.xyz",
+    issuer: "keel",
+  });
   expect(identity).not.toBeNull();
 
   const logs = await sql<Audit<Identity>>`SELECT * FROM keel_audit`.execute(

--- a/integration/testdata/functions_model_api/main.test.ts
+++ b/integration/testdata/functions_model_api/main.test.ts
@@ -145,3 +145,55 @@ const createNPosts = async (n: number) =>
       });
     })
   );
+
+test("findOne - compound unique with relationships", async () => {
+  const tom = await models.profile.create({
+    name: "Tom",
+  });
+  const benoit = await models.profile.create({
+    name: "Benoit",
+  });
+
+  await models.follow.create({
+    fromId: tom.id,
+    toId: benoit.id,
+  });
+
+  const dbFollow = await models.follow.findOne({
+    fromId: tom.id,
+    toId: benoit.id,
+  });
+
+  expect(dbFollow).not.toBeNull();
+});
+
+test("findOne - has-many", async () => {
+  const dickens = await models.author.create({
+    name: "Charles Dickens",
+  });
+  const book = await models.book.create({
+    authorId: dickens.id,
+    title: "Oliver Twist",
+  });
+
+  const dbAuthor = await models.author.findOne({
+    books: {
+      id: book.id,
+    },
+  });
+
+  expect(dbAuthor).not.toBeNull();
+});
+
+test("findOne - one-to-one", async () => {
+  const u = await models.user.create({});
+  const s = await models.settings.create({
+    userId: u.id,
+  });
+
+  const dbSettings = await models.settings.findOne({
+    userId: u.id,
+  });
+  expect(dbSettings).not.toBeNull();
+  expect(dbSettings!.id).toEqual(s.id);
+});

--- a/integration/testdata/functions_model_api/schema.keel
+++ b/integration/testdata/functions_model_api/schema.keel
@@ -15,3 +15,44 @@ model Post {
         }
     }
 }
+
+model Profile {
+    fields {
+        name Text
+    }
+}
+
+model Follow {
+    fields {
+        from Profile
+        to Profile
+    }
+
+    @unique([from, to])
+}
+
+model Author {
+    fields {
+        name Text
+        books Book[]
+    }
+}
+
+model Book {
+    fields {
+        title Text
+        author Author
+    }
+}
+
+model User {
+    fields {
+        settings Settings
+    }
+}
+
+model Settings {
+    fields {
+        user User @unique
+    }
+}

--- a/integration/testdata/identity_and_authentication/tests.test.ts
+++ b/integration/testdata/identity_and_authentication/tests.test.ts
@@ -173,7 +173,7 @@ test("withAuthToken - identity does not exist - authentication failed", async ()
     },
   });
 
-  await models.identity.delete({ email: "user@keel.xyz" });
+  await models.identity.delete({ email: "user@keel.xyz", issuer: "keel" });
 
   await expect(
     actions.withAuthToken(token).createPostWithIdentity({ title: "temp" })
@@ -209,10 +209,13 @@ test("withIdentity - identity does not exist - authentication failed", async () 
     },
   });
 
-  const identity = await models.identity.findOne({ email: "user@keel.xyz" });
+  const identity = await models.identity.findOne({
+    email: "user@keel.xyz",
+    issuer: "keel",
+  });
   expect(identity).not.toBeNull();
 
-  await models.identity.delete({ email: "user@keel.xyz" });
+  await models.identity.delete({ email: "user@keel.xyz", issuer: "keel" });
 
   await expect(
     actions.withIdentity(identity!).createPostWithIdentity({ title: "temp" })

--- a/integration/testdata/permissions_and_roles/tests.test.ts
+++ b/integration/testdata/permissions_and_roles/tests.test.ts
@@ -88,6 +88,7 @@ test("permission role email is authorized", async () => {
   await models.identity.update(
     {
       email: "verified@agency.org",
+      issuer: "keel",
     },
     {
       emailVerified: true,
@@ -147,6 +148,7 @@ test("permission role domain is authorized", async () => {
   await models.identity.update(
     {
       email: "john.witherow@times.co.uk",
+      issuer: "keel",
     },
     {
       emailVerified: true,

--- a/integration/testdata/permissions_custom_function/tests.test.ts
+++ b/integration/testdata/permissions_custom_function/tests.test.ts
@@ -256,6 +256,7 @@ test("creating a post with a role based permission rule - email based - permitte
   await models.identity.update(
     {
       email: "verified@keel.xyz",
+      issuer: "keel",
     },
     {
       emailVerified: true,
@@ -317,6 +318,7 @@ test("creating a post with a role based permission rule - domain based - permitt
   await models.identity.update(
     {
       email: "adam@abc.com",
+      issuer: "keel",
     },
     {
       emailVerified: true,

--- a/integration/testdata/set_backlinks/tests.test.ts
+++ b/integration/testdata/set_backlinks/tests.test.ts
@@ -235,7 +235,7 @@ test("create - @set with identity fields", async () => {
   expect(identityCreated).toBeTruthy();
 
   const identity = await models.identity.update(
-    { email: "user@keel.xyz" },
+    { email: "user@keel.xyz", issuer: "keel" },
     { externalId: "extId" }
   );
 
@@ -277,7 +277,7 @@ test("update - @set with identity fields", async () => {
   expect(identityCreated).toBeTruthy();
 
   const identity = await models.identity.update(
-    { email: "user@keel.xyz" },
+    { email: "user@keel.xyz", issuer: "keel" },
     { externalId: "extId" }
   );
 


### PR DESCRIPTION
This fixes the generation of the unique conditions interface for relationship fields.

As an example the following schema:
```
model Profile {
    fields {
        name Text
    }
}

model Follow {
    fields {
        from Profile
        to Profile
    }

    @unique([from, to])
}
```

Currently produces a unique conditions interface for `Follow` that looks like this. Both not grouping the `from` and `to` fields into one object, but also using the whole `Profile` model as the type.
```ts
export type FollowUniqueConditions = 
    | {from: Profile}
    | {to: Profile}
    | {id: string};
```


With this fix the unique conditions interface is now this, which correctly groups the fields and uses the id's rather than the whole model.
```ts
export type FollowUniqueConditions = 
    | {fromId: string, toId: string}
    | {id: string};
```