### PR TITLE
feat: set oneOf json schema property for id and string messages

### DIFF
--- a/runtime/jsonschema/jsonschema.go
+++ b/runtime/jsonschema/jsonschema.go
@@ -52,11 +52,12 @@ type JSONSchema struct {
 	Format string `json:"format,omitempty"`
 
 	// Validation for objects
-	Properties           map[string]JSONSchema `json:"properties,omitempty"`
-	AdditionalProperties *bool                 `json:"additionalProperties,omitempty"`
-	Required             []string              `json:"required,omitempty"`
-	OneOf                []JSONSchema          `json:"oneOf,omitempty"`
-	Title                string                `json:"title,omitempty"`
+	Properties            map[string]JSONSchema `json:"properties,omitempty"`
+	AdditionalProperties  *bool                 `json:"additionalProperties,omitempty"`
+	UnevaluatedProperties *bool                 `json:"unevaluatedProperties,omitempty"`
+	Required              []string              `json:"required,omitempty"`
+	OneOf                 []JSONSchema          `json:"oneOf,omitempty"`
+	Title                 string                `json:"title,omitempty"`
 
 	// For arrays
 	Items *JSONSchema `json:"items,omitempty"`
@@ -191,11 +192,11 @@ func JSONSchemaForMessage(ctx context.Context, schema *proto.Schema, action *pro
 
 				oneOfOption.Properties[field.Name] = prop
 				oneOfOption.Title = field.Name
+				oneOfOption.Required = append(oneOfOption.Required, field.Name)
+				// https://json-schema.org/understanding-json-schema/reference/object#unevaluatedproperties
+				root.UnevaluatedProperties = boolPtr(false)
+				root.AdditionalProperties = nil
 
-				// If the input is not optional then mark it required in the JSON schema
-				if !field.Optional {
-					oneOfOption.Required = append(oneOfOption.Required, field.Name)
-				}
 				oneOf = append(oneOf, oneOfOption)
 			}
 

--- a/runtime/jsonschema/jsonschema.go
+++ b/runtime/jsonschema/jsonschema.go
@@ -201,6 +201,7 @@ func JSONSchemaForMessage(ctx context.Context, schema *proto.Schema, action *pro
 			}
 
 			root.OneOf = oneOf
+			root.Type = nil
 
 		} else {
 			for _, field := range message.Fields {

--- a/runtime/jsonschema/jsonschema_test.go
+++ b/runtime/jsonschema/jsonschema_test.go
@@ -731,8 +731,8 @@ func TestValidateRequest(t *testing.T) {
 					opName:  "listBooks",
 					request: `{"where": {"id": null, "title": null, "genre": null, "price": null, "available": null, "createdAt": null}}`,
 					errors: map[string][]string{
-						"where.id":        {`Invalid type. Expected: object, given: null`},
-						"where.title":     {`Invalid type. Expected: object, given: null`},
+						"where.id":        {`Must validate one and only one schema (oneOf)`, `Invalid type. Expected: object, given: null`},
+						"where.title":     {`Must validate one and only one schema (oneOf)`, `Invalid type. Expected: object, given: null`},
 						"where.genre":     {`Invalid type. Expected: object, given: null`},
 						"where.price":     {`Invalid type. Expected: object, given: null`},
 						"where.available": {`Invalid type. Expected: object, given: null`},

--- a/runtime/jsonschema/jsonschema_test.go
+++ b/runtime/jsonschema/jsonschema_test.go
@@ -83,7 +83,7 @@ func TestValidateRequest(t *testing.T) {
 		name    string
 		opName  string
 		request string
-		errors  map[string]string
+		errors  map[string][]string
 	}
 
 	type fixtureGroup struct {
@@ -125,40 +125,40 @@ func TestValidateRequest(t *testing.T) {
 					name:    "missing input",
 					request: `{}`,
 					opName:  "getPerson",
-					errors: map[string]string{
-						"(root)": "id is required",
+					errors: map[string][]string{
+						"(root)": {"id is required"},
 					},
 				},
 				{
 					name:    "wrong type",
 					request: `{"id": 1234}`,
 					opName:  "getPerson",
-					errors: map[string]string{
-						"id": "Invalid type. Expected: string, given: integer",
+					errors: map[string][]string{
+						"id": {"Invalid type. Expected: string, given: integer"},
 					},
 				},
 				{
 					name:    "null",
 					request: `{"id": null}`,
 					opName:  "getPerson",
-					errors: map[string]string{
-						"id": "Invalid type. Expected: string, given: null",
+					errors: map[string][]string{
+						"id": {"Invalid type. Expected: string, given: null"},
 					},
 				},
 				{
 					name:    "valid inputs with additional properties",
 					request: `{"id": "1234", "foo": "bar"}`,
 					opName:  "getPerson",
-					errors: map[string]string{
-						"(root)": "Additional property foo is not allowed",
+					errors: map[string][]string{
+						"(root)": {"Additional property foo is not allowed"},
 					},
 				},
 				{
 					name:    "additional properties when no inputs expected",
 					request: `{"id": "1234"}`,
 					opName:  "getBestBeatle",
-					errors: map[string]string{
-						"(root)": "Additional property id is not allowed",
+					errors: map[string][]string{
+						"(root)": {"Additional property id is not allowed"},
 					},
 				},
 			},
@@ -195,40 +195,40 @@ func TestValidateRequest(t *testing.T) {
 					name:    "missing input",
 					request: `{}`,
 					opName:  "deletePerson",
-					errors: map[string]string{
-						"(root)": "id is required",
+					errors: map[string][]string{
+						"(root)": {"id is required"},
 					},
 				},
 				{
 					name:    "wrong type",
 					request: `{"id": 1234}`,
 					opName:  "deletePerson",
-					errors: map[string]string{
-						"id": "Invalid type. Expected: string, given: integer",
+					errors: map[string][]string{
+						"id": {"Invalid type. Expected: string, given: integer"},
 					},
 				},
 				{
 					name:    "null",
 					request: `{"id": null}`,
 					opName:  "deletePerson",
-					errors: map[string]string{
-						"id": "Invalid type. Expected: string, given: null",
+					errors: map[string][]string{
+						"id": {"Invalid type. Expected: string, given: null"},
 					},
 				},
 				{
 					name:    "valid inputs with additional properties",
 					request: `{"id": "1234", "foo": "bar"}`,
 					opName:  "deletePerson",
-					errors: map[string]string{
-						"(root)": "Additional property foo is not allowed",
+					errors: map[string][]string{
+						"(root)": {"Additional property foo is not allowed"},
 					},
 				},
 				{
 					name:    "additional properties when no inputs expected",
 					request: `{"id": "1234"}`,
 					opName:  "deleteBob",
-					errors: map[string]string{
-						"(root)": "Additional property id is not allowed",
+					errors: map[string][]string{
+						"(root)": {"Additional property id is not allowed"},
 					},
 				},
 			},
@@ -313,64 +313,64 @@ func TestValidateRequest(t *testing.T) {
 					name:    "missing input",
 					request: `{}`,
 					opName:  "createPerson",
-					errors: map[string]string{
-						"(root)": "name is required",
+					errors: map[string][]string{
+						"(root)": {"name is required"},
 					},
 				},
 				{
 					name:    "missing required enum on optional field",
 					request: `{}`,
 					opName:  "createPersonWithEnum",
-					errors: map[string]string{
-						"(root)": "hobby is required",
+					errors: map[string][]string{
+						"(root)": {"hobby is required"},
 					},
 				},
 				{
 					name:    "missing required input on optional field",
 					request: `{"name": "Jon"}`,
 					opName:  "createPersonWithDob",
-					errors: map[string]string{
-						"(root)": "birthday is required",
+					errors: map[string][]string{
+						"(root)": {"birthday is required"},
 					},
 				},
 				{
 					name:    "null",
 					request: `{"name": null}`,
 					opName:  "createPerson",
-					errors: map[string]string{
-						"name": "Invalid type. Expected: string, given: null",
+					errors: map[string][]string{
+						"name": {"Invalid type. Expected: string, given: null"},
 					},
 				},
 				{
 					name:    "wrong type",
 					request: `{"name": 1234}`,
 					opName:  "createPerson",
-					errors: map[string]string{
-						"name": "Invalid type. Expected: string, given: integer",
+					errors: map[string][]string{
+						"name": {"Invalid type. Expected: string, given: integer"},
 					},
 				},
 				{
 					name:    "wrong format for date",
 					request: `{"name": "Jon", "birthday": "18th March 1986"}`,
 					opName:  "createPersonWithDob",
-					errors: map[string]string{
-						"birthday": "Does not match format 'date'",
+					errors: map[string][]string{
+						"birthday": {"Does not match format 'date'"},
 					},
 				},
 				{
 					name:    "providing ISO8601 time format for a Date",
 					request: `{"name": "Jon", "birthday": "12:01:00Z"}`,
 					opName:  "createPersonWithOptionalDob",
-					errors: map[string]string{
-						"birthday": "Does not match format 'date'",
+					errors: map[string][]string{
+						"birthday": {"Does not match format 'date'"},
 					},
 				},
 				{
 					name:    "additional properties",
 					request: `{"name": "Bob", "foo": "bar"}`,
 					opName:  "createPerson",
-					errors: map[string]string{
-						"(root)": "Additional property foo is not allowed",
+					errors: map[string][]string{
+						"(root)": {"Additional property foo is not allowed"},
 					},
 				},
 			},
@@ -450,32 +450,32 @@ func TestValidateRequest(t *testing.T) {
 					name:    "missing required value",
 					request: `{"where": {"id": "1234"}, "values": {}}`,
 					opName:  "updateName",
-					errors: map[string]string{
-						"values": "name is required",
+					errors: map[string][]string{
+						"values": {"name is required"},
 					},
 				},
 				{
 					name:    "missing required where",
 					request: `{"where": {}, "values": {"name": "Jon"}}`,
 					opName:  "updateName",
-					errors: map[string]string{
-						"where": "id is required",
+					errors: map[string][]string{
+						"where": {"id is required"},
 					},
 				},
 				{
 					name:    "incorrect type for value",
 					request: `{"where": {"id": "1234"}, "values": {"name": true}}`,
 					opName:  "updateName",
-					errors: map[string]string{
-						"values.name": "Invalid type. Expected: string, given: boolean",
+					errors: map[string][]string{
+						"values.name": {"Invalid type. Expected: string, given: boolean"},
 					},
 				},
 				{
 					name:    "incorrect type for where",
 					request: `{"where": {"id": 1234}, "values": {"name": "Jon"}}`,
 					opName:  "updateName",
-					errors: map[string]string{
-						"where.id": "Invalid type. Expected: string, given: integer",
+					errors: map[string][]string{
+						"where.id": {"Invalid type. Expected: string, given: integer"},
 					},
 				},
 			},
@@ -530,6 +530,11 @@ func TestValidateRequest(t *testing.T) {
 					request: `{"where": {}}`,
 				},
 				{
+					name:    "valid - id equals",
+					opName:  "listBooks",
+					request: `{"where": {"id": {"equals": "1234"}}}`,
+				},
+				{
 					name:    "valid - text equals",
 					opName:  "listBooks",
 					request: `{"where": {"title": {"equals": "Great Gatsby"}}}`,
@@ -559,11 +564,11 @@ func TestValidateRequest(t *testing.T) {
 					opName:  "listBooks",
 					request: `{"where": {"title": {"oneOf": ["Great Gatsby", "Ulysses"]}}}`,
 				},
-				{
-					name:    "valid - text multi",
-					opName:  "listBooks",
-					request: `{"where": {"title": {"startsWith": "Great", "endsWith": "Gatsby"}}}`,
-				},
+				// {
+				// 	name:    "valid - text multi",
+				// 	opName:  "listBooks",
+				// 	request: `{"where": {"title": {"startsWith": "Great", "endsWith": "Gatsby"}}}`,
+				// },
 				{
 					name:    "valid - enum equals",
 					opName:  "listBooks",
@@ -700,95 +705,95 @@ func TestValidateRequest(t *testing.T) {
 					name:    "invalid sort direction",
 					opName:  "listBooks",
 					request: `{"orderBy": [{"title":"asc"},{"genre":"down"}]}`,
-					errors: map[string]string{
-						"orderBy.1":       `Must validate one and only one schema (oneOf)`,
-						"orderBy.1.genre": `orderBy.1.genre must be one of the following: "asc", "desc"`,
+					errors: map[string][]string{
+						"orderBy.1":       {`Must validate one and only one schema (oneOf)`},
+						"orderBy.1.genre": {`orderBy.1.genre must be one of the following: "asc", "desc"`},
 					},
 				},
 				{
 					name:    "nullable nested model list field as null",
 					opName:  "listBooksByPublisherDateFounded",
 					request: `{"where": {"author": { "publisher": { "dateFounded": null}}}}`,
-					errors: map[string]string{
-						"where.author.publisher.dateFounded": `Invalid type. Expected: object, given: null`,
+					errors: map[string][]string{
+						"where.author.publisher.dateFounded": {`Invalid type. Expected: object, given: null`},
 					},
 				},
 				{
 					name:    "missing required input targeting optional field",
 					opName:  "listBooksByPublisherDateFounded",
 					request: `{"where": { }}`,
-					errors: map[string]string{
-						"where": `author is required`,
+					errors: map[string][]string{
+						"where": {`author is required`},
 					},
 				},
 				{
 					name:    "optional inputs cannot be null when fields are required",
 					opName:  "listBooks",
 					request: `{"where": {"id": null, "title": null, "genre": null, "price": null, "available": null, "createdAt": null}}`,
-					errors: map[string]string{
-						"where.id":        `Invalid type. Expected: object, given: null`,
-						"where.title":     `Invalid type. Expected: object, given: null`,
-						"where.genre":     `Invalid type. Expected: object, given: null`,
-						"where.price":     `Invalid type. Expected: object, given: null`,
-						"where.available": `Invalid type. Expected: object, given: null`,
-						"where.createdAt": `Invalid type. Expected: object, given: null`,
+					errors: map[string][]string{
+						"where.id":        {`Invalid type. Expected: object, given: null`},
+						"where.title":     {`Invalid type. Expected: object, given: null`},
+						"where.genre":     {`Invalid type. Expected: object, given: null`},
+						"where.price":     {`Invalid type. Expected: object, given: null`},
+						"where.available": {`Invalid type. Expected: object, given: null`},
+						"where.createdAt": {`Invalid type. Expected: object, given: null`},
 					},
 				},
 				{
 					name:    "text unknown filter",
 					opName:  "listBooks",
 					request: `{"where": {"title": {"isSimilarTo": "Sci-fi"}}}`,
-					errors: map[string]string{
-						"where.title": `Additional property isSimilarTo is not allowed`,
+					errors: map[string][]string{
+						"where.title": {`Must validate one and only one schema (oneOf)`, `Additional property isSimilarTo is not allowed`, `equals is required`},
 					},
 				},
 				{
 					name:    "enum equals not valid enum",
 					opName:  "listBooks",
 					request: `{"where": {"genre": {"equals": "Sci-fi"}}}`,
-					errors: map[string]string{
-						"where.genre.equals": `where.genre.equals must be one of the following: "Romance", "Horror", null`,
+					errors: map[string][]string{
+						"where.genre.equals": {`where.genre.equals must be one of the following: "Romance", "Horror", null`},
 					},
 				},
 				{
 					name:    "enum one of not valid enum",
 					opName:  "listBooks",
 					request: `{"where": {"genre": {"oneOf": ["Sci-fi"]}}}`,
-					errors: map[string]string{
-						"where.genre.oneOf.0": `where.genre.oneOf.0 must be one of the following: "Romance", "Horror"`,
+					errors: map[string][]string{
+						"where.genre.oneOf.0": {`where.genre.oneOf.0 must be one of the following: "Romance", "Horror"`},
 					},
 				},
 				{
 					name:    "timestamp invalid format",
 					opName:  "listBooks",
 					request: `{"where": {"createdAt": {"after": "not-a-date-time"}}}`,
-					errors: map[string]string{
-						"where.createdAt.after": `Does not match format 'date-time'`,
+					errors: map[string][]string{
+						"where.createdAt.after": {`Does not match format 'date-time'`},
 					},
 				},
 				{
 					name:    "date invalid format with only time component",
 					opName:  "listBooks",
 					request: `{"where": {"releaseDate": {"after": "12:00:00Z"}}}`,
-					errors: map[string]string{
-						"where.releaseDate.after": `Does not match format 'date'`,
+					errors: map[string][]string{
+						"where.releaseDate.after": {`Does not match format 'date'`},
 					},
 				},
 				{
 					name:    "date invalid format",
 					opName:  "listBooks",
 					request: `{"where": {"releaseDate": {"after": "not-a-date-time"}}}`,
-					errors: map[string]string{
-						"where.releaseDate.after": `Does not match format 'date'`,
+					errors: map[string][]string{
+						"where.releaseDate.after": {`Does not match format 'date'`},
 					},
 				},
 				{
 					name:    "using invalid query types for explicit filters",
 					opName:  "booksByTitleAndGenre",
 					request: `{"where": {"title": {"contains": "Some title"}, "genre": {"equals": "Romance"}}}`,
-					errors: map[string]string{
-						"where.title": `Invalid type. Expected: string, given: object`,
-						"where.genre": `where.genre must be one of the following: "Romance", "Horror"`,
+					errors: map[string][]string{
+						"where.title": {`Invalid type. Expected: string, given: object`},
+						"where.genre": {`where.genre must be one of the following: "Romance", "Horror"`},
 					},
 				},
 			},
@@ -913,8 +918,13 @@ func TestValidateRequest(t *testing.T) {
 						continue
 					}
 
-					assert.Equal(t, expected, e.Description(), "error for path %s did not match expected", jsonPath)
-					delete(f.errors, jsonPath)
+					assert.Contains(t, expected, e.Description(), "error for path %s did not contain expected error", jsonPath)
+
+					if len(expected) > 1 {
+						f.errors[jsonPath] = deleteMatch(expected, e.Description())
+					} else {
+						delete(f.errors, jsonPath)
+					}
 				}
 
 				// f.errors should now be empty, if not mark test as failed
@@ -925,4 +935,14 @@ func TestValidateRequest(t *testing.T) {
 		}
 	}
 
+}
+
+func deleteMatch(slice []string, match string) []string {
+	var result []string
+	for _, v := range slice {
+		if v != match {
+			result = append(result, v)
+		}
+	}
+	return result
 }

--- a/runtime/jsonschema/testdata/list.json
+++ b/runtime/jsonschema/testdata/list.json
@@ -1,214 +1,310 @@
 {
-	"type": "object",
-	"properties": {
-		"after": {
-			"type": "string"
-		},
-		"before": {
-			"type": "string"
-		},
-		"first": {
-			"type": "number"
-		},
-		"last": {
-			"type": "number"
-		},
-		"where": {
-			"$ref": "#/components/schemas/TestActionWhere"
-		}
-	},
-	"additionalProperties": false,
-	"required": ["where"],
-	"components": {
-		"schemas": {
-			"BooleanQueryInput": {
-				"type": "object",
-				"properties": {
-					"equals": {
-						"type": ["boolean", "null"]
-					},
-					"notEquals": {
-						"type": ["boolean", "null"]
-					}
-				},
-				"additionalProperties": false
-			},
-			"DateQueryInput": {
-				"type": "object",
-				"properties": {
-					"after": {
-						"type": "string",
-						"format": "date"
-					},
-					"before": {
-						"type": "string",
-						"format": "date"
-					},
-					"equals": {
-						"type": ["string", "null"],
-						"format": "date"
-					},
-					"notEquals": {
-						"type": ["string", "null"],
-						"format": "date"
-					},
-					"onOrAfter": {
-						"type": "string",
-						"format": "date"
-					},
-					"onOrBefore": {
-						"type": "string",
-						"format": "date"
-					}
-				},
-				"additionalProperties": false
-			},
-			"HobbyQueryInput": {
-				"type": "object",
-				"properties": {
-					"equals": {
-						"enum": ["Tennis", "Chess", null]
-					},
-					"notEquals": {
-						"enum": ["Tennis", "Chess", null]
-					},
-					"oneOf": {
-						"type": "array",
-						"items": {
-							"enum": ["Tennis", "Chess"]
-						}
-					}
-				},
-				"additionalProperties": false
-			},
-			"IntQueryInput": {
-				"type": "object",
-				"properties": {
-					"equals": {
-						"type": ["number", "null"]
-					},
-					"greaterThan": {
-						"type": "number"
-					},
-					"greaterThanOrEquals": {
-						"type": "number"
-					},
-					"lessThan": {
-						"type": "number"
-					},
-					"lessThanOrEquals": {
-						"type": "number"
-					},
-					"notEquals": {
-						"type": ["number", "null"]
-					},
-					"oneOf": {
-						"type": "array",
-						"items": {
-							"type": "number"
-						}
-					}
-				},
-				"additionalProperties": false
-			},
-			"StringQueryInput": {
-				"type": "object",
-				"properties": {
-					"contains": {
-						"type": "string"
-					},
-					"endsWith": {
-						"type": "string"
-					},
-					"equals": {
-						"type": ["string", "null"]
-					},
-					"notEquals": {
-						"type": ["string", "null"]
-					},
-					"oneOf": {
-						"type": "array",
-						"items": {
-							"type": "string"
-						}
-					},
-					"startsWith": {
-						"type": "string"
-					}
-				},
-				"additionalProperties": false
-			},
-			"TestActionCurrentCityInput": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"$ref": "#/components/schemas/StringQueryInput"
-					}
-				},
-				"additionalProperties": false,
-				"required": ["name"]
-			},
-			"TestActionPreviousCityInput": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"$ref": "#/components/schemas/StringQueryInput"
-					}
-				},
-				"additionalProperties": false,
-				"required": ["name"]
-			},
-			"TestActionWhere": {
-				"type": "object",
-				"properties": {
-					"birthday": {
-						"$ref": "#/components/schemas/DateQueryInput"
-					},
-					"currentCity": {
-						"$ref": "#/components/schemas/TestActionCurrentCityInput"
-					},
-					"favouriteNumber": {
-						"$ref": "#/components/schemas/IntQueryInput"
-					},
-					"hobby": {
-						"$ref": "#/components/schemas/HobbyQueryInput"
-					},
-					"isAdmin": {
-						"$ref": "#/components/schemas/BooleanQueryInput"
-					},
-					"lastSeenAt": {
-						"$ref": "#/components/schemas/TimestampQueryInput"
-					},
-					"name": {
-						"$ref": "#/components/schemas/StringQueryInput"
-					},
-					"preferredName": {
-						"$ref": "#/components/schemas/StringQueryInput"
-					},
-					"previousCity": {
-						"$ref": "#/components/schemas/TestActionPreviousCityInput"
-					},
-					"secondHobby": {
-						"$ref": "#/components/schemas/HobbyQueryInput"
-					}
-				},
-				"additionalProperties": false,
-				"required": ["name", "preferredName", "favouriteNumber", "birthday", "hobby", "secondHobby", "isAdmin", "lastSeenAt", "currentCity", "previousCity"]
-			},
-			"TimestampQueryInput": {
-				"type": "object",
-				"properties": {
-					"after": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"before": {
-						"type": "string",
-						"format": "date-time"
-					}
-				},
-				"additionalProperties": false
-			}
-		}
-	}
+  "type": "object",
+  "properties": {
+    "after": {
+      "type": "string"
+    },
+    "before": {
+      "type": "string"
+    },
+    "first": {
+      "type": "number"
+    },
+    "last": {
+      "type": "number"
+    },
+    "where": {
+      "$ref": "#/components/schemas/TestActionWhere"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["where"],
+  "components": {
+    "schemas": {
+      "BooleanQueryInput": {
+        "type": "object",
+        "properties": {
+          "equals": {
+            "type": ["boolean", "null"]
+          },
+          "notEquals": {
+            "type": ["boolean", "null"]
+          }
+        },
+        "additionalProperties": false
+      },
+      "DateQueryInput": {
+        "type": "object",
+        "properties": {
+          "after": {
+            "type": "string",
+            "format": "date"
+          },
+          "before": {
+            "type": "string",
+            "format": "date"
+          },
+          "equals": {
+            "type": ["string", "null"],
+            "format": "date"
+          },
+          "notEquals": {
+            "type": ["string", "null"],
+            "format": "date"
+          },
+          "onOrAfter": {
+            "type": "string",
+            "format": "date"
+          },
+          "onOrBefore": {
+            "type": "string",
+            "format": "date"
+          }
+        },
+        "additionalProperties": false
+      },
+      "HobbyQueryInput": {
+        "type": "object",
+        "properties": {
+          "equals": {
+            "enum": ["Tennis", "Chess", null]
+          },
+          "notEquals": {
+            "enum": ["Tennis", "Chess", null]
+          },
+          "oneOf": {
+            "type": "array",
+            "items": {
+              "enum": ["Tennis", "Chess"]
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "IdQueryInput": {
+        "additionalProperties": false,
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "equals": {
+                "type": ["string", "null"]
+              }
+            },
+            "title": "equals",
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "oneOf": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "title": "oneOf",
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "notEquals": {
+                "type": ["string", "null"]
+              }
+            },
+            "title": "notEquals",
+            "type": "object"
+          }
+        ],
+        "type": "object"
+      },
+      "IntQueryInput": {
+        "type": "object",
+        "properties": {
+          "equals": {
+            "type": ["number", "null"]
+          },
+          "greaterThan": {
+            "type": "number"
+          },
+          "greaterThanOrEquals": {
+            "type": "number"
+          },
+          "lessThan": {
+            "type": "number"
+          },
+          "lessThanOrEquals": {
+            "type": "number"
+          },
+          "notEquals": {
+            "type": ["number", "null"]
+          },
+          "oneOf": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "StringQueryInput": {
+        "type": "object",
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "equals": {
+                "type": ["string", "null"]
+              }
+            },
+            "title": "equals",
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "notEquals": {
+                "type": ["string", "null"]
+              }
+            },
+            "title": "notEquals",
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "startsWith": {
+                "type": "string"
+              }
+            },
+            "title": "startsWith",
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "endsWith": {
+                "type": "string"
+              }
+            },
+            "title": "endsWith",
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "contains": {
+                "type": "string"
+              }
+            },
+            "title": "contains",
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "oneOf": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "title": "oneOf",
+            "type": "object"
+          }
+        ],
+        "additionalProperties": false
+      },
+      "TestActionCurrentCityInput": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "$ref": "#/components/schemas/StringQueryInput"
+          }
+        },
+        "additionalProperties": false,
+        "required": ["name"]
+      },
+      "TestActionPreviousCityInput": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "$ref": "#/components/schemas/StringQueryInput"
+          }
+        },
+        "additionalProperties": false,
+        "required": ["name"]
+      },
+      "TestActionWhere": {
+        "type": "object",
+        "properties": {
+          "birthday": {
+            "$ref": "#/components/schemas/DateQueryInput"
+          },
+          "currentCity": {
+            "$ref": "#/components/schemas/TestActionCurrentCityInput"
+          },
+          "favouriteNumber": {
+            "$ref": "#/components/schemas/IntQueryInput"
+          },
+          "hobby": {
+            "$ref": "#/components/schemas/HobbyQueryInput"
+          },
+          "id": {
+            "$ref": "#/components/schemas/IdQueryInput"
+          },
+          "isAdmin": {
+            "$ref": "#/components/schemas/BooleanQueryInput"
+          },
+          "lastSeenAt": {
+            "$ref": "#/components/schemas/TimestampQueryInput"
+          },
+          "name": {
+            "$ref": "#/components/schemas/StringQueryInput"
+          },
+          "preferredName": {
+            "$ref": "#/components/schemas/StringQueryInput"
+          },
+          "previousCity": {
+            "$ref": "#/components/schemas/TestActionPreviousCityInput"
+          },
+          "secondHobby": {
+            "$ref": "#/components/schemas/HobbyQueryInput"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "name",
+          "preferredName",
+          "favouriteNumber",
+          "birthday",
+          "hobby",
+          "secondHobby",
+          "isAdmin",
+          "lastSeenAt",
+          "currentCity",
+          "previousCity"
+        ]
+      },
+      "TimestampQueryInput": {
+        "type": "object",
+        "properties": {
+          "after": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "before": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
 }

--- a/runtime/jsonschema/testdata/list.json
+++ b/runtime/jsonschema/testdata/list.json
@@ -82,7 +82,7 @@
         "additionalProperties": false
       },
       "IdQueryInput": {
-        "additionalProperties": false,
+        "unevaluatedProperties": false,
         "oneOf": [
           {
             "additionalProperties": false,
@@ -91,6 +91,7 @@
                 "type": ["string", "null"]
               }
             },
+            "required": ["equals"],
             "title": "equals",
             "type": "object"
           },
@@ -104,6 +105,7 @@
                 "type": "array"
               }
             },
+            "required": ["oneOf"],
             "title": "oneOf",
             "type": "object"
           },
@@ -114,6 +116,7 @@
                 "type": ["string", "null"]
               }
             },
+            "required": ["notEquals"],
             "title": "notEquals",
             "type": "object"
           }
@@ -152,6 +155,7 @@
       },
       "StringQueryInput": {
         "type": "object",
+        "unevaluatedProperties": false,
         "oneOf": [
           {
             "additionalProperties": false,
@@ -160,6 +164,7 @@
                 "type": ["string", "null"]
               }
             },
+            "required": ["equals"],
             "title": "equals",
             "type": "object"
           },
@@ -170,6 +175,7 @@
                 "type": ["string", "null"]
               }
             },
+            "required": ["notEquals"],
             "title": "notEquals",
             "type": "object"
           },
@@ -180,6 +186,7 @@
                 "type": "string"
               }
             },
+            "required": ["startsWith"],
             "title": "startsWith",
             "type": "object"
           },
@@ -190,6 +197,7 @@
                 "type": "string"
               }
             },
+            "required": ["endsWith"],
             "title": "endsWith",
             "type": "object"
           },
@@ -200,6 +208,7 @@
                 "type": "string"
               }
             },
+            "required": ["contains"],
             "title": "contains",
             "type": "object"
           },
@@ -213,11 +222,11 @@
                 "type": "array"
               }
             },
+            "required": ["oneOf"],
             "title": "oneOf",
             "type": "object"
           }
-        ],
-        "additionalProperties": false
+        ]
       },
       "TestActionCurrentCityInput": {
         "type": "object",

--- a/runtime/jsonschema/testdata/list.json
+++ b/runtime/jsonschema/testdata/list.json
@@ -120,8 +120,7 @@
             "title": "notEquals",
             "type": "object"
           }
-        ],
-        "type": "object"
+        ]
       },
       "IntQueryInput": {
         "type": "object",
@@ -154,7 +153,6 @@
         "additionalProperties": false
       },
       "StringQueryInput": {
-        "type": "object",
         "unevaluatedProperties": false,
         "oneOf": [
           {

--- a/runtime/jsonschema/testdata/list.keel
+++ b/runtime/jsonschema/testdata/list.keel
@@ -24,6 +24,6 @@ model Person {
     }
 
     actions {
-        list testAction(name, preferredName, favouriteNumber, birthday, hobby, secondHobby, isAdmin, lastSeenAt, currentCity.name, previousCity.name)
+        list testAction(id, name, preferredName, favouriteNumber, birthday, hobby, secondHobby, isAdmin, lastSeenAt, currentCity.name, previousCity.name)
     }
 }

--- a/runtime/jsonschema/testdata/list_on_related_field.json
+++ b/runtime/jsonschema/testdata/list_on_related_field.json
@@ -1,76 +1,118 @@
 {
-	"type": "object",
-	"properties": {
-		"after": {
-			"type": "string"
-		},
-		"before": {
-			"type": "string"
-		},
-		"first": {
-			"type": "number"
-		},
-		"last": {
-			"type": "number"
-		},
-		"where": {
-			"$ref": "#/components/schemas/TestActionWhere"
-		}
-	},
-	"additionalProperties": false,
-	"required": ["where"],
-	"components": {
-		"schemas": {
-			"StringQueryInput": {
-				"type": "object",
-				"properties": {
-					"contains": {
-						"type": "string"
-					},
-					"endsWith": {
-						"type": "string"
-					},
-					"equals": {
-						"type": ["string", "null"]
-					},
-					"notEquals": {
-						"type": ["string", "null"]
-					},
-					"oneOf": {
-						"type": "array",
-						"items": {
-							"type": "string"
-						}
-					},
-					"startsWith": {
-						"type": "string"
-					}
-				},
-				"additionalProperties": false
-			},
-			"TestActionCompanyInput": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"$ref": "#/components/schemas/StringQueryInput"
-					},
-					"tradingAs": {
-						"$ref": "#/components/schemas/StringQueryInput"
-					}
-				},
-				"additionalProperties": false,
-				"required": ["name", "tradingAs"]
-			},
-			"TestActionWhere": {
-				"type": "object",
-				"properties": {
-					"company": {
-						"$ref": "#/components/schemas/TestActionCompanyInput"
-					}
-				},
-				"additionalProperties": false,
-				"required": ["company"]
-			}
-		}
-	}
+  "type": "object",
+  "properties": {
+    "after": {
+      "type": "string"
+    },
+    "before": {
+      "type": "string"
+    },
+    "first": {
+      "type": "number"
+    },
+    "last": {
+      "type": "number"
+    },
+    "where": {
+      "$ref": "#/components/schemas/TestActionWhere"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["where"],
+  "components": {
+    "schemas": {
+      "StringQueryInput": {
+        "type": "object",
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "equals": {
+                "type": ["string", "null"]
+              }
+            },
+            "title": "equals",
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "notEquals": {
+                "type": ["string", "null"]
+              }
+            },
+            "title": "notEquals",
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "startsWith": {
+                "type": "string"
+              }
+            },
+            "title": "startsWith",
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "endsWith": {
+                "type": "string"
+              }
+            },
+            "title": "endsWith",
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "contains": {
+                "type": "string"
+              }
+            },
+            "title": "contains",
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "oneOf": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "title": "oneOf",
+            "type": "object"
+          }
+        ],
+        "additionalProperties": false
+      },
+      "TestActionCompanyInput": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "$ref": "#/components/schemas/StringQueryInput"
+          },
+          "tradingAs": {
+            "$ref": "#/components/schemas/StringQueryInput"
+          }
+        },
+        "additionalProperties": false,
+        "required": ["name", "tradingAs"]
+      },
+      "TestActionWhere": {
+        "type": "object",
+        "properties": {
+          "company": {
+            "$ref": "#/components/schemas/TestActionCompanyInput"
+          }
+        },
+        "additionalProperties": false,
+        "required": ["company"]
+      }
+    }
+  }
 }

--- a/runtime/jsonschema/testdata/list_on_related_field.json
+++ b/runtime/jsonschema/testdata/list_on_related_field.json
@@ -22,7 +22,6 @@
   "components": {
     "schemas": {
       "StringQueryInput": {
-        "type": "object",
         "unevaluatedProperties": false,
         "oneOf": [
           {

--- a/runtime/jsonschema/testdata/list_on_related_field.json
+++ b/runtime/jsonschema/testdata/list_on_related_field.json
@@ -23,6 +23,7 @@
     "schemas": {
       "StringQueryInput": {
         "type": "object",
+        "unevaluatedProperties": false,
         "oneOf": [
           {
             "additionalProperties": false,
@@ -31,6 +32,7 @@
                 "type": ["string", "null"]
               }
             },
+            "required": ["equals"],
             "title": "equals",
             "type": "object"
           },
@@ -41,6 +43,7 @@
                 "type": ["string", "null"]
               }
             },
+            "required": ["notEquals"],
             "title": "notEquals",
             "type": "object"
           },
@@ -51,6 +54,7 @@
                 "type": "string"
               }
             },
+            "required": ["startsWith"],
             "title": "startsWith",
             "type": "object"
           },
@@ -61,6 +65,7 @@
                 "type": "string"
               }
             },
+            "required": ["endsWith"],
             "title": "endsWith",
             "type": "object"
           },
@@ -71,6 +76,7 @@
                 "type": "string"
               }
             },
+            "required": ["contains"],
             "title": "contains",
             "type": "object"
           },
@@ -84,11 +90,11 @@
                 "type": "array"
               }
             },
+            "required": ["oneOf"],
             "title": "oneOf",
             "type": "object"
           }
-        ],
-        "additionalProperties": false
+        ]
       },
       "TestActionCompanyInput": {
         "type": "object",

--- a/runtime/jsonschema/testdata/list_optional_inputs.json
+++ b/runtime/jsonschema/testdata/list_optional_inputs.json
@@ -21,7 +21,6 @@
   "components": {
     "schemas": {
       "StringQueryInput": {
-        "type": "object",
         "unevaluatedProperties": false,
         "oneOf": [
           {

--- a/runtime/jsonschema/testdata/list_optional_inputs.json
+++ b/runtime/jsonschema/testdata/list_optional_inputs.json
@@ -22,6 +22,7 @@
     "schemas": {
       "StringQueryInput": {
         "type": "object",
+        "unevaluatedProperties": false,
         "oneOf": [
           {
             "additionalProperties": false,
@@ -30,6 +31,7 @@
                 "type": ["string", "null"]
               }
             },
+            "required": ["equals"],
             "title": "equals",
             "type": "object"
           },
@@ -40,6 +42,7 @@
                 "type": ["string", "null"]
               }
             },
+            "required": ["notEquals"],
             "title": "notEquals",
             "type": "object"
           },
@@ -50,6 +53,7 @@
                 "type": "string"
               }
             },
+            "required": ["startsWith"],
             "title": "startsWith",
             "type": "object"
           },
@@ -60,6 +64,7 @@
                 "type": "string"
               }
             },
+            "required": ["endsWith"],
             "title": "endsWith",
             "type": "object"
           },
@@ -70,6 +75,7 @@
                 "type": "string"
               }
             },
+            "required": ["contains"],
             "title": "contains",
             "type": "object"
           },
@@ -83,11 +89,11 @@
                 "type": "array"
               }
             },
+            "required": ["oneOf"],
             "title": "oneOf",
             "type": "object"
           }
-        ],
-        "additionalProperties": false
+        ]
       },
       "TestActionCompanyInput": {
         "type": "object",

--- a/runtime/jsonschema/testdata/list_optional_inputs.json
+++ b/runtime/jsonschema/testdata/list_optional_inputs.json
@@ -1,73 +1,115 @@
 {
-	"type": "object",
-	"properties": {
-		"after": {
-			"type": "string"
-		},
-		"before": {
-			"type": "string"
-		},
-		"first": {
-			"type": "number"
-		},
-		"last": {
-			"type": "number"
-		},
-		"where": {
-			"$ref": "#/components/schemas/TestActionWhere"
-		}
-	},
-	"additionalProperties": false,
-	"components": {
-		"schemas": {
-			"StringQueryInput": {
-				"type": "object",
-				"properties": {
-					"contains": {
-						"type": "string"
-					},
-					"endsWith": {
-						"type": "string"
-					},
-					"equals": {
-						"type": ["string", "null"]
-					},
-					"notEquals": {
-						"type": ["string", "null"]
-					},
-					"oneOf": {
-						"type": "array",
-						"items": {
-							"type": "string"
-						}
-					},
-					"startsWith": {
-						"type": "string"
-					}
-				},
-				"additionalProperties": false
-			},
-			"TestActionCompanyInput": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"$ref": "#/components/schemas/StringQueryInput"
-					}
-				},
-				"additionalProperties": false
-			},
-			"TestActionWhere": {
-				"type": "object",
-				"properties": {
-					"company": {
-						"$ref": "#/components/schemas/TestActionCompanyInput"
-					},
-					"firstName": {
-						"$ref": "#/components/schemas/StringQueryInput"
-					}
-				},
-				"additionalProperties": false
-			}
-		}
-	}
+  "type": "object",
+  "properties": {
+    "after": {
+      "type": "string"
+    },
+    "before": {
+      "type": "string"
+    },
+    "first": {
+      "type": "number"
+    },
+    "last": {
+      "type": "number"
+    },
+    "where": {
+      "$ref": "#/components/schemas/TestActionWhere"
+    }
+  },
+  "additionalProperties": false,
+  "components": {
+    "schemas": {
+      "StringQueryInput": {
+        "type": "object",
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "equals": {
+                "type": ["string", "null"]
+              }
+            },
+            "title": "equals",
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "notEquals": {
+                "type": ["string", "null"]
+              }
+            },
+            "title": "notEquals",
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "startsWith": {
+                "type": "string"
+              }
+            },
+            "title": "startsWith",
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "endsWith": {
+                "type": "string"
+              }
+            },
+            "title": "endsWith",
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "contains": {
+                "type": "string"
+              }
+            },
+            "title": "contains",
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "oneOf": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "title": "oneOf",
+            "type": "object"
+          }
+        ],
+        "additionalProperties": false
+      },
+      "TestActionCompanyInput": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "$ref": "#/components/schemas/StringQueryInput"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TestActionWhere": {
+        "type": "object",
+        "properties": {
+          "company": {
+            "$ref": "#/components/schemas/TestActionCompanyInput"
+          },
+          "firstName": {
+            "$ref": "#/components/schemas/StringQueryInput"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
 }

--- a/runtime/openapi/testdata/basic.json
+++ b/runtime/openapi/testdata/basic.json
@@ -1,661 +1,710 @@
 {
-	"openapi": "3.1.0",
-	"info": {
-		"title": "Web",
-		"version": "1"
-	},
-	"paths": {
-		"/web/json/authenticate": {
-			"post": {
-				"operationId": "authenticate",
-				"requestBody": {
-					"description": "authenticate Request",
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"properties": {
-									"createIfNotExists": {
-										"type": "boolean"
-									},
-									"emailPassword": {
-										"$ref": "#/components/schemas/EmailPasswordInput"
-									}
-								},
-								"additionalProperties": false,
-								"required": ["emailPassword"]
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "authenticate Response",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "object",
-									"properties": {
-										"identityCreated": {
-											"type": "boolean"
-										},
-										"token": {
-											"type": "string"
-										}
-									},
-									"additionalProperties": false,
-									"required": ["identityCreated", "token"]
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "authenticate Response Errors",
-						"content": {
-							"application/json": {
-								"schema": {
-									"properties": {
-										"code": {
-											"type": "string"
-										},
-										"data": {
-											"type": ["object", "null"],
-											"properties": {
-												"errors": {
-													"type": "array",
-													"properties": {
-														"error": {
-															"type": "string"
-														},
-														"field": {
-															"type": "string"
-														}
-													}
-												}
-											}
-										},
-										"message": {
-											"type": "string"
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/web/json/createCustomer": {
-			"post": {
-				"operationId": "createCustomer",
-				"requestBody": {
-					"description": "createCustomer Request",
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"properties": {
-									"address": {
-										"$ref": "#/components/schemas/CreateCustomerAddressInput"
-									},
-									"dateOfBirth": {
-										"type": "string",
-										"format": "date"
-									},
-									"name": {
-										"type": "string"
-									}
-								},
-								"additionalProperties": false,
-								"required": ["name", "dateOfBirth", "address"]
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "createCustomer Response",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Customer"
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "createCustomer Response Errors",
-						"content": {
-							"application/json": {
-								"schema": {
-									"properties": {
-										"code": {
-											"type": "string"
-										},
-										"data": {
-											"type": ["object", "null"],
-											"properties": {
-												"errors": {
-													"type": "array",
-													"properties": {
-														"error": {
-															"type": "string"
-														},
-														"field": {
-															"type": "string"
-														}
-													}
-												}
-											}
-										},
-										"message": {
-											"type": "string"
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/web/json/customers": {
-			"post": {
-				"operationId": "customers",
-				"requestBody": {
-					"description": "customers Request",
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"properties": {
-									"after": {
-										"type": "string"
-									},
-									"before": {
-										"type": "string"
-									},
-									"first": {
-										"type": "number"
-									},
-									"last": {
-										"type": "number"
-									},
-									"where": {
-										"$ref": "#/components/schemas/CustomersWhere"
-									}
-								},
-								"additionalProperties": false
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "customers Response",
-						"content": {
-							"application/json": {
-								"schema": {
-									"properties": {
-										"pageInfo": {
-											"properties": {
-												"count": {
-													"type": "number"
-												},
-												"endCursor": {
-													"type": "string"
-												},
-												"hasNextPage": {
-													"type": "boolean"
-												},
-												"startCursor": {
-													"type": "string"
-												},
-												"totalCount": {
-													"type": "number"
-												}
-											}
-										},
-										"results": {
-											"type": "array",
-											"items": {
-												"$ref": "#/components/schemas/Customer"
-											}
-										}
-									}
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "customers Response Errors",
-						"content": {
-							"application/json": {
-								"schema": {
-									"properties": {
-										"code": {
-											"type": "string"
-										},
-										"data": {
-											"type": ["object", "null"],
-											"properties": {
-												"errors": {
-													"type": "array",
-													"properties": {
-														"error": {
-															"type": "string"
-														},
-														"field": {
-															"type": "string"
-														}
-													}
-												}
-											}
-										},
-										"message": {
-											"type": "string"
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/web/json/getCustomer": {
-			"post": {
-				"operationId": "getCustomer",
-				"requestBody": {
-					"description": "getCustomer Request",
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"properties": {
-									"id": {
-										"type": "string"
-									}
-								},
-								"additionalProperties": false,
-								"required": ["id"]
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "getCustomer Response",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Customer"
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "getCustomer Response Errors",
-						"content": {
-							"application/json": {
-								"schema": {
-									"properties": {
-										"code": {
-											"type": "string"
-										},
-										"data": {
-											"type": ["object", "null"],
-											"properties": {
-												"errors": {
-													"type": "array",
-													"properties": {
-														"error": {
-															"type": "string"
-														},
-														"field": {
-															"type": "string"
-														}
-													}
-												}
-											}
-										},
-										"message": {
-											"type": "string"
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/web/json/requestPasswordReset": {
-			"post": {
-				"operationId": "requestPasswordReset",
-				"requestBody": {
-					"description": "requestPasswordReset Request",
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"properties": {
-									"email": {
-										"type": "string"
-									},
-									"redirectUrl": {
-										"type": "string"
-									}
-								},
-								"additionalProperties": false,
-								"required": ["email", "redirectUrl"]
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "requestPasswordReset Response",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "object",
-									"additionalProperties": false
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "requestPasswordReset Response Errors",
-						"content": {
-							"application/json": {
-								"schema": {
-									"properties": {
-										"code": {
-											"type": "string"
-										},
-										"data": {
-											"type": ["object", "null"],
-											"properties": {
-												"errors": {
-													"type": "array",
-													"properties": {
-														"error": {
-															"type": "string"
-														},
-														"field": {
-															"type": "string"
-														}
-													}
-												}
-											}
-										},
-										"message": {
-											"type": "string"
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/web/json/resetPassword": {
-			"post": {
-				"operationId": "resetPassword",
-				"requestBody": {
-					"description": "resetPassword Request",
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"properties": {
-									"password": {
-										"type": "string"
-									},
-									"token": {
-										"type": "string"
-									}
-								},
-								"additionalProperties": false,
-								"required": ["token", "password"]
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "resetPassword Response",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "object",
-									"additionalProperties": false
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "resetPassword Response Errors",
-						"content": {
-							"application/json": {
-								"schema": {
-									"properties": {
-										"code": {
-											"type": "string"
-										},
-										"data": {
-											"type": ["object", "null"],
-											"properties": {
-												"errors": {
-													"type": "array",
-													"properties": {
-														"error": {
-															"type": "string"
-														},
-														"field": {
-															"type": "string"
-														}
-													}
-												}
-											}
-										},
-										"message": {
-											"type": "string"
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/web/json/updateCustomer": {
-			"post": {
-				"operationId": "updateCustomer",
-				"requestBody": {
-					"description": "updateCustomer Request",
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"properties": {
-									"values": {
-										"$ref": "#/components/schemas/UpdateCustomerValues"
-									},
-									"where": {
-										"$ref": "#/components/schemas/UpdateCustomerWhere"
-									}
-								},
-								"additionalProperties": false,
-								"required": ["where"]
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "updateCustomer Response",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Customer"
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "updateCustomer Response Errors",
-						"content": {
-							"application/json": {
-								"schema": {
-									"properties": {
-										"code": {
-											"type": "string"
-										},
-										"data": {
-											"type": ["object", "null"],
-											"properties": {
-												"errors": {
-													"type": "array",
-													"properties": {
-														"error": {
-															"type": "string"
-														},
-														"field": {
-															"type": "string"
-														}
-													}
-												}
-											}
-										},
-										"message": {
-											"type": "string"
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-	},
-	"components": {
-		"schemas": {
-			"CreateCustomerAddressInput": {
-				"type": "object",
-				"properties": {
-					"addressLine1": {
-						"type": "string"
-					},
-					"town": {
-						"type": "string"
-					}
-				},
-				"additionalProperties": false,
-				"required": ["addressLine1", "town"]
-			},
-			"Customer": {
-				"properties": {
-					"addressId": {
-						"type": "string"
-					},
-					"createdAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"dateOfBirth": {
-						"type": "string",
-						"format": "date"
-					},
-					"id": {
-						"type": "string"
-					},
-					"name": {
-						"type": "string"
-					},
-					"updatedAt": {
-						"type": "string",
-						"format": "date-time"
-					}
-				},
-				"required": ["name", "dateOfBirth", "id", "createdAt", "updatedAt", "addressId"]
-			},
-			"CustomersWhere": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"$ref": "#/components/schemas/StringQueryInput"
-					}
-				},
-				"additionalProperties": false
-			},
-			"EmailPasswordInput": {
-				"type": "object",
-				"properties": {
-					"email": {
-						"type": "string"
-					},
-					"password": {
-						"type": "string"
-					}
-				},
-				"additionalProperties": false,
-				"required": ["email", "password"]
-			},
-			"StringQueryInput": {
-				"type": "object",
-				"properties": {
-					"contains": {
-						"type": "string"
-					},
-					"endsWith": {
-						"type": "string"
-					},
-					"equals": {
-						"type": ["string", "null"]
-					},
-					"notEquals": {
-						"type": ["string", "null"]
-					},
-					"oneOf": {
-						"type": "array",
-						"items": {
-							"type": "string"
-						}
-					},
-					"startsWith": {
-						"type": "string"
-					}
-				},
-				"additionalProperties": false
-			},
-			"UpdateCustomerValues": {
-				"type": "object",
-				"properties": {
-					"dateOfBirth": {
-						"type": "string",
-						"format": "date"
-					},
-					"name": {
-						"type": "string"
-					}
-				},
-				"additionalProperties": false
-			},
-			"UpdateCustomerWhere": {
-				"type": "object",
-				"properties": {
-					"id": {
-						"type": "string"
-					}
-				},
-				"additionalProperties": false,
-				"required": ["id"]
-			}
-		}
-	}
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Web",
+    "version": "1"
+  },
+  "paths": {
+    "/web/json/authenticate": {
+      "post": {
+        "operationId": "authenticate",
+        "requestBody": {
+          "description": "authenticate Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "createIfNotExists": {
+                    "type": "boolean"
+                  },
+                  "emailPassword": {
+                    "$ref": "#/components/schemas/EmailPasswordInput"
+                  }
+                },
+                "additionalProperties": false,
+                "required": ["emailPassword"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "authenticate Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "identityCreated": {
+                      "type": "boolean"
+                    },
+                    "token": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": ["identityCreated", "token"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "authenticate Response Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": ["object", "null"],
+                      "properties": {
+                        "errors": {
+                          "type": "array",
+                          "properties": {
+                            "error": {
+                              "type": "string"
+                            },
+                            "field": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/web/json/createCustomer": {
+      "post": {
+        "operationId": "createCustomer",
+        "requestBody": {
+          "description": "createCustomer Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "address": {
+                    "$ref": "#/components/schemas/CreateCustomerAddressInput"
+                  },
+                  "dateOfBirth": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false,
+                "required": ["name", "dateOfBirth", "address"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "createCustomer Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Customer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "createCustomer Response Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": ["object", "null"],
+                      "properties": {
+                        "errors": {
+                          "type": "array",
+                          "properties": {
+                            "error": {
+                              "type": "string"
+                            },
+                            "field": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/web/json/customers": {
+      "post": {
+        "operationId": "customers",
+        "requestBody": {
+          "description": "customers Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "after": {
+                    "type": "string"
+                  },
+                  "before": {
+                    "type": "string"
+                  },
+                  "first": {
+                    "type": "number"
+                  },
+                  "last": {
+                    "type": "number"
+                  },
+                  "where": {
+                    "$ref": "#/components/schemas/CustomersWhere"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "customers Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "pageInfo": {
+                      "properties": {
+                        "count": {
+                          "type": "number"
+                        },
+                        "endCursor": {
+                          "type": "string"
+                        },
+                        "hasNextPage": {
+                          "type": "boolean"
+                        },
+                        "startCursor": {
+                          "type": "string"
+                        },
+                        "totalCount": {
+                          "type": "number"
+                        }
+                      }
+                    },
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Customer"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "customers Response Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": ["object", "null"],
+                      "properties": {
+                        "errors": {
+                          "type": "array",
+                          "properties": {
+                            "error": {
+                              "type": "string"
+                            },
+                            "field": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/web/json/getCustomer": {
+      "post": {
+        "operationId": "getCustomer",
+        "requestBody": {
+          "description": "getCustomer Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false,
+                "required": ["id"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "getCustomer Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Customer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "getCustomer Response Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": ["object", "null"],
+                      "properties": {
+                        "errors": {
+                          "type": "array",
+                          "properties": {
+                            "error": {
+                              "type": "string"
+                            },
+                            "field": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/web/json/requestPasswordReset": {
+      "post": {
+        "operationId": "requestPasswordReset",
+        "requestBody": {
+          "description": "requestPasswordReset Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string"
+                  },
+                  "redirectUrl": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false,
+                "required": ["email", "redirectUrl"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "requestPasswordReset Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "requestPasswordReset Response Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": ["object", "null"],
+                      "properties": {
+                        "errors": {
+                          "type": "array",
+                          "properties": {
+                            "error": {
+                              "type": "string"
+                            },
+                            "field": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/web/json/resetPassword": {
+      "post": {
+        "operationId": "resetPassword",
+        "requestBody": {
+          "description": "resetPassword Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "password": {
+                    "type": "string"
+                  },
+                  "token": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false,
+                "required": ["token", "password"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "resetPassword Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "resetPassword Response Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": ["object", "null"],
+                      "properties": {
+                        "errors": {
+                          "type": "array",
+                          "properties": {
+                            "error": {
+                              "type": "string"
+                            },
+                            "field": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/web/json/updateCustomer": {
+      "post": {
+        "operationId": "updateCustomer",
+        "requestBody": {
+          "description": "updateCustomer Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "values": {
+                    "$ref": "#/components/schemas/UpdateCustomerValues"
+                  },
+                  "where": {
+                    "$ref": "#/components/schemas/UpdateCustomerWhere"
+                  }
+                },
+                "additionalProperties": false,
+                "required": ["where"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "updateCustomer Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Customer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "updateCustomer Response Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": ["object", "null"],
+                      "properties": {
+                        "errors": {
+                          "type": "array",
+                          "properties": {
+                            "error": {
+                              "type": "string"
+                            },
+                            "field": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "CreateCustomerAddressInput": {
+        "type": "object",
+        "properties": {
+          "addressLine1": {
+            "type": "string"
+          },
+          "town": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": ["addressLine1", "town"]
+      },
+      "Customer": {
+        "properties": {
+          "addressId": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "dateOfBirth": {
+            "type": "string",
+            "format": "date"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "name",
+          "dateOfBirth",
+          "id",
+          "createdAt",
+          "updatedAt",
+          "addressId"
+        ]
+      },
+      "CustomersWhere": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "$ref": "#/components/schemas/StringQueryInput"
+          }
+        },
+        "additionalProperties": false
+      },
+      "EmailPasswordInput": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": ["email", "password"]
+      },
+      "StringQueryInput": {
+        "type": "object",
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "equals": {
+                "type": ["string", "null"]
+              }
+            },
+            "title": "equals",
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "notEquals": {
+                "type": ["string", "null"]
+              }
+            },
+            "title": "notEquals",
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "startsWith": {
+                "type": "string"
+              }
+            },
+            "title": "startsWith",
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "endsWith": {
+                "type": "string"
+              }
+            },
+            "title": "endsWith",
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "contains": {
+                "type": "string"
+              }
+            },
+            "title": "contains",
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "oneOf": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "title": "oneOf",
+            "type": "object"
+          }
+        ],
+        "additionalProperties": false
+      },
+      "UpdateCustomerValues": {
+        "type": "object",
+        "properties": {
+          "dateOfBirth": {
+            "type": "string",
+            "format": "date"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateCustomerWhere": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": ["id"]
+      }
+    }
+  }
 }

--- a/runtime/openapi/testdata/basic.json
+++ b/runtime/openapi/testdata/basic.json
@@ -614,7 +614,6 @@
         "required": ["email", "password"]
       },
       "StringQueryInput": {
-        "type": "object",
         "unevaluatedProperties": false,
         "oneOf": [
           {

--- a/runtime/openapi/testdata/basic.json
+++ b/runtime/openapi/testdata/basic.json
@@ -615,6 +615,7 @@
       },
       "StringQueryInput": {
         "type": "object",
+        "unevaluatedProperties": false,
         "oneOf": [
           {
             "additionalProperties": false,
@@ -623,6 +624,7 @@
                 "type": ["string", "null"]
               }
             },
+            "required": ["equals"],
             "title": "equals",
             "type": "object"
           },
@@ -633,6 +635,7 @@
                 "type": ["string", "null"]
               }
             },
+            "required": ["notEquals"],
             "title": "notEquals",
             "type": "object"
           },
@@ -643,6 +646,7 @@
                 "type": "string"
               }
             },
+            "required": ["startsWith"],
             "title": "startsWith",
             "type": "object"
           },
@@ -653,6 +657,7 @@
                 "type": "string"
               }
             },
+            "required": ["endsWith"],
             "title": "endsWith",
             "type": "object"
           },
@@ -663,6 +668,7 @@
                 "type": "string"
               }
             },
+            "required": ["contains"],
             "title": "contains",
             "type": "object"
           },
@@ -676,11 +682,11 @@
                 "type": "array"
               }
             },
+            "required": ["oneOf"],
             "title": "oneOf",
             "type": "object"
           }
-        ],
-        "additionalProperties": false
+        ]
       },
       "UpdateCustomerValues": {
         "type": "object",

--- a/runtime/openapi/testdata/optional_fields.json
+++ b/runtime/openapi/testdata/optional_fields.json
@@ -619,7 +619,6 @@
         "required": ["addressLine1"]
       },
       "StringQueryInput": {
-        "type": "object",
         "unevaluatedProperties": false,
         "oneOf": [
           {

--- a/runtime/openapi/testdata/optional_fields.json
+++ b/runtime/openapi/testdata/optional_fields.json
@@ -1,674 +1,716 @@
 {
-	"openapi": "3.1.0",
-	"info": {
-		"title": "Web",
-		"version": "1"
-	},
-	"paths": {
-		"/web/json/authenticate": {
-			"post": {
-				"operationId": "authenticate",
-				"requestBody": {
-					"description": "authenticate Request",
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"properties": {
-									"createIfNotExists": {
-										"type": "boolean"
-									},
-									"emailPassword": {
-										"$ref": "#/components/schemas/EmailPasswordInput"
-									}
-								},
-								"additionalProperties": false,
-								"required": ["emailPassword"]
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "authenticate Response",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "object",
-									"properties": {
-										"identityCreated": {
-											"type": "boolean"
-										},
-										"token": {
-											"type": "string"
-										}
-									},
-									"additionalProperties": false,
-									"required": ["identityCreated", "token"]
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "authenticate Response Errors",
-						"content": {
-							"application/json": {
-								"schema": {
-									"properties": {
-										"code": {
-											"type": "string"
-										},
-										"data": {
-											"type": ["object", "null"],
-											"properties": {
-												"errors": {
-													"type": "array",
-													"properties": {
-														"error": {
-															"type": "string"
-														},
-														"field": {
-															"type": "string"
-														}
-													}
-												}
-											}
-										},
-										"message": {
-											"type": "string"
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/web/json/createCustomer": {
-			"post": {
-				"operationId": "createCustomer",
-				"requestBody": {
-					"description": "createCustomer Request",
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"properties": {
-									"address": {
-										"$ref": "#/components/schemas/NullableCreateCustomerAddressInput"
-									},
-									"timeOfBirth": {
-										"type": ["string", "null"],
-										"format": "date-time"
-									},
-									"name": {
-										"type": ["string", "null"]
-									}
-								},
-								"additionalProperties": false,
-								"required": ["name", "timeOfBirth", "address"]
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "createCustomer Response",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Customer"
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "createCustomer Response Errors",
-						"content": {
-							"application/json": {
-								"schema": {
-									"properties": {
-										"code": {
-											"type": "string"
-										},
-										"data": {
-											"type": ["object", "null"],
-											"properties": {
-												"errors": {
-													"type": "array",
-													"properties": {
-														"error": {
-															"type": "string"
-														},
-														"field": {
-															"type": "string"
-														}
-													}
-												}
-											}
-										},
-										"message": {
-											"type": "string"
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/web/json/customers": {
-			"post": {
-				"operationId": "customers",
-				"requestBody": {
-					"description": "customers Request",
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"properties": {
-									"after": {
-										"type": "string"
-									},
-									"before": {
-										"type": "string"
-									},
-									"first": {
-										"type": "number"
-									},
-									"last": {
-										"type": "number"
-									},
-									"where": {
-										"$ref": "#/components/schemas/CustomersWhere"
-									}
-								},
-								"additionalProperties": false,
-								"required": ["where"]
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "customers Response",
-						"content": {
-							"application/json": {
-								"schema": {
-									"properties": {
-										"pageInfo": {
-											"properties": {
-												"count": {
-													"type": "number"
-												},
-												"endCursor": {
-													"type": "string"
-												},
-												"hasNextPage": {
-													"type": "boolean"
-												},
-												"startCursor": {
-													"type": "string"
-												},
-												"totalCount": {
-													"type": "number"
-												}
-											}
-										},
-										"results": {
-											"type": "array",
-											"items": {
-												"$ref": "#/components/schemas/Customer"
-											}
-										}
-									}
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "customers Response Errors",
-						"content": {
-							"application/json": {
-								"schema": {
-									"properties": {
-										"code": {
-											"type": "string"
-										},
-										"data": {
-											"type": ["object", "null"],
-											"properties": {
-												"errors": {
-													"type": "array",
-													"properties": {
-														"error": {
-															"type": "string"
-														},
-														"field": {
-															"type": "string"
-														}
-													}
-												}
-											}
-										},
-										"message": {
-											"type": "string"
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/web/json/getCustomer": {
-			"post": {
-				"operationId": "getCustomer",
-				"requestBody": {
-					"description": "getCustomer Request",
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"properties": {
-									"id": {
-										"type": "string"
-									}
-								},
-								"additionalProperties": false,
-								"required": ["id"]
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "getCustomer Response",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Customer"
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "getCustomer Response Errors",
-						"content": {
-							"application/json": {
-								"schema": {
-									"properties": {
-										"code": {
-											"type": "string"
-										},
-										"data": {
-											"type": ["object", "null"],
-											"properties": {
-												"errors": {
-													"type": "array",
-													"properties": {
-														"error": {
-															"type": "string"
-														},
-														"field": {
-															"type": "string"
-														}
-													}
-												}
-											}
-										},
-										"message": {
-											"type": "string"
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/web/json/requestPasswordReset": {
-			"post": {
-				"operationId": "requestPasswordReset",
-				"requestBody": {
-					"description": "requestPasswordReset Request",
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"properties": {
-									"email": {
-										"type": "string"
-									},
-									"redirectUrl": {
-										"type": "string"
-									}
-								},
-								"additionalProperties": false,
-								"required": ["email", "redirectUrl"]
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "requestPasswordReset Response",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "object",
-									"additionalProperties": false
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "requestPasswordReset Response Errors",
-						"content": {
-							"application/json": {
-								"schema": {
-									"properties": {
-										"code": {
-											"type": "string"
-										},
-										"data": {
-											"type": ["object", "null"],
-											"properties": {
-												"errors": {
-													"type": "array",
-													"properties": {
-														"error": {
-															"type": "string"
-														},
-														"field": {
-															"type": "string"
-														}
-													}
-												}
-											}
-										},
-										"message": {
-											"type": "string"
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/web/json/resetPassword": {
-			"post": {
-				"operationId": "resetPassword",
-				"requestBody": {
-					"description": "resetPassword Request",
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"properties": {
-									"password": {
-										"type": "string"
-									},
-									"token": {
-										"type": "string"
-									}
-								},
-								"additionalProperties": false,
-								"required": ["token", "password"]
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "resetPassword Response",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "object",
-									"additionalProperties": false
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "resetPassword Response Errors",
-						"content": {
-							"application/json": {
-								"schema": {
-									"properties": {
-										"code": {
-											"type": "string"
-										},
-										"data": {
-											"type": ["object", "null"],
-											"properties": {
-												"errors": {
-													"type": "array",
-													"properties": {
-														"error": {
-															"type": "string"
-														},
-														"field": {
-															"type": "string"
-														}
-													}
-												}
-											}
-										},
-										"message": {
-											"type": "string"
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/web/json/updateCustomer": {
-			"post": {
-				"operationId": "updateCustomer",
-				"requestBody": {
-					"description": "updateCustomer Request",
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"properties": {
-									"values": {
-										"$ref": "#/components/schemas/UpdateCustomerValues"
-									},
-									"where": {
-										"$ref": "#/components/schemas/UpdateCustomerWhere"
-									}
-								},
-								"additionalProperties": false,
-								"required": ["where", "values"]
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "updateCustomer Response",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Customer"
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "updateCustomer Response Errors",
-						"content": {
-							"application/json": {
-								"schema": {
-									"properties": {
-										"code": {
-											"type": "string"
-										},
-										"data": {
-											"type": ["object", "null"],
-											"properties": {
-												"errors": {
-													"type": "array",
-													"properties": {
-														"error": {
-															"type": "string"
-														},
-														"field": {
-															"type": "string"
-														}
-													}
-												}
-											}
-										},
-										"message": {
-											"type": "string"
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-	},
-	"components": {
-		"schemas": {
-			"Customer": {
-				"properties": {
-					"addressId": {
-						"type": ["string", "null"]
-					},
-					"createdAt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"timeOfBirth": {
-						"type": ["string", "null"],
-						"format": "date-time"
-					},
-					"id": {
-						"type": "string"
-					},
-					"name": {
-						"type": ["string", "null"]
-					},
-					"updatedAt": {
-						"type": "string",
-						"format": "date-time"
-					}
-				},
-				"required": ["id", "createdAt", "updatedAt"]
-			},
-			"CustomersAddressInput": {
-				"type": "object",
-				"properties": {
-					"addressLine1": {
-						"$ref": "#/components/schemas/StringQueryInput"
-					}
-				},
-				"additionalProperties": false,
-				"required": ["addressLine1"]
-			},
-			"CustomersWhere": {
-				"type": "object",
-				"properties": {
-					"address": {
-						"$ref": "#/components/schemas/CustomersAddressInput"
-					},
-					"name": {
-						"$ref": "#/components/schemas/StringQueryInput"
-					}
-				},
-				"additionalProperties": false,
-				"required": ["name", "address"]
-			},
-			"EmailPasswordInput": {
-				"type": "object",
-				"properties": {
-					"email": {
-						"type": "string"
-					},
-					"password": {
-						"type": "string"
-					}
-				},
-				"additionalProperties": false,
-				"required": ["email", "password"]
-			},
-			"NullableCreateCustomerAddressInput": {
-				"type": ["object", "null"],
-				"properties": {
-					"addressLine1": {
-						"type": ["string", "null"]
-					}
-				},
-				"additionalProperties": false,
-				"required": ["addressLine1"]
-			},
-			"StringQueryInput": {
-				"type": "object",
-				"properties": {
-					"contains": {
-						"type": "string"
-					},
-					"endsWith": {
-						"type": "string"
-					},
-					"equals": {
-						"type": ["string", "null"]
-					},
-					"notEquals": {
-						"type": ["string", "null"]
-					},
-					"oneOf": {
-						"type": "array",
-						"items": {
-							"type": "string"
-						}
-					},
-					"startsWith": {
-						"type": "string"
-					}
-				},
-				"additionalProperties": false
-			},
-			"UpdateCustomerValues": {
-				"type": "object",
-				"properties": {
-					"timeOfBirth": {
-						"type": ["string", "null"],
-						"format": "date-time"
-					},
-					"name": {
-						"type": ["string", "null"]
-					}
-				},
-				"additionalProperties": false,
-				"required": ["name", "timeOfBirth"]
-			},
-			"UpdateCustomerWhere": {
-				"type": "object",
-				"properties": {
-					"id": {
-						"type": "string"
-					}
-				},
-				"additionalProperties": false,
-				"required": ["id"]
-			}
-		}
-	}
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Web",
+    "version": "1"
+  },
+  "paths": {
+    "/web/json/authenticate": {
+      "post": {
+        "operationId": "authenticate",
+        "requestBody": {
+          "description": "authenticate Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "createIfNotExists": {
+                    "type": "boolean"
+                  },
+                  "emailPassword": {
+                    "$ref": "#/components/schemas/EmailPasswordInput"
+                  }
+                },
+                "additionalProperties": false,
+                "required": ["emailPassword"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "authenticate Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "identityCreated": {
+                      "type": "boolean"
+                    },
+                    "token": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": ["identityCreated", "token"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "authenticate Response Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": ["object", "null"],
+                      "properties": {
+                        "errors": {
+                          "type": "array",
+                          "properties": {
+                            "error": {
+                              "type": "string"
+                            },
+                            "field": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/web/json/createCustomer": {
+      "post": {
+        "operationId": "createCustomer",
+        "requestBody": {
+          "description": "createCustomer Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "address": {
+                    "$ref": "#/components/schemas/NullableCreateCustomerAddressInput"
+                  },
+                  "timeOfBirth": {
+                    "type": ["string", "null"],
+                    "format": "date-time"
+                  },
+                  "name": {
+                    "type": ["string", "null"]
+                  }
+                },
+                "additionalProperties": false,
+                "required": ["name", "timeOfBirth", "address"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "createCustomer Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Customer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "createCustomer Response Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": ["object", "null"],
+                      "properties": {
+                        "errors": {
+                          "type": "array",
+                          "properties": {
+                            "error": {
+                              "type": "string"
+                            },
+                            "field": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/web/json/customers": {
+      "post": {
+        "operationId": "customers",
+        "requestBody": {
+          "description": "customers Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "after": {
+                    "type": "string"
+                  },
+                  "before": {
+                    "type": "string"
+                  },
+                  "first": {
+                    "type": "number"
+                  },
+                  "last": {
+                    "type": "number"
+                  },
+                  "where": {
+                    "$ref": "#/components/schemas/CustomersWhere"
+                  }
+                },
+                "additionalProperties": false,
+                "required": ["where"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "customers Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "pageInfo": {
+                      "properties": {
+                        "count": {
+                          "type": "number"
+                        },
+                        "endCursor": {
+                          "type": "string"
+                        },
+                        "hasNextPage": {
+                          "type": "boolean"
+                        },
+                        "startCursor": {
+                          "type": "string"
+                        },
+                        "totalCount": {
+                          "type": "number"
+                        }
+                      }
+                    },
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Customer"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "customers Response Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": ["object", "null"],
+                      "properties": {
+                        "errors": {
+                          "type": "array",
+                          "properties": {
+                            "error": {
+                              "type": "string"
+                            },
+                            "field": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/web/json/getCustomer": {
+      "post": {
+        "operationId": "getCustomer",
+        "requestBody": {
+          "description": "getCustomer Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false,
+                "required": ["id"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "getCustomer Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Customer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "getCustomer Response Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": ["object", "null"],
+                      "properties": {
+                        "errors": {
+                          "type": "array",
+                          "properties": {
+                            "error": {
+                              "type": "string"
+                            },
+                            "field": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/web/json/requestPasswordReset": {
+      "post": {
+        "operationId": "requestPasswordReset",
+        "requestBody": {
+          "description": "requestPasswordReset Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string"
+                  },
+                  "redirectUrl": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false,
+                "required": ["email", "redirectUrl"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "requestPasswordReset Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "requestPasswordReset Response Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": ["object", "null"],
+                      "properties": {
+                        "errors": {
+                          "type": "array",
+                          "properties": {
+                            "error": {
+                              "type": "string"
+                            },
+                            "field": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/web/json/resetPassword": {
+      "post": {
+        "operationId": "resetPassword",
+        "requestBody": {
+          "description": "resetPassword Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "password": {
+                    "type": "string"
+                  },
+                  "token": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false,
+                "required": ["token", "password"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "resetPassword Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "resetPassword Response Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": ["object", "null"],
+                      "properties": {
+                        "errors": {
+                          "type": "array",
+                          "properties": {
+                            "error": {
+                              "type": "string"
+                            },
+                            "field": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/web/json/updateCustomer": {
+      "post": {
+        "operationId": "updateCustomer",
+        "requestBody": {
+          "description": "updateCustomer Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "values": {
+                    "$ref": "#/components/schemas/UpdateCustomerValues"
+                  },
+                  "where": {
+                    "$ref": "#/components/schemas/UpdateCustomerWhere"
+                  }
+                },
+                "additionalProperties": false,
+                "required": ["where", "values"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "updateCustomer Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Customer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "updateCustomer Response Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": ["object", "null"],
+                      "properties": {
+                        "errors": {
+                          "type": "array",
+                          "properties": {
+                            "error": {
+                              "type": "string"
+                            },
+                            "field": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Customer": {
+        "properties": {
+          "addressId": {
+            "type": ["string", "null"]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "timeOfBirth": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": ["string", "null"]
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": ["id", "createdAt", "updatedAt"]
+      },
+      "CustomersAddressInput": {
+        "type": "object",
+        "properties": {
+          "addressLine1": {
+            "$ref": "#/components/schemas/StringQueryInput"
+          }
+        },
+        "additionalProperties": false,
+        "required": ["addressLine1"]
+      },
+      "CustomersWhere": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "$ref": "#/components/schemas/CustomersAddressInput"
+          },
+          "name": {
+            "$ref": "#/components/schemas/StringQueryInput"
+          }
+        },
+        "additionalProperties": false,
+        "required": ["name", "address"]
+      },
+      "EmailPasswordInput": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": ["email", "password"]
+      },
+      "NullableCreateCustomerAddressInput": {
+        "type": ["object", "null"],
+        "properties": {
+          "addressLine1": {
+            "type": ["string", "null"]
+          }
+        },
+        "additionalProperties": false,
+        "required": ["addressLine1"]
+      },
+      "StringQueryInput": {
+        "type": "object",
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "equals": {
+                "type": ["string", "null"]
+              }
+            },
+            "title": "equals",
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "notEquals": {
+                "type": ["string", "null"]
+              }
+            },
+            "title": "notEquals",
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "startsWith": {
+                "type": "string"
+              }
+            },
+            "title": "startsWith",
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "endsWith": {
+                "type": "string"
+              }
+            },
+            "title": "endsWith",
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "contains": {
+                "type": "string"
+              }
+            },
+            "title": "contains",
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "oneOf": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "title": "oneOf",
+            "type": "object"
+          }
+        ],
+        "additionalProperties": false
+      },
+      "UpdateCustomerValues": {
+        "type": "object",
+        "properties": {
+          "timeOfBirth": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          },
+          "name": {
+            "type": ["string", "null"]
+          }
+        },
+        "additionalProperties": false,
+        "required": ["name", "timeOfBirth"]
+      },
+      "UpdateCustomerWhere": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": ["id"]
+      }
+    }
+  }
 }

--- a/runtime/openapi/testdata/optional_fields.json
+++ b/runtime/openapi/testdata/optional_fields.json
@@ -620,6 +620,7 @@
       },
       "StringQueryInput": {
         "type": "object",
+        "unevaluatedProperties": false,
         "oneOf": [
           {
             "additionalProperties": false,
@@ -628,6 +629,7 @@
                 "type": ["string", "null"]
               }
             },
+            "required": ["equals"],
             "title": "equals",
             "type": "object"
           },
@@ -638,6 +640,7 @@
                 "type": ["string", "null"]
               }
             },
+            "required": ["notEquals"],
             "title": "notEquals",
             "type": "object"
           },
@@ -648,6 +651,7 @@
                 "type": "string"
               }
             },
+            "required": ["startsWith"],
             "title": "startsWith",
             "type": "object"
           },
@@ -658,6 +662,7 @@
                 "type": "string"
               }
             },
+            "required": ["endsWith"],
             "title": "endsWith",
             "type": "object"
           },
@@ -668,6 +673,7 @@
                 "type": "string"
               }
             },
+            "required": ["contains"],
             "title": "contains",
             "type": "object"
           },
@@ -681,11 +687,11 @@
                 "type": "array"
               }
             },
+            "required": ["oneOf"],
             "title": "oneOf",
             "type": "object"
           }
-        ],
-        "additionalProperties": false
+        ]
       },
       "UpdateCustomerValues": {
         "type": "object",


### PR DESCRIPTION
For ID and String messages, we want to set the json schema to use `oneOf` so that only one of the filters can be used at a time. Tom and I had a chat about this and agreed that we would only do this for ID and String fields for now and only allowing one filter at a time makes sense for both string and id filters.

Looking for feedback on how best to approach this

Attempting to go from:
```
"IdQueryInput": {
        "type": "object",
        "properties": {
          "equals": { "type": ["string", "null"] },
          "notEquals": { "type": ["string", "null"] },
          "oneOf": { "type": "array", "items": { "type": "string" } }
        },
        "additionalProperties": false
      }
```
to:
```
"IdQueryInput": {
        "type": "object",
        "oneOf": [
          {
            "title": "Equals",
            "properties": {
              "equals": { "type": "string" }
            },
            "required": ["equals"],
            "additionalProperties": false
          },
          {
            "title": "Not equals",
            "properties": {
              "notEquals": { "type": "string" }
            },
            "required": ["notEquals"],
            "additionalProperties": false
          },
          {
            "title": "One of",
            "properties": {
              "oneOf": { "type": "array", "items": { "type": "string" } }
            },
            "required": ["oneOf"],
            "additionalProperties": false
          }
        ],
        "additionalProperties": false
      }
```