### PR TITLE
Group together all equals, notEquals and oneOf message fields

### DIFF
--- a/runtime/jsonschema/jsonschema_test.go
+++ b/runtime/jsonschema/jsonschema_test.go
@@ -733,7 +733,7 @@ func TestValidateRequest(t *testing.T) {
 					errors: map[string][]string{
 						"where.id":        {`Must validate one and only one schema (oneOf)`, `Invalid type. Expected: object, given: null`},
 						"where.title":     {`Must validate one and only one schema (oneOf)`, `Invalid type. Expected: object, given: null`},
-						"where.genre":     {`Invalid type. Expected: object, given: null`},
+						"where.genre":     {`Must validate one and only one schema (oneOf)`, `Invalid type. Expected: object, given: null`},
 						"where.price":     {`Invalid type. Expected: object, given: null`},
 						"where.available": {`Invalid type. Expected: object, given: null`},
 						"where.createdAt": {`Invalid type. Expected: object, given: null`},
@@ -752,6 +752,7 @@ func TestValidateRequest(t *testing.T) {
 					opName:  "listBooks",
 					request: `{"where": {"genre": {"equals": "Sci-fi"}}}`,
 					errors: map[string][]string{
+						"where.genre":        {`Must validate one and only one schema (oneOf)`},
 						"where.genre.equals": {`where.genre.equals must be one of the following: "Romance", "Horror", null`},
 					},
 				},
@@ -760,6 +761,7 @@ func TestValidateRequest(t *testing.T) {
 					opName:  "listBooks",
 					request: `{"where": {"genre": {"oneOf": ["Sci-fi"]}}}`,
 					errors: map[string][]string{
+						"where.genre":         {`Must validate one and only one schema (oneOf)`},
 						"where.genre.oneOf.0": {`where.genre.oneOf.0 must be one of the following: "Romance", "Horror"`},
 					},
 				},

--- a/runtime/jsonschema/testdata/list.json
+++ b/runtime/jsonschema/testdata/list.json
@@ -64,22 +64,45 @@
         "additionalProperties": false
       },
       "HobbyQueryInput": {
-        "type": "object",
-        "properties": {
-          "equals": {
-            "enum": ["Tennis", "Chess", null]
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "equals": {
+                "enum": ["Tennis", "Chess", null]
+              }
+            },
+            "required": ["equals"],
+            "title": "equals",
+            "type": "object"
           },
-          "notEquals": {
-            "enum": ["Tennis", "Chess", null]
+          {
+            "additionalProperties": false,
+            "properties": {
+              "notEquals": {
+                "enum": ["Tennis", "Chess", null]
+              }
+            },
+            "required": ["notEquals"],
+            "title": "notEquals",
+            "type": "object"
           },
-          "oneOf": {
-            "type": "array",
-            "items": {
-              "enum": ["Tennis", "Chess"]
-            }
+          {
+            "additionalProperties": false,
+            "properties": {
+              "oneOf": {
+                "items": {
+                  "enum": ["Tennis", "Chess"]
+                },
+                "type": "array"
+              }
+            },
+            "required": ["oneOf"],
+            "title": "oneOf",
+            "type": "object"
           }
-        },
-        "additionalProperties": false
+        ],
+        "unevaluatedProperties": false
       },
       "IdQueryInput": {
         "unevaluatedProperties": false,


### PR DESCRIPTION
This change means messages that are enum types (which also have only equals, notEquals and oneOf fields), will also be grouped together in the jsonschema. Previously we were only grouping `StringQueryInput` and `IdQueryInput`, but enums e.g. `Status` would allow you to set all three queries.