### PR TITLE
fix: capitalised asc and desc error in modelapi

### DIFF
--- a/.github/workflows/test_npm_modules.yml
+++ b/.github/workflows/test_npm_modules.yml
@@ -18,7 +18,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
         ports:
-          - 5432:5432
+          - 7654:5432
 
     steps:
       - uses: actions/setup-node@v3

--- a/packages/functions-runtime/.env.test
+++ b/packages/functions-runtime/.env.test
@@ -1,2 +1,2 @@
-KEEL_DB_CONN=postgresql://postgres:postgres@localhost:5432/functions-runtime
+KEEL_DB_CONN=postgresql://postgres:postgres@localhost:7654/functions-runtime
 KEEL_DB_CONN_TYPE=pg

--- a/packages/functions-runtime/compose.yaml
+++ b/packages/functions-runtime/compose.yaml
@@ -7,4 +7,4 @@ services:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=functions-runtime
     ports:
-      - "5432:5432"
+      - "7654:5432"

--- a/packages/functions-runtime/src/ModelAPI.test.js
+++ b/packages/functions-runtime/src/ModelAPI.test.js
@@ -517,6 +517,46 @@ test("ModelAPI.findMany - orderBy", async () => {
   expect(descendingDates.map((r) => r.name)).toEqual(["Sally", "Bob", "Jim"]);
 });
 
+test("ModelAPI.findMany - orderBy ASC and DESC capitalised", async () => {
+  await personAPI.create({
+    id: KSUID.randomSync().string,
+    name: "Jim",
+    married: false,
+    favouriteNumber: 10,
+    date: new Date(2023, 12, 29),
+  });
+  await personAPI.create({
+    id: KSUID.randomSync().string,
+    name: "Bob",
+    married: true,
+    favouriteNumber: 11,
+    date: new Date(2023, 12, 30),
+  });
+  await personAPI.create({
+    id: KSUID.randomSync().string,
+    name: "Sally",
+    married: true,
+    favouriteNumber: 12,
+    date: new Date(2023, 12, 31),
+  });
+
+  const ascendingNames = await personAPI.findMany({
+    orderBy: {
+      name: "ASC",
+    },
+  });
+
+  expect(ascendingNames.map((r) => r.name)).toEqual(["Bob", "Jim", "Sally"]);
+
+  const descendingNames = await personAPI.findMany({
+    orderBy: {
+      name: "DESC",
+    },
+  });
+
+  expect(descendingNames.map((r) => r.name)).toEqual(["Sally", "Jim", "Bob"]);
+});
+
 test("ModelAPI.findMany - offset", async () => {
   await personAPI.create({
     id: KSUID.randomSync().string,

--- a/packages/functions-runtime/src/applyAdditionalQueryConstraints.js
+++ b/packages/functions-runtime/src/applyAdditionalQueryConstraints.js
@@ -10,7 +10,7 @@ function applyOffset(context, qb, offset) {
 
 function applyOrderBy(context, qb, tableName, orderBy = {}) {
   Object.entries(orderBy).forEach(([key, sortOrder]) => {
-    qb = qb.orderBy(`${tableName}.${snakeCase(key)}`, sortOrder);
+    qb = qb.orderBy(`${tableName}.${snakeCase(key)}`, sortOrder.toLowerCase());
   });
   return qb;
 }

--- a/packages/functions-runtime/src/handleJob.test.js
+++ b/packages/functions-runtime/src/handleJob.test.js
@@ -99,9 +99,6 @@ describe("ModelAPI error handling", () => {
   let db;
 
   beforeEach(async () => {
-    process.env.KEEL_DB_CONN_TYPE = "pg";
-    process.env.KEEL_DB_CONN = `postgresql://postgres:postgres@localhost:5432/functions-runtime`;
-
     db = useDatabase();
 
     await sql`

--- a/packages/functions-runtime/src/handleRequest.test.js
+++ b/packages/functions-runtime/src/handleRequest.test.js
@@ -218,9 +218,6 @@ describe("ModelAPI error handling", () => {
   let db;
 
   beforeEach(async () => {
-    process.env.KEEL_DB_CONN_TYPE = "pg";
-    process.env.KEEL_DB_CONN = `postgresql://postgres:postgres@localhost:5432/functions-runtime`;
-
     db = useDatabase();
 
     await sql`


### PR DESCRIPTION
Fixed bug reported by Jay whereby using "ASC" or "DESC" (capitalised) in the ModelAPI's `orderBy` caused a runtime exception.  For example:

```ts
const ascendingNames = await personAPI.findMany({
  orderBy: {
    name: "ASC",
  },
});
```

Resulted in the following:

```
TypeError: expr.toOperationNode is not a function
 ❯ parseOrderByDirectionExpression node_modules/.pnpm/kysely@0.23.5/node_modules/kysely/dist/cjs/parser/order-by-parser.js:22:21
 ❯ parseOrderBy node_modules/.pnpm/kysely@0.23.5/node_modules/kysely/dist/cjs/parser/order-by-parser.js:8:92
 ❯ SelectQueryBuilder.orderBy node_modules/.pnpm/kysely@0.23.5/node_modules/kysely/dist/cjs/query-builder/select-query-builder.js:404:145
 ❯ src/applyAdditionalQueryConstraints.js:13:13
 ❯ applyOrderBy src/applyAdditionalQueryConstraints.js:12:27
 ❯ src/ModelAPI.js:124:19
    122|         Object.keys(params?.orderBy).length > 0
    123|       ) {
    124|         builder = applyOrderBy(
       |                   ^
    125|           context,
    126|           builder,
 ❯ src/tracing.js:13:20
 ❯ NoopContextManager.with node_modules/.pnpm/@opentelemetry+api@1.7.0/node_modules/@opentelemetry/api/src/context/NoopContextManager.ts:31:15
 ❯ ContextAPI.with node_modules/.pnpm/@opentelemetry+api@1.7.0/node_modules/@opentelemetry/api/src/api/context.ts:77:42
```