### PR TITLE
fix: keel test broken

### DIFF
--- a/integration/testdata/functions_http/tests.test.ts
+++ b/integration/testdata/functions_http/tests.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from "vitest";
 
 test("headers", async () => {
   const response = await fetch(
-    process.env.KEEL_TESTING_ACTIONS_API_URL + "/json/withHeaders",
+    process.env.KEEL_TESTING_ACTIONS_API_URL + "/withHeaders",
     {
       body: "{}",
       method: "POST",
@@ -19,7 +19,7 @@ test("headers", async () => {
 
 test("status", async () => {
   const response = await fetch(
-    process.env.KEEL_TESTING_ACTIONS_API_URL + "/json/withStatus",
+    process.env.KEEL_TESTING_ACTIONS_API_URL + "/withStatus",
     {
       body: "{}",
       method: "POST",
@@ -37,7 +37,7 @@ test("status", async () => {
 test("query params", async () => {
   const response = await fetch(
     process.env.KEEL_TESTING_ACTIONS_API_URL +
-      "/json/withQueryParams?a=1&b=foo&c=true"
+      "/withQueryParams?a=1&b=foo&c=true"
   );
 
   const body = await response.json();

--- a/integration/testdata/graphql/main.test.ts
+++ b/integration/testdata/graphql/main.test.ts
@@ -52,7 +52,7 @@ test("list action with has-one relationship", async () => {
 
 async function graphql(query, token) {
   const res = await fetch(
-    process.env.KEEL_TESTING_ACTIONS_API_URL + "/graphql",
+    process.env.KEEL_TESTING_ACTIONS_API_URL!.replace("/json", "/graphql"),
     {
       method: "POST",
       body: JSON.stringify({

--- a/packages/testing-runtime/src/ActionExecutor.mjs
+++ b/packages/testing-runtime/src/ActionExecutor.mjs
@@ -2,7 +2,7 @@ import { Executor } from "./Executor.mjs";
 
 export class ActionExecutor extends Executor {
   constructor(props) {
-    props.apiBaseUrl = process.env.KEEL_TESTING_ACTIONS_API_URL + "/json";
+    props.apiBaseUrl = process.env.KEEL_TESTING_ACTIONS_API_URL;
     props.parseJsonResult = true;
 
     super(props);

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -260,7 +260,7 @@ func Run(ctx context.Context, opts *RunnerOpts) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Env = append(os.Environ(), []string{
-		fmt.Sprintf("KEEL_TESTING_ACTIONS_API_URL=http://localhost:%s/%s", runtimePort, ActionApiPath),
+		fmt.Sprintf("KEEL_TESTING_ACTIONS_API_URL=http://localhost:%s/%s/json", runtimePort, ActionApiPath),
 		fmt.Sprintf("KEEL_TESTING_JOBS_URL=http://localhost:%s/%s/json", runtimePort, JobPath),
 		fmt.Sprintf("KEEL_TESTING_SUBSCRIBERS_URL=http://localhost:%s/%s/json", runtimePort, SubscriberPath),
 		"KEEL_DB_CONN_TYPE=pg",


### PR DESCRIPTION
### `keel test` broken

I've had to undo [this change](https://github.com/teamkeel/keel/commit/05ee73c1ec0422a121d72397709ff6118ee85fe4) that Jon made as it is breaking `keel test`. We have ZERO testing on `keel test` which makes releasing bugs like this totally likely.

I'd like to see how we can unify the go test and keel test code for integration tests, so that we have less to worry about.  Also, we do need CLI testing.  For now, just fixing the issue.