### PR TITLE
build: option to perform dry run database migration

### DIFF
--- a/cmd/program/commands.go
+++ b/cmd/program/commands.go
@@ -325,7 +325,7 @@ func RunMigrations(schema *proto.Schema, database db.Database) tea.Cmd {
 			Changes: m.Changes,
 		}
 
-		err = m.Apply(context.Background())
+		err = m.Apply(context.Background(), false)
 		if err != nil {
 			msg.Err = &ApplyMigrationsError{
 				Err: err,

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -91,7 +91,7 @@ func TestMigrations(t *testing.T) {
 
 				m, err := migrations.New(ctx, currProto, database)
 				require.NoError(t, err)
-				err = m.Apply(ctx)
+				err = m.Apply(ctx, false)
 				require.NoError(t, err)
 			}
 
@@ -118,7 +118,7 @@ func TestMigrations(t *testing.T) {
 			assertJSON(t, []byte(expectedChanges), actualChanges)
 
 			// Check the new migrations can be applied without error
-			require.NoError(t, m.Apply(ctx))
+			require.NoError(t, m.Apply(ctx, false))
 
 			// Now fetch the "current" schema from the database, which
 			// should be the new one we just applied

--- a/runtime/runtime_audit_test.go
+++ b/runtime/runtime_audit_test.go
@@ -471,7 +471,7 @@ func TestAuditDatabaseMigration(t *testing.T) {
 	m, err := migrations.New(ctx, pSchema, database)
 	require.NoError(t, err)
 
-	err = m.Apply(ctx)
+	err = m.Apply(ctx, false)
 	require.NoError(t, err)
 
 	var audits []map[string]any

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -98,7 +98,7 @@ func SetupDatabaseForTestCase(ctx context.Context, dbConnInfo *db.ConnectionInfo
 		return nil, err
 	}
 
-	err = m.Apply(ctx)
+	err = m.Apply(ctx, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Used by the Console/Backend deploy steps to perform a dry run of the database migration early on during the deployment.  This will let us stop the deployment early, before any resources have been updated.

See https://github.com/teamkeel/backend/pull/1108

I think we can tackle this better when we properly looking at how we do migrations. It might be better to rather perform a smarter detection of breaking changes than what I've done here.