### PR TITLE
chore: remove additionalProperties for isAny type in jsonschema

### DIFF
--- a/runtime/jsonschema/jsonschema.go
+++ b/runtime/jsonschema/jsonschema.go
@@ -172,7 +172,7 @@ func JSONSchemaForMessage(ctx context.Context, schema *proto.Schema, action *pro
 	root := JSONSchema{
 		Type:                 "object",
 		Properties:           map[string]JSONSchema{},
-		AdditionalProperties: boolPtr(isAny),
+		AdditionalProperties: boolPtr(false),
 	}
 
 	if isAny {
@@ -183,6 +183,7 @@ func JSONSchemaForMessage(ctx context.Context, schema *proto.Schema, action *pro
 
 		root.AnyOf = anyOf
 		root.Type = nil
+		root.AdditionalProperties = nil
 	}
 
 	if !isAny {
@@ -195,7 +196,7 @@ func JSONSchemaForMessage(ctx context.Context, schema *proto.Schema, action *pro
 				oneOfOption := JSONSchema{
 					Type:                 "object",
 					Properties:           map[string]JSONSchema{},
-					AdditionalProperties: boolPtr(isAny),
+					AdditionalProperties: boolPtr(false),
 				}
 
 				prop := jsonSchemaForField(ctx, schema, action, field.Type, field.Nullable)

--- a/runtime/jsonschema/testdata/arbitrary_function_any.json
+++ b/runtime/jsonschema/testdata/arbitrary_function_any.json
@@ -1,5 +1,4 @@
 {
-  "additionalProperties": true,
   "anyOf": [
     {
       "title": "string",


### PR DESCRIPTION
`additionalProperties` is not required for `any` types in the jsonschema and breaks the RJSF ui on tools as no additional property names are provided:

