### PR TITLE
chore: update any type in jsonschema to use anyOf

### DIFF
--- a/runtime/jsonschema/jsonschema.go
+++ b/runtime/jsonschema/jsonschema.go
@@ -57,6 +57,7 @@ type JSONSchema struct {
 	UnevaluatedProperties *bool                 `json:"unevaluatedProperties,omitempty"`
 	Required              []string              `json:"required,omitempty"`
 	OneOf                 []JSONSchema          `json:"oneOf,omitempty"`
+	AnyOf                 []JSONSchema          `json:"anyOf,omitempty"`
 	Title                 string                `json:"title,omitempty"`
 
 	// For arrays
@@ -175,7 +176,13 @@ func JSONSchemaForMessage(ctx context.Context, schema *proto.Schema, action *pro
 	}
 
 	if isAny {
-		root.Type = AnyTypes
+		anyOf := []JSONSchema{}
+		for _, v := range AnyTypes {
+			anyOf = append(anyOf, JSONSchema{Title: v, Type: v})
+		}
+
+		root.AnyOf = anyOf
+		root.Type = nil
 	}
 
 	if !isAny {
@@ -295,7 +302,11 @@ func jsonSchemaForField(ctx context.Context, schema *proto.Schema, action *proto
 
 	switch t.Type {
 	case proto.Type_TYPE_ANY:
-		prop.Type = AnyTypes
+		anyOf := []JSONSchema{}
+		for _, v := range AnyTypes {
+			anyOf = append(anyOf, JSONSchema{Title: v, Type: v})
+		}
+		prop.AnyOf = anyOf
 	case proto.Type_TYPE_MESSAGE:
 		// Add the nested message to schema components.
 		message := proto.FindMessage(schema.Messages, t.MessageName.Value)

--- a/runtime/jsonschema/testdata/arbitrary_function_any.json
+++ b/runtime/jsonschema/testdata/arbitrary_function_any.json
@@ -1,4 +1,33 @@
 {
-  "type": ["string","object","array","integer","number","boolean","null"],
-  "additionalProperties":true
+  "additionalProperties": true,
+  "anyOf": [
+    {
+      "title": "string",
+      "type": "string"
+    },
+    {
+      "title": "object",
+      "type": "object"
+    },
+    {
+      "title": "array",
+      "type": "array"
+    },
+    {
+      "title": "integer",
+      "type": "integer"
+    },
+    {
+      "title": "number",
+      "type": "number"
+    },
+    {
+      "title": "boolean",
+      "type": "boolean"
+    },
+    {
+      "title": "null",
+      "type": "null"
+    }
+  ]
 }


### PR DESCRIPTION
Looking into the OpenAPI docs, our previous implementation of the `any` type was not valid.
Updated to use the `anyOf` property as suggested in the docs.