### PR TITLE
build: add support for identity backlinks to permissions package

### DIFF
--- a/integration/testdata/functions_permissions/functions/createAdmission.ts
+++ b/integration/testdata/functions_permissions/functions/createAdmission.ts
@@ -1,0 +1,14 @@
+import { models, CreateAdmission } from "@teamkeel/sdk";
+
+export default CreateAdmission({
+  async beforeWrite(ctx, inputs, values) {
+    const audience = await models.audience.findOne({
+      identityId: ctx.identity!.id,
+    });
+
+    return {
+      ...values,
+      audienceId: audience!.id,
+    };
+  },
+});

--- a/integration/testdata/functions_permissions/functions/createUser.ts
+++ b/integration/testdata/functions_permissions/functions/createUser.ts
@@ -1,0 +1,10 @@
+import { CreateUser } from "@teamkeel/sdk";
+
+export default CreateUser({
+  beforeWrite(ctx, inputs, values) {
+    return {
+      ...values,
+      identityId: ctx.identity!.id,
+    };
+  },
+});

--- a/integration/testdata/functions_permissions/functions/getUser.ts
+++ b/integration/testdata/functions_permissions/functions/getUser.ts
@@ -1,0 +1,3 @@
+import { GetUser } from "@teamkeel/sdk";
+
+export default GetUser({});

--- a/integration/testdata/functions_permissions/functions/listUsersByOrganisation.ts
+++ b/integration/testdata/functions_permissions/functions/listUsersByOrganisation.ts
@@ -1,0 +1,3 @@
+import { ListUsersByOrganisation } from "@teamkeel/sdk";
+
+export default ListUsersByOrganisation({});

--- a/integration/testdata/functions_permissions/main.test.ts
+++ b/integration/testdata/functions_permissions/main.test.ts
@@ -1,0 +1,185 @@
+import { Admission, Film, Identity } from "@teamkeel/sdk";
+import { models, actions, resetDatabase } from "@teamkeel/testing";
+import { test, expect, beforeEach } from "vitest";
+
+beforeEach(resetDatabase);
+
+test("many-to-many - can only view users that are in a shared org", async () => {
+  const meta = await models.organisation.create({
+    name: "Meta",
+  });
+  const netflix = await models.organisation.create({
+    name: "Netflix",
+  });
+  const microsoft = await models.organisation.create({
+    name: "Microsoft",
+  });
+
+  const identityAdam = await models.identity.create({
+    email: "adam@keel.xyz",
+    password: "foo",
+  });
+  const adam = await models.user.create({
+    name: "Adam",
+    identityId: identityAdam.id,
+  });
+
+  const identityDave = await models.identity.create({
+    email: "dave@keel.xyz",
+    password: "foo",
+  });
+  const dave = await models.user.create({
+    name: "Dave",
+    identityId: identityDave.id,
+  });
+
+  const identityTom = await models.identity.create({
+    email: "tom@keel.xyz",
+    password: "foo",
+  });
+  const tom = await models.user.create({
+    name: "Tom",
+    identityId: identityTom.id,
+  });
+
+  // Adam work at Meta and Microsoft
+  await models.userOrganisation.create({
+    orgId: meta.id,
+    userId: adam.id,
+  });
+  await models.userOrganisation.create({
+    orgId: microsoft.id,
+    userId: adam.id,
+  });
+
+  // Tom works at Meta
+  await models.userOrganisation.create({
+    orgId: meta.id,
+    userId: tom.id,
+  });
+
+  // Dave works at Netflix and Microsoft
+  await models.userOrganisation.create({
+    orgId: netflix.id,
+    userId: dave.id,
+  });
+  await models.userOrganisation.create({
+    orgId: microsoft.id,
+    userId: dave.id,
+  });
+
+  // Dave is trying to view the users of Microsoft, which are Dave + Adam.
+  // This is allowed as Dave shared an org with both of these users
+  const res = await actions.withIdentity(identityDave).listUsersByOrganisation({
+    where: {
+      orgs: {
+        org: { id: { equals: microsoft.id } },
+      },
+    },
+  });
+  expect(res.results.length).toBe(2);
+
+  // Dave is trying to view the users of Meta, which are Adam + Tom.
+  // Dave is allowed to view Adam, as they both work at Microsoft
+  // But Dave is NOT allowed to view Tom, as they do not work at any org together
+  // Because there are records that fail the permission rule (Tom) permission will be denied
+  await expect(
+    actions.withIdentity(identityDave).listUsersByOrganisation({
+      where: {
+        orgs: {
+          org: { id: { equals: meta.id } },
+        },
+      },
+    })
+  ).toHaveAuthorizationError();
+});
+
+test("boolean condition / multiple joins / >= condition", async () => {
+  const pulpFiction = await models.film.create({
+    title: "Pulp Fiction",
+    ageRestriction: 18,
+  });
+  const barbie = await models.film.create({
+    title: "Barbie",
+    ageRestriction: 12,
+  });
+  const shrek = await models.film.create({
+    title: "Shrek",
+    ageRestriction: 0,
+  });
+  const dailyMail = await models.publication.create({
+    name: "Daily Mail",
+  });
+  const timeout = await models.publication.create({
+    name: "Timeout",
+  });
+
+  const bob = await models.identity.create({
+    email: "bob@gmail.com",
+  });
+  await models.audience.create({
+    isCritic: false,
+    age: 22,
+    identityId: bob.id,
+  });
+
+  const mike = await models.identity.create({
+    email: "mike@gmail.com",
+  });
+  await models.audience.create({
+    isCritic: false,
+    age: 9,
+    identityId: mike.id,
+  });
+
+  const sally = await models.identity.create({
+    email: "sally@timeout.com",
+  });
+  await models.audience.create({
+    isCritic: true,
+    publicationId: timeout.id,
+    age: 17,
+    identityId: sally.id,
+  });
+
+  const kim = await models.identity.create({
+    email: "kim@dailymail.com",
+  });
+  await models.audience.create({
+    isCritic: true,
+    publicationId: dailyMail.id,
+    age: 15,
+    identityId: kim.id,
+  });
+
+  const createAdmission = (i: Identity, f: Film) =>
+    actions.withIdentity(i).createAdmission({
+      film: {
+        id: f.id,
+      },
+    });
+
+  // Bob can watch Pulp Fiction because he is old enough
+  await expect(createAdmission(bob, pulpFiction)).resolves.toBeTruthy();
+
+  // Sally can watch Pulp Fiction because although she is not old enough she is a critic
+  await expect(createAdmission(sally, pulpFiction)).resolves.toBeTruthy();
+
+  // Kim cannot watch Pulp Fiction because although she is a critic she works for the Daily Mail
+  await expect(createAdmission(kim, pulpFiction)).rejects.toEqual({
+    code: "ERR_PERMISSION_DENIED",
+    message: "not authorized to access this action",
+  });
+
+  // Kim can watch Barbie because she is old enough
+  await expect(createAdmission(kim, barbie)).resolves.toBeTruthy();
+
+  // Mike can watch Shrek because he is old enough
+  await expect(createAdmission(mike, shrek)).resolves.toBeTruthy();
+
+  // Mike cannot watch Barbie because he is too young
+  await expect(createAdmission(mike, barbie)).rejects.toEqual({
+    code: "ERR_PERMISSION_DENIED",
+    message: "not authorized to access this action",
+  });
+});

--- a/integration/testdata/functions_permissions/schema.keel
+++ b/integration/testdata/functions_permissions/schema.keel
@@ -1,0 +1,84 @@
+model User {
+    fields {
+        identity Identity @unique
+        name Text
+        orgs UserOrganisation[]
+    }
+
+    actions {
+        create createUser() with (name) @function
+        get getUser(id) @function
+        list listUsersByOrganisation(orgs.org.id) @function
+    }
+
+    @permission(
+        expression: ctx.identity == user.identity,
+        actions: [create, get]
+    )
+
+    @permission(
+        expression: ctx.identity.user in user.orgs.org.users.user,
+        actions: [get, list]
+    )
+}
+
+model Organisation {
+    fields {
+        name Text
+        users UserOrganisation[]
+    }
+}
+
+model UserOrganisation {
+    fields {
+        user User
+        org Organisation
+    }
+
+    @unique([user, org])
+}
+
+model Film {
+    fields {
+        title Text
+        ageRestriction Number
+    }
+}
+
+model Admission {
+    fields {
+        film Film
+        audience Audience
+    }
+
+    actions {
+        create createAdmission() with (film.id) @function
+    }
+
+    // Critics can always watch films, unless they work for the Daily Mail
+    @permission(
+        expression: ctx.identity.audience.isCritic and ctx.identity.audience.publication.name != "Daily Mail",
+        actions: [create]
+    )
+
+    // Otherwise the audience member needs to be old enough to view the film
+    @permission(
+        expression: ctx.identity.audience.age >= admission.film.ageRestriction,
+        actions: [create]
+    )
+}
+
+model Audience {
+    fields {
+        identity Identity @unique
+        isCritic Boolean
+        age Number
+        publication Publication?
+    }
+}
+
+model Publication {
+    fields {
+        name Text
+    }
+}


### PR DESCRIPTION
* Updated `permissions` package to support backlinks from `ctx.identity`
* Updated permissions tests
* Added quick integration test for function permissions that uses a backlink

I **strongly** feel that we should update the runtime permissions stuff to use the `permissions` package SQL generation so that we can be sure behaviour is the same between runtime and functions. Looking at the runtime code I don't think this should be too tricky as ultimately we just [execute some SQL](https://github.com/teamkeel/keel/blob/566acda51d3d2e833036e48311d08294f00e4414/runtime/actions/authorization.go#L85)