### PR TITLE
perf: smarter transactions and authorization for built-in actions

### DIFF
--- a/integration/testdata/functions_custom/schema.keel
+++ b/integration/testdata/functions_custom/schema.keel
@@ -38,15 +38,33 @@ model Person {
     }
 
     actions {
-        read countName(name) returns (CountResponse)
-        read countNameAdvanced(AdvancedSearchInput) returns (CountResponse)
-        write createAndCount(name) returns (CountResponse)
-        write createManyAndCount(CreateManyInput) returns (CountResponse)
-        read people(PeopleInput) returns (PeopleResponse)
-        read customPersonSearch(CustomPersonSearchInput) returns (CustomPersonSearchResponse)
-        read customSearch(Any) returns (Any)
-        write bulkPersonUpload(BulkPersonUpload) returns (BulkPersonUpload)
-        read noInputs() returns (Any)
+        read countName(name) returns (CountResponse) {
+            @permission(expression: true)
+        }
+        read countNameAdvanced(AdvancedSearchInput) returns (CountResponse) {
+            @permission(expression: true)
+        }
+        write createAndCount(name) returns (CountResponse) {
+            @permission(expression: true)
+        }
+        write createManyAndCount(CreateManyInput) returns (CountResponse) {
+            @permission(expression: true)
+        }
+        read people(PeopleInput) returns (PeopleResponse) {
+            @permission(expression: true)
+        }
+        read customPersonSearch(CustomPersonSearchInput) returns (CustomPersonSearchResponse) {
+            @permission(expression: true)
+        }
+        read customSearch(Any) returns (Any) {
+            @permission(expression: true)
+        }
+        write bulkPersonUpload(BulkPersonUpload) returns (BulkPersonUpload) {
+            @permission(expression: true)
+        }
+        read noInputs() returns (Any) {
+            @permission(expression: true)
+        }
     }
 
     @permission(

--- a/integration/testdata/functions_http/schema.keel
+++ b/integration/testdata/functions_http/schema.keel
@@ -1,7 +1,13 @@
 model TestModel {
     actions {
-        read withQueryParams(Any) returns (Any)
-        read withHeaders(Any) returns (Any)
-        read withStatus(Any) returns (Any)
+        read withQueryParams(Any) returns (Any) {
+            @permission(expression: true)
+        }
+        read withHeaders(Any) returns (Any) {
+            @permission(expression: true)
+        }
+        read withStatus(Any) returns (Any) {
+            @permission(expression: true)
+        }
     }
 }

--- a/runtime/actions/authenticate.go
+++ b/runtime/actions/authenticate.go
@@ -201,7 +201,7 @@ func ResetPassword(scope *Scope, input map[string]any) error {
 
 	identityModel := proto.FindModel(scope.Schema.Models, parser.ImplicitIdentityModelName)
 
-	query := NewQuery(scope.Context, identityModel)
+	query := NewQuery(identityModel)
 	err = query.Where(Field("id"), Equals, Value(identityId))
 	if err != nil {
 		return err
@@ -209,7 +209,7 @@ func ResetPassword(scope *Scope, input map[string]any) error {
 
 	query.AddWriteValue(Field("password"), Value(string(hashedPassword)))
 
-	affected, err := query.UpdateStatement().Execute(scope.Context)
+	affected, err := query.UpdateStatement(scope.Context).Execute(scope.Context)
 	if err != nil {
 		return err
 	}

--- a/runtime/actions/authorization.go
+++ b/runtime/actions/authorization.go
@@ -105,6 +105,10 @@ func authorise(scope *Scope, permissions []*proto.PermissionRule, input map[stri
 // TryResolveAuthorisationEarly will attempt to check authorisation early without row-based querying.
 // This will take into account logical conditions and multiple expression and role permission attributes.
 func TryResolveAuthorisationEarly(scope *Scope, permissions []*proto.PermissionRule) (canResolveAll bool, authorised bool, err error) {
+	if len(permissions) == 0 {
+		return true, false, nil
+	}
+
 	hasDatabaseCheck := false
 	canResolveAll = false
 	for _, permission := range permissions {

--- a/runtime/actions/authorization.go
+++ b/runtime/actions/authorization.go
@@ -190,7 +190,7 @@ func resolveRolePermissionRule(ctx context.Context, schema *proto.Schema, permis
 
 func GeneratePermissionStatement(scope *Scope, permissions []*proto.PermissionRule, input map[string]any, idsToAuthorise []string) (*Statement, error) {
 	permissions = proto.PermissionsWithExpression(permissions)
-	query := NewQuery(scope.Context, scope.Model, WithJoinType(JoinTypeLeft))
+	query := NewQuery(scope.Model, WithJoinType(JoinTypeLeft))
 
 	// We should never have an empty list of permissions as this is checked
 	// higher up in the code path, but just to be safe

--- a/runtime/actions/authorization_test.go
+++ b/runtime/actions/authorization_test.go
@@ -354,6 +354,17 @@ var authorisationTestCases = []authorisationTestCase{
 		identity:     unverifiedIdentity,
 	},
 	{
+		name: "early_evaluate_no_permissions",
+		keelSchema: `
+			model Thing {
+				actions {
+					create createThing()
+				}
+			}`,
+		actionName: "createThing",
+		earlyAuth:  AuthorisationDeniedEarly(),
+	},
+	{
 		name: "early_evaluate_create_op",
 		keelSchema: `
 			model Thing {

--- a/runtime/actions/create.go
+++ b/runtime/actions/create.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/teamkeel/keel/db"
+	"github.com/teamkeel/keel/proto"
 	"github.com/teamkeel/keel/runtime/common"
 )
 
@@ -13,33 +14,60 @@ func Create(scope *Scope, input map[string]any) (res map[string]any, err error) 
 		return nil, err
 	}
 
-	err = database.Transaction(scope.Context, func(ctx context.Context) error {
-		scope := scope.WithContext(ctx)
+	permissions := proto.PermissionsForAction(scope.Schema, scope.Action)
+
+	// Attempt to resolve permissions early; i.e. before row-based database querying.
+	canResolveEarly, authorised, err := TryResolveAuthorisationEarly(scope, permissions)
+	if err != nil {
+		return nil, err
+	}
+	if canResolveEarly && !authorised {
+		return nil, common.NewPermissionError()
+	}
+
+	if canResolveEarly {
 		query := NewQuery(scope.Context, scope.Model)
 
 		// Generate the SQL statement
 		statement, err := GenerateCreateStatement(query, scope, input)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		// Execute database request, expecting a single result
 		res, err = statement.ExecuteToSingle(scope.Context)
 		if err != nil {
-			return err
+			return nil, err
 		}
+	} else {
+		err = database.Transaction(scope.Context, func(ctx context.Context) error {
+			scope := scope.WithContext(ctx)
+			query := NewQuery(scope.Context, scope.Model)
 
-		isAuthorised, err := AuthoriseAction(scope, input, []map[string]any{res})
-		if err != nil {
-			return err
-		}
+			// Generate the SQL statement
+			statement, err := GenerateCreateStatement(query, scope, input)
+			if err != nil {
+				return err
+			}
 
-		if !isAuthorised {
-			return common.NewPermissionError()
-		}
+			// Execute database request, expecting a single result
+			res, err = statement.ExecuteToSingle(scope.Context)
+			if err != nil {
+				return err
+			}
 
-		return nil
-	})
+			isAuthorised, err := AuthoriseAction(scope, input, []map[string]any{res})
+			if err != nil {
+				return err
+			}
+
+			if !isAuthorised {
+				return common.NewPermissionError()
+			}
+
+			return nil
+		})
+	}
 
 	return res, err
 }

--- a/runtime/actions/create.go
+++ b/runtime/actions/create.go
@@ -26,7 +26,7 @@ func Create(scope *Scope, input map[string]any) (res map[string]any, err error) 
 	}
 
 	if canResolveEarly {
-		query := NewQuery(scope.Context, scope.Model)
+		query := NewQuery(scope.Model)
 
 		// Generate the SQL statement
 		statement, err := GenerateCreateStatement(query, scope, input)
@@ -42,7 +42,7 @@ func Create(scope *Scope, input map[string]any) (res map[string]any, err error) 
 	} else {
 		err = database.Transaction(scope.Context, func(ctx context.Context) error {
 			scope := scope.WithContext(ctx)
-			query := NewQuery(scope.Context, scope.Model)
+			query := NewQuery(scope.Model)
 
 			// Generate the SQL statement
 			statement, err := GenerateCreateStatement(query, scope, input)
@@ -86,5 +86,5 @@ func GenerateCreateStatement(query *QueryBuilder, scope *Scope, input map[string
 	// Return the inserted row
 	query.AppendReturning(AllFields())
 
-	return query.InsertStatement(), nil
+	return query.InsertStatement(scope.Context), nil
 }

--- a/runtime/actions/delete.go
+++ b/runtime/actions/delete.go
@@ -29,7 +29,7 @@ func Delete(scope *Scope, input map[string]any) (res *string, err error) {
 	var row map[string]any
 
 	if canResolveEarly {
-		query := NewQuery(scope.Context, scope.Model)
+		query := NewQuery(scope.Model)
 
 		// Generate the SQL statement
 		statement, err := GenerateDeleteStatement(query, scope, input)
@@ -47,7 +47,7 @@ func Delete(scope *Scope, input map[string]any) (res *string, err error) {
 
 		err = database.Transaction(scope.Context, func(ctx context.Context) error {
 			scope := scope.WithContext(ctx)
-			query := NewQuery(scope.Context, scope.Model)
+			query := NewQuery(scope.Model)
 
 			// Generate the SQL statement
 			statement, err := GenerateDeleteStatement(query, scope, input)
@@ -111,5 +111,5 @@ func GenerateDeleteStatement(query *QueryBuilder, scope *Scope, input map[string
 
 	query.AppendReturning(Field("id"))
 
-	return query.DeleteStatement(), nil
+	return query.DeleteStatement(scope.Context), nil
 }

--- a/runtime/actions/delete.go
+++ b/runtime/actions/delete.go
@@ -44,7 +44,6 @@ func Delete(scope *Scope, input map[string]any) (res *string, err error) {
 		}
 
 	} else {
-
 		err = database.Transaction(scope.Context, func(ctx context.Context) error {
 			scope := scope.WithContext(ctx)
 			query := NewQuery(scope.Model)
@@ -84,6 +83,10 @@ func Delete(scope *Scope, input map[string]any) (res *string, err error) {
 
 			return nil
 		})
+	}
+
+	if err != nil {
+		return nil, err
 	}
 
 	if row == nil {

--- a/runtime/actions/expression.go
+++ b/runtime/actions/expression.go
@@ -252,7 +252,7 @@ func generateQueryOperand(resolver *expressions.OperandResolver, args map[string
 
 		model := proto.FindModel(resolver.Schema.Models, strcase.ToCamel(fragments[0]))
 		ctxScope := NewModelScope(resolver.Context, model, resolver.Schema)
-		query := NewQuery(resolver.Context, model)
+		query := NewQuery(model)
 
 		identityId := ""
 		if auth.IsAuthenticated(resolver.Context) {

--- a/runtime/actions/get.go
+++ b/runtime/actions/get.go
@@ -17,7 +17,7 @@ func Get(scope *Scope, input map[string]any) (map[string]any, error) {
 		return nil, common.NewPermissionError()
 	}
 
-	query := NewQuery(scope.Context, scope.Model)
+	query := NewQuery(scope.Model)
 
 	// Generate the SQL statement
 	statement, err := GenerateGetStatement(query, scope, input)

--- a/runtime/actions/get.go
+++ b/runtime/actions/get.go
@@ -1,8 +1,22 @@
 package actions
 
-import "github.com/teamkeel/keel/runtime/common"
+import (
+	"github.com/teamkeel/keel/proto"
+	"github.com/teamkeel/keel/runtime/common"
+)
 
 func Get(scope *Scope, input map[string]any) (map[string]any, error) {
+	permissions := proto.PermissionsForAction(scope.Schema, scope.Action)
+
+	// Attempt to resolve permissions early; i.e. before row-based database querying.
+	canResolveEarly, authorised, err := TryResolveAuthorisationEarly(scope, permissions)
+	if err != nil {
+		return nil, err
+	}
+	if canResolveEarly && !authorised {
+		return nil, common.NewPermissionError()
+	}
+
 	query := NewQuery(scope.Context, scope.Model)
 
 	// Generate the SQL statement

--- a/runtime/actions/identity.go
+++ b/runtime/actions/identity.go
@@ -19,7 +19,7 @@ import (
 
 func FindIdentityById(ctx context.Context, schema *proto.Schema, id string) (*auth.Identity, error) {
 	identityModel := proto.FindModel(schema.Models, parser.ImplicitIdentityModelName)
-	query := NewQuery(ctx, identityModel)
+	query := NewQuery(identityModel)
 	err := query.Where(Field("id"), Equals, Value(id))
 	if err != nil {
 		return nil, err
@@ -40,7 +40,7 @@ func FindIdentityById(ctx context.Context, schema *proto.Schema, id string) (*au
 
 func FindIdentityByEmail(ctx context.Context, schema *proto.Schema, email string, issuer string) (*auth.Identity, error) {
 	identityModel := proto.FindModel(schema.Models, parser.ImplicitIdentityModelName)
-	query := NewQuery(ctx, identityModel)
+	query := NewQuery(identityModel)
 	err := query.Where(Field("email"), Equals, Value(email))
 	if err != nil {
 		return nil, err
@@ -66,7 +66,7 @@ func FindIdentityByEmail(ctx context.Context, schema *proto.Schema, email string
 
 func FindIdentityByExternalId(ctx context.Context, schema *proto.Schema, externalId string, issuer string) (*auth.Identity, error) {
 	identityModel := proto.FindModel(schema.Models, parser.ImplicitIdentityModelName)
-	query := NewQuery(ctx, identityModel)
+	query := NewQuery(identityModel)
 	err := query.Where(Field("externalId"), Equals, Value(externalId))
 	if err != nil {
 		return nil, err
@@ -94,7 +94,7 @@ func FindIdentityByExternalId(ctx context.Context, schema *proto.Schema, externa
 func CreateIdentity(ctx context.Context, schema *proto.Schema, email string, password string) (*auth.Identity, error) {
 	identityModel := proto.FindModel(schema.Models, parser.ImplicitIdentityModelName)
 
-	query := NewQuery(ctx, identityModel)
+	query := NewQuery(identityModel)
 	query.AddWriteValues(map[string]*QueryOperand{
 		"email":    Value(email),
 		"password": Value(password),
@@ -103,7 +103,7 @@ func CreateIdentity(ctx context.Context, schema *proto.Schema, email string, pas
 	query.AppendSelect(AllFields())
 	query.AppendReturning(IdField())
 
-	result, err := query.InsertStatement().ExecuteToSingle(ctx)
+	result, err := query.InsertStatement(ctx).ExecuteToSingle(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +137,7 @@ func CreateExternalIdentity(ctx context.Context, schema *proto.Schema, externalI
 		}
 	}
 
-	query := NewQuery(ctx, identityModel)
+	query := NewQuery(identityModel)
 	// even if we can't fetch the user data, create it with the core information
 	query.AddWriteValues(map[string]*QueryOperand{
 		"externalId": Value(externalId),
@@ -157,7 +157,7 @@ func CreateExternalIdentity(ctx context.Context, schema *proto.Schema, externalI
 	query.AppendSelect(AllFields())
 	query.AppendReturning(IdField())
 
-	result, err := query.InsertStatement().ExecuteToSingle(ctx)
+	result, err := query.InsertStatement(ctx).ExecuteToSingle(ctx)
 	if err != nil {
 		span.RecordError(err, trace.WithStackTrace(true))
 		span.SetStatus(codes.Error, err.Error())
@@ -176,7 +176,7 @@ func CreateIdentityWithIdTokenClaims(ctx context.Context, schema *proto.Schema, 
 
 	identityModel := proto.FindModel(schema.Models, parser.ImplicitIdentityModelName)
 
-	query := NewQuery(ctx, identityModel)
+	query := NewQuery(identityModel)
 
 	query.AddWriteValues(map[string]*QueryOperand{
 		"externalId":    Value(externalId),
@@ -188,7 +188,7 @@ func CreateIdentityWithIdTokenClaims(ctx context.Context, schema *proto.Schema, 
 	query.AppendSelect(AllFields())
 	query.AppendReturning(IdField())
 
-	result, err := query.InsertStatement().ExecuteToSingle(ctx)
+	result, err := query.InsertStatement(ctx).ExecuteToSingle(ctx)
 	if err != nil {
 		span.RecordError(err, trace.WithStackTrace(true))
 		span.SetStatus(codes.Error, err.Error())
@@ -207,7 +207,7 @@ func UpdateIdentityWithIdTokenClaims(ctx context.Context, schema *proto.Schema, 
 
 	identityModel := proto.FindModel(schema.Models, parser.ImplicitIdentityModelName)
 
-	query := NewQuery(ctx, identityModel)
+	query := NewQuery(identityModel)
 
 	err := query.Where(Field("externalId"), Equals, Value(claims.Subject))
 	if err != nil {
@@ -227,7 +227,7 @@ func UpdateIdentityWithIdTokenClaims(ctx context.Context, schema *proto.Schema, 
 	query.AppendSelect(AllFields())
 	query.AppendReturning(AllFields())
 
-	result, err := query.UpdateStatement().ExecuteToSingle(ctx)
+	result, err := query.UpdateStatement(ctx).ExecuteToSingle(ctx)
 	if err != nil {
 		span.RecordError(err, trace.WithStackTrace(true))
 		span.SetStatus(codes.Error, err.Error())

--- a/runtime/actions/list.go
+++ b/runtime/actions/list.go
@@ -121,7 +121,7 @@ func List(scope *Scope, input map[string]any) (map[string]any, error) {
 		return nil, common.NewPermissionError()
 	}
 
-	query := NewQuery(scope.Context, scope.Model)
+	query := NewQuery(scope.Model)
 
 	// Generate the SQL statement.
 	statement, page, err := GenerateListStatement(query, scope, input)

--- a/runtime/actions/scope.go
+++ b/runtime/actions/scope.go
@@ -210,17 +210,6 @@ func executeRuntimeAction(scope *Scope, inputs map[string]any) (any, *common.Res
 }
 
 func executeAutoAction(scope *Scope, inputs map[string]any) (any, *common.ResponseMetadata, error) {
-	permissions := proto.PermissionsForAction(scope.Schema, scope.Action)
-
-	// Attempt to resolve permissions early; i.e. before row-based database querying.
-	canResolveEarly, authorised, err := TryResolveAuthorisationEarly(scope, permissions)
-	if err != nil {
-		return nil, nil, err
-	}
-	if canResolveEarly && !authorised {
-		return nil, nil, common.NewPermissionError()
-	}
-
 	switch scope.Action.Type {
 	case proto.ActionType_ACTION_TYPE_GET:
 		v, err := Get(scope, inputs)

--- a/runtime/actions/update.go
+++ b/runtime/actions/update.go
@@ -24,7 +24,7 @@ func Update(scope *Scope, input map[string]any) (res map[string]any, err error) 
 	}
 
 	if canResolveEarly {
-		query := NewQuery(scope.Context, scope.Model)
+		query := NewQuery(scope.Model)
 
 		// Generate the SQL statement
 		statement, err := GenerateUpdateStatement(query, scope, input)
@@ -40,7 +40,7 @@ func Update(scope *Scope, input map[string]any) (res map[string]any, err error) 
 	} else {
 		err = database.Transaction(scope.Context, func(ctx context.Context) error {
 			scope := scope.WithContext(ctx)
-			query := NewQuery(scope.Context, scope.Model)
+			query := NewQuery(scope.Model)
 
 			// Generate the SQL statement
 			statement, err := GenerateUpdateStatement(query, scope, input)
@@ -120,5 +120,5 @@ func GenerateUpdateStatement(query *QueryBuilder, scope *Scope, input map[string
 	// Return the updated row
 	query.AppendReturning(AllFields())
 
-	return query.UpdateStatement(), nil
+	return query.UpdateStatement(scope.Context), nil
 }

--- a/runtime/actions/update.go
+++ b/runtime/actions/update.go
@@ -79,6 +79,10 @@ func Update(scope *Scope, input map[string]any) (res map[string]any, err error) 
 		})
 	}
 
+	if err != nil {
+		return nil, err
+	}
+
 	if res == nil {
 		return nil, common.NewNotFoundError()
 	}

--- a/runtime/actions/update.go
+++ b/runtime/actions/update.go
@@ -1,19 +1,11 @@
 package actions
 
 import (
-	"context"
-
-	"github.com/teamkeel/keel/db"
 	"github.com/teamkeel/keel/proto"
 	"github.com/teamkeel/keel/runtime/common"
 )
 
 func Update(scope *Scope, input map[string]any) (res map[string]any, err error) {
-	database, err := db.GetDatabase(scope.Context)
-	if err != nil {
-		return nil, err
-	}
-
 	// Attempt to resolve permissions early; i.e. before row-based database querying.
 	permissions := proto.PermissionsForAction(scope.Schema, scope.Action)
 	canResolveEarly, authorised, err := TryResolveAuthorisationEarly(scope, permissions)
@@ -21,7 +13,7 @@ func Update(scope *Scope, input map[string]any) (res map[string]any, err error) 
 		return nil, err
 	}
 
-	// Generate update statement
+	// Generate SQL statement
 	query := NewQuery(scope.Model)
 	statement, err := GenerateUpdateStatement(query, scope, input)
 	if err != nil {
@@ -30,45 +22,32 @@ func Update(scope *Scope, input map[string]any) (res map[string]any, err error) 
 
 	switch {
 	case canResolveEarly && !authorised:
-		err = common.NewPermissionError()
-	case canResolveEarly && authorised:
-		// Execute database request, expecting a single result
-		res, err = statement.ExecuteToSingle(scope.Context)
+		return nil, common.NewPermissionError()
 	case !canResolveEarly:
-		err = database.Transaction(scope.Context, func(ctx context.Context) error {
-			scope := scope.WithContext(ctx)
+		query.AppendSelect(IdField())
+		query.AppendDistinctOn(IdField())
+		rowToAuthorise, err := query.SelectStatement().ExecuteToSingle(scope.Context)
+		if err != nil {
+			return nil, err
+		}
 
-			query.AppendSelect(IdField())
-			query.AppendDistinctOn(IdField())
-			rowToAuthorise, err := query.SelectStatement().ExecuteToSingle(scope.Context)
-			if err != nil {
-				return err
-			}
+		rowsToAuthorise := []map[string]any{}
+		if rowToAuthorise != nil {
+			rowsToAuthorise = append(rowsToAuthorise, rowToAuthorise)
+		}
 
-			rowsToAuthorise := []map[string]any{}
-			if rowToAuthorise != nil {
-				rowsToAuthorise = append(rowsToAuthorise, rowToAuthorise)
-			}
+		isAuthorised, err := AuthoriseAction(scope, input, rowsToAuthorise)
+		if err != nil {
+			return nil, err
+		}
 
-			isAuthorised, err := AuthoriseAction(scope, input, rowsToAuthorise)
-			if err != nil {
-				return err
-			}
-
-			if !isAuthorised {
-				return common.NewPermissionError()
-			}
-
-			// Execute database request, expecting a single result
-			res, err = statement.ExecuteToSingle(scope.Context)
-			if err != nil {
-				return err
-			}
-
-			return nil
-		})
+		if !isAuthorised {
+			return nil, common.NewPermissionError()
+		}
 	}
 
+	// Execute database request, expecting a single result
+	res, err = statement.ExecuteToSingle(scope.Context)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/actions/writeinputs.go
+++ b/runtime/actions/writeinputs.go
@@ -17,7 +17,7 @@ import (
 func (query *QueryBuilder) captureSetValues(scope *Scope, args map[string]any) error {
 	model := proto.FindModel(scope.Schema.Models, strcase.ToCamel("identity"))
 	ctxScope := NewModelScope(scope.Context, model, scope.Schema)
-	identityQuery := NewQuery(scope.Context, model)
+	identityQuery := NewQuery(model)
 
 	identityId := ""
 	if auth.IsAuthenticated(scope.Context) {

--- a/runtime/apis/graphql/graphql.go
+++ b/runtime/apis/graphql/graphql.go
@@ -316,7 +316,7 @@ func (mk *graphqlSchemaBuilder) addModel(model *proto.Model) (*graphql.Object, e
 				relatedModel := proto.FindModel(mk.proto.Models, field.Type.ModelName.Value)
 
 				// Create a new query for the related model
-				query := actions.NewQuery(ctx, relatedModel)
+				query := actions.NewQuery(relatedModel)
 				query.AppendSelect(actions.AllFields())
 
 				foreignKeyField := proto.GetForignKeyFieldName(mk.proto.Models, field)

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -130,7 +130,6 @@ func NewApiHandler(s *proto.Schema) common.HandlerFunc {
 
 		httpJson := httpjson.NewHandler(s, api)
 		for _, name := range proto.GetActionNamesForApi(s, api) {
-			fmt.Println(root + "/json/" + strings.ToLower(name))
 			handlers[root+"/json/"+strings.ToLower(name)] = httpJson
 		}
 		handlers[root+"/json/openapi.json"] = httpJson
@@ -141,7 +140,6 @@ func NewApiHandler(s *proto.Schema) common.HandlerFunc {
 
 		handler, ok := handlers[strings.ToLower(r.URL.Path)]
 		if !ok {
-			fmt.Println(strings.ToLower(r.URL.Path))
 			return common.Response{
 				Status: http.StatusNotFound,
 				Body:   []byte("Not found"),

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -130,6 +130,7 @@ func NewApiHandler(s *proto.Schema) common.HandlerFunc {
 
 		httpJson := httpjson.NewHandler(s, api)
 		for _, name := range proto.GetActionNamesForApi(s, api) {
+			fmt.Println(root + "/json/" + strings.ToLower(name))
 			handlers[root+"/json/"+strings.ToLower(name)] = httpJson
 		}
 		handlers[root+"/json/openapi.json"] = httpJson
@@ -140,6 +141,7 @@ func NewApiHandler(s *proto.Schema) common.HandlerFunc {
 
 		handler, ok := handlers[strings.ToLower(r.URL.Path)]
 		if !ok {
+			fmt.Println(strings.ToLower(r.URL.Path))
 			return common.Response{
 				Status: http.StatusNotFound,
 				Body:   []byte("Not found"),

--- a/runtime/runtime_audit_test.go
+++ b/runtime/runtime_audit_test.go
@@ -385,11 +385,11 @@ func TestAuditOnStatementExecuteWithoutResult(t *testing.T) {
 	action := proto.FindAction(schema, "createWedding")
 
 	scope := actions.NewScope(ctx, action, schema)
-	query := actions.NewQuery(scope.Context, scope.Model)
+	query := actions.NewQuery(scope.Model)
 	err = query.Where(actions.IdField(), actions.Equals, actions.Value(result["id"]))
 	require.NoError(t, err)
 	query.AddWriteValue(actions.Field("name"), actions.Value("Devin"))
-	affected, err := query.UpdateStatement().Execute(ctx)
+	affected, err := query.UpdateStatement(scope.Context).Execute(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 1, affected)
 


### PR DESCRIPTION
## Performance improvements on built-in actions

Summary:
 - `create`: reduced from 5 to 2 - 5 db hits
 - `update`: reduced from 6 to 2 - 4 db hits
 - `delete`: reduced from 6 to 2 - 4 db hits

### Smarter authorization

For all action types, we perform better early authorization checks, which means we can avoid unnecessary database hits when row-based permissions aren't being used.  For `create`, we even avoid the use of transactions entirely.

Typically, this is the order of database events (i.e. incurring a DB 'hit') for an built-in `create` action:
 a) open transaction
 b) execute create statement
 c) perform row-based permissions query
 d) commit (or rollback) transaction

That is FOUR hits to the database, which is expensive especially when no row-based permissions are even performed.

Now we check if transaction and row-based permission checks are even needed.  If they aren't needed, then the action will be reduced to a single query - executing the insert statement without a transaction block

### No more transactions on `update` and `delete`

Furthermore, transactions were only in place on `update` and `delete` as a fail safe if multiple rows happened to be affected (which would be an error on Keel's part).  We have so many tests and I think the risk of this happening is so low.  The cost of a transaction for every single action call is quite high, so I've opted for dropping it.