### PR TITLE
fix: update action unique input in with only

### DIFF
--- a/schema/testdata/errors/update_operation_no_unique_lookup.keel
+++ b/schema/testdata/errors/update_operation_no_unique_lookup.keel
@@ -1,6 +1,13 @@
 model MyModel {
+    fields {
+        name Text @unique
+    }
+
     actions {
         //expect-error:16:29:ActionInputError:The action 'updateMyModel' can only update a single record and therefore must be filtered by unique fields
         update updateMyModel()
+
+        //expect-error:16:33:ActionInputError:The action 'updateMyModelName' can only update a single record and therefore must be filtered by unique fields
+        update updateMyModelName() with (name)
     }
 }

--- a/schema/validation/unique_lookup.go
+++ b/schema/validation/unique_lookup.go
@@ -98,6 +98,11 @@ func UniqueLookup(asts []*parser.AST, errs *errorhandling.ValidationErrors) Visi
 				return
 			}
 
+			// We are only concerned with filters inputs (and not 'with' inputs)
+			if !lo.Contains(action.Inputs, input) {
+				return
+			}
+
 			// Ignore if it's a named input
 			// for example `get getMyThing(name: Text)`
 			if query.ResolveInputField(asts, input, model) == nil {


### PR DESCRIPTION
### Update action unique input in with input only

@murej found a case where unique inputs constraint for the update action was not being enforce.  It happened when a unique field was used in `with`. The validation code was not discerning between filter and with inputs correctly.