### PR TITLE
fix: bug with permissions in graphql

### DIFF
--- a/integration/testdata/functions_http/tests.test.ts
+++ b/integration/testdata/functions_http/tests.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from "vitest";
 
 test("headers", async () => {
   const response = await fetch(
-    process.env.KEEL_TESTING_ACTIONS_API_URL + "/withHeaders",
+    process.env.KEEL_TESTING_ACTIONS_API_URL + "/json/withHeaders",
     {
       body: "{}",
       method: "POST",
@@ -19,7 +19,7 @@ test("headers", async () => {
 
 test("status", async () => {
   const response = await fetch(
-    process.env.KEEL_TESTING_ACTIONS_API_URL + "/withStatus",
+    process.env.KEEL_TESTING_ACTIONS_API_URL + "/json/withStatus",
     {
       body: "{}",
       method: "POST",
@@ -37,7 +37,7 @@ test("status", async () => {
 test("query params", async () => {
   const response = await fetch(
     process.env.KEEL_TESTING_ACTIONS_API_URL +
-      "/withQueryParams?a=1&b=foo&c=true"
+      "/json/withQueryParams?a=1&b=foo&c=true"
   );
 
   const body = await response.json();

--- a/integration/testdata/graphql/main.test.ts
+++ b/integration/testdata/graphql/main.test.ts
@@ -1,0 +1,67 @@
+import { test, expect, beforeEach } from "vitest";
+import { actions, resetDatabase } from "@teamkeel/testing";
+
+beforeEach(resetDatabase);
+
+test("list action with has-one relationship", async () => {
+  const { token } = await actions.authenticate({
+    createIfNotExists: true,
+    emailPassword: {
+      email: "user@keel.xyz",
+      password: "1234",
+    },
+  });
+
+  const authed = actions.withAuthToken(token);
+
+  const user = await authed.createUser({
+    firstName: "John",
+    lastName: "Lennon",
+  });
+
+  await authed.createBlogPost({
+    title: "Why I left The Beatles",
+    content: "blah blah blah",
+  });
+
+  const resp = await graphql(
+    `
+      query {
+        blogPosts {
+          edges {
+            node {
+              id
+              user {
+                id
+                firstName
+              }
+            }
+          }
+        }
+      }
+    `,
+    token
+  );
+
+  expect(resp.data.blogPosts.edges.length).toBe(1);
+  expect(resp.data.blogPosts.edges[0].node.user).toEqual({
+    id: user.id,
+    firstName: user.firstName,
+  });
+});
+
+async function graphql(query, token) {
+  const res = await fetch(
+    process.env.KEEL_TESTING_ACTIONS_API_URL + "/graphql",
+    {
+      method: "POST",
+      body: JSON.stringify({
+        query,
+      }),
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    }
+  );
+  return res.json();
+}

--- a/integration/testdata/graphql/schema.keel
+++ b/integration/testdata/graphql/schema.keel
@@ -1,0 +1,42 @@
+model User {
+    fields {
+        firstName Text
+        lastName Text
+        identity Identity @unique
+        blogPosts BlogPost[]
+    }
+
+    actions {
+        create createUser() with (firstName, lastName) {
+            @set(user.identity = ctx.identity)
+            @permission(expression: ctx.isAuthenticated)
+        }
+        get getUser() {
+            @where(user.identity == ctx.identity)
+        }
+    }
+
+    @permission(
+        actions: [get],
+        expression: user.identity == ctx.identity
+    )
+}
+
+model BlogPost {
+    fields {
+        title Text
+        content Text
+        user User
+    }
+
+    actions {
+        create createBlogPost() with (title, content) {
+            @set(blogPost.user = ctx.identity.user)
+            @permission(expression: ctx.isAuthenticated)
+        }
+        list blogPosts() {
+            @where(blogPost.user.id == ctx.identity.user.id)
+            @permission(expression: ctx.isAuthenticated)
+        }
+    }
+}

--- a/integration/testdata/identity_user_organisations/schema.keel
+++ b/integration/testdata/identity_user_organisations/schema.keel
@@ -10,7 +10,7 @@ model User {
             @set(user.identity = ctx.identity)
         }
         get getUser(id)
-        list listUsersByOrganisation(organisations.organisation.id) 
+        list listUsersByOrganisation(organisations.organisation.id)
     }
 
     @permission(

--- a/packages/testing-runtime/src/ActionExecutor.mjs
+++ b/packages/testing-runtime/src/ActionExecutor.mjs
@@ -2,7 +2,7 @@ import { Executor } from "./Executor.mjs";
 
 export class ActionExecutor extends Executor {
   constructor(props) {
-    props.apiBaseUrl = process.env.KEEL_TESTING_ACTIONS_API_URL;
+    props.apiBaseUrl = process.env.KEEL_TESTING_ACTIONS_API_URL + "/json";
     props.parseJsonResult = true;
 
     super(props);

--- a/runtime/actions/authorization_test.go
+++ b/runtime/actions/authorization_test.go
@@ -478,11 +478,10 @@ var authorisationTestCases = []authorisationTestCase{
 				"thing"
 			LEFT JOIN "identity" AS "thing$created_by" ON
 				"thing$created_by"."id" = "thing"."created_by_id"
-			WHERE 
-				"thing"."id" IS NOT DISTINCT FROM ? AND 
+			WHERE
 				( ( ? IS NOT DISTINCT FROM ? AND "thing$created_by"."id" IS NOT DISTINCT FROM ? ) )
 				AND "thing"."id" IN (?)`,
-		expectedArgs: []any{"123", true, true, unverifiedIdentity.Id, "idToAuthorise"},
+		expectedArgs: []any{true, true, unverifiedIdentity.Id, "idToAuthorise"},
 		identity:     unverifiedIdentity,
 	},
 	{
@@ -1001,10 +1000,9 @@ var authorisationTestCases = []authorisationTestCase{
 			LEFT JOIN 
 				"identity" AS "thing$updated_by" ON "thing$updated_by"."id" = "thing"."updated_by_id" 
 			WHERE 
-				"thing"."id" IS NOT DISTINCT FROM ? AND 
 				( "thing$created_by"."id" IS NOT DISTINCT FROM ? OR "thing$updated_by"."id" IS NOT DISTINCT FROM ? )
 				AND "thing"."id" IN (?)`,
-		expectedArgs: []any{"123", unverifiedIdentity.Id, unverifiedIdentity.Id, "idToAuthorise"},
+		expectedArgs: []any{unverifiedIdentity.Id, unverifiedIdentity.Id, "idToAuthorise"},
 		identity:     unverifiedIdentity,
 	},
 	{
@@ -1054,10 +1052,10 @@ var authorisationTestCases = []authorisationTestCase{
 			LEFT JOIN 
 				"user" AS "user$organisations$organisation$users$user" ON "user$organisations$organisation$users$user"."id" = "user$organisations$organisation$users"."user_id" 
 			WHERE 
-				"user$organisations$organisation"."id" IS NOT DISTINCT FROM ? AND ( ? IS NOT DISTINCT FROM "user$organisations$organisation$users$user"."identity_id" )
+				( ? IS NOT DISTINCT FROM "user$organisations$organisation$users$user"."identity_id" )
 				AND "user"."id" IN (?)
 			`,
-		expectedArgs: []any{"123", unverifiedIdentity.Id, "idToAuthorise"},
+		expectedArgs: []any{unverifiedIdentity.Id, "idToAuthorise"},
 		identity:     unverifiedIdentity,
 	},
 	{
@@ -1195,13 +1193,12 @@ var authorisationTestCases = []authorisationTestCase{
 			SELECT COUNT(DISTINCT "adult_film"."id") = 1 AS authorised
 			FROM "adult_film" 
 			WHERE 
-				"adult_film"."id" IS NOT DISTINCT FROM ? AND 
-					((SELECT "identity$user"."is_adult" 
+				((SELECT "identity$user"."is_adult" 
 					FROM "identity" 
 					LEFT JOIN "user" AS "identity$user" ON "identity$user"."identity_id" = "identity"."id" 
 					WHERE "identity"."id" IS NOT DISTINCT FROM ? AND "identity$user"."is_adult" IS DISTINCT FROM NULL) IS NOT DISTINCT FROM ?)
 				AND "adult_film"."id" IN (?)`,
-		expectedArgs: []any{"123", unverifiedIdentity.Id, true, "idToAuthorise"},
+		expectedArgs: []any{unverifiedIdentity.Id, true, "idToAuthorise"},
 		earlyAuth:    CouldNotAuthoriseEarly(),
 		identity:     unverifiedIdentity,
 	},
@@ -1232,13 +1229,12 @@ var authorisationTestCases = []authorisationTestCase{
 			LEFT JOIN "identity" AS "adult_film$identity" ON "adult_film$identity"."id" = "adult_film"."identity_id" 
 			LEFT JOIN "user" AS "adult_film$identity$user" ON "adult_film$identity$user"."identity_id" = "adult_film$identity"."id" 
 			WHERE 
-				"adult_film"."id" IS NOT DISTINCT FROM ? AND 
-					((SELECT "identity$user"."id" 
+				((SELECT "identity$user"."id" 
 					FROM "identity" 
 					LEFT JOIN "user" AS "identity$user" ON "identity$user"."identity_id" = "identity"."id" 
 					WHERE "identity"."id" IS NOT DISTINCT FROM ?  AND "identity$user"."id" IS DISTINCT FROM NULL) IS NOT DISTINCT FROM "adult_film$identity$user"."id")
 				AND "adult_film"."id" IN (?)`,
-		expectedArgs: []any{"123", unverifiedIdentity.Id, "idToAuthorise"},
+		expectedArgs: []any{unverifiedIdentity.Id, "idToAuthorise"},
 		earlyAuth:    CouldNotAuthoriseEarly(),
 		identity:     unverifiedIdentity,
 	},
@@ -1268,14 +1264,13 @@ var authorisationTestCases = []authorisationTestCase{
 			FROM "adult_film" 
 			LEFT JOIN "identity" AS "adult_film$identity" ON "adult_film$identity"."id" = "adult_film"."identity_id" 
 			LEFT JOIN "user" AS "adult_film$identity$user" ON "adult_film$identity$user"."identity_id" = "adult_film$identity"."id" 
-			WHERE 
-				"adult_film"."id" IS NOT DISTINCT FROM ? AND 
-					((SELECT "identity$user"."id" 
+			WHERE
+				((SELECT "identity$user"."id" 
 					FROM "identity" 
 					LEFT JOIN "user" AS "identity$user" ON "identity$user"."identity_id" = "identity"."id" 
 					WHERE "identity"."id" IS NOT DISTINCT FROM ?  AND "identity$user"."id" IS DISTINCT FROM NULL) IS NOT DISTINCT FROM "adult_film$identity$user"."id")
 				AND "adult_film"."id" IN (?)`,
-		expectedArgs: []any{"123", unverifiedIdentity.Id, "idToAuthorise"},
+		expectedArgs: []any{unverifiedIdentity.Id, "idToAuthorise"},
 		earlyAuth:    CouldNotAuthoriseEarly(),
 		identity:     unverifiedIdentity,
 	},
@@ -1304,11 +1299,10 @@ var authorisationTestCases = []authorisationTestCase{
 				COUNT(DISTINCT "bank_account"."id") = 1 AS authorised
 			FROM 
 				"bank_account" 
-			WHERE 
-				"bank_account"."id" IS NOT DISTINCT FROM ? AND 
+			WHERE
 				(? IS NOT DISTINCT FROM "bank_account"."identity_id")
 				AND "bank_account"."id" IN (?)`,
-		expectedArgs: []any{"123", unverifiedIdentity.Id, "idToAuthorise"},
+		expectedArgs: []any{unverifiedIdentity.Id, "idToAuthorise"},
 		earlyAuth:    CouldNotAuthoriseEarly(),
 		identity:     unverifiedIdentity,
 	},
@@ -1351,10 +1345,7 @@ var authorisationTestCases = []authorisationTestCase{
 				COUNT(DISTINCT "entity_user"."id") = 1 AS authorised
 			FROM 
 				"entity_user" 
-			LEFT JOIN 
-				"entity" AS "entity_user$entity" ON "entity_user$entity"."id" = "entity_user"."entity_id" 
-			WHERE 
-				"entity_user$entity"."id" IS NOT DISTINCT FROM ? AND 
+			WHERE
 				("entity_user"."id" IN 
 					(SELECT "identity$administrator$access$entity$users"."id" 
 					FROM "identity" 
@@ -1364,7 +1355,7 @@ var authorisationTestCases = []authorisationTestCase{
 					LEFT JOIN "entity_user" AS "identity$administrator$access$entity$users" ON "identity$administrator$access$entity$users"."entity_id" = "identity$administrator$access$entity"."id" 
 					WHERE "identity"."id" IS NOT DISTINCT FROM ? AND "identity$administrator$access$entity$users"."id" IS DISTINCT FROM NULL))
 				AND "entity_user"."id" IN (?)`,
-		expectedArgs: []any{"123", unverifiedIdentity.Id, "idToAuthorise"},
+		expectedArgs: []any{unverifiedIdentity.Id, "idToAuthorise"},
 		earlyAuth:    CouldNotAuthoriseEarly(),
 		identity:     unverifiedIdentity,
 	},
@@ -1406,11 +1397,8 @@ var authorisationTestCases = []authorisationTestCase{
 			SELECT 
 				COUNT(DISTINCT "entity_user"."id") = 1 AS authorised
 			FROM 
-				"entity_user" 
-			LEFT JOIN 
-				"entity" AS "entity_user$entity" ON "entity_user$entity"."id" = "entity_user"."entity_id" 
-			WHERE 
-				"entity_user$entity"."id" IS NOT DISTINCT FROM ? AND 
+				"entity_user"
+			WHERE
 				("entity_user"."id" IN 
 					(SELECT "identity$administrator$access$entity$users"."id" 
 					FROM "identity" 
@@ -1420,7 +1408,7 @@ var authorisationTestCases = []authorisationTestCase{
 					LEFT JOIN "entity_user" AS "identity$administrator$access$entity$users" ON "identity$administrator$access$entity$users"."entity_id" = "identity$administrator$access$entity"."id" 
 					WHERE "identity"."id" IS NOT DISTINCT FROM ? AND "identity$administrator$access$entity$users"."id" IS DISTINCT FROM NULL))
 				AND "entity_user"."id" IN (?)`,
-		expectedArgs: []any{"123", unverifiedIdentity.Id, "idToAuthorise"},
+		expectedArgs: []any{unverifiedIdentity.Id, "idToAuthorise"},
 		earlyAuth:    CouldNotAuthoriseEarly(),
 		identity:     unverifiedIdentity,
 	},


### PR DESCRIPTION
Permissions were blowing up in GraphQL relationships as the scope doesn't contain an action.

The actual fix here though is to remove the inclusion of explicit (`@where`) and implicit (inputs) filters from the permission query. @tomfrew and I discussed this and we feel this is correct.

Fundamentally permissions are _row based_ - meaning you are either **allowed to view a row or not**. By including the action inputs / where conditions you might _sometimes_ be able to view a row and other times not - which is weird.

The updated `identity_user_organisations` test was the only test that failed as a result of removing this, and so I've updated that test.

I've also added a quick graphql integration test - we should build these out to cover all the graphql specific stuff.

  