### PR TITLE
fix: pageInfo typing in typescript client

### DIFF
--- a/node/client.go
+++ b/node/client.go
@@ -240,6 +240,18 @@ func writeClientTypes(w *codegen.Writer, schema *proto.Schema, api *proto.Api) {
 	}
 
 	w.Writeln(`export type SortDirection = "asc" | "desc" | "ASC" | "DESC";`)
+
+	w.Writeln("")
+	w.Writeln("type PageInfo = {")
+	w.Indent()
+	w.Writeln("count: number;")
+	w.Writeln("endCursor: string;")
+	w.Writeln("hasNextPage: boolean;")
+	w.Writeln("startCursor: string;")
+	w.Writeln("totalCount: number;")
+	w.Dedent()
+	w.Writeln("};")
+
 }
 
 func toClientActionReturnType(model *proto.Model, op *proto.Action) string {
@@ -443,13 +455,6 @@ type Err<U> = {
   data?: never;
   error: U;
 };
-
-type PageInfo = {
-    first?: number;
-    after?: string;
-    last?: number;
-    before?: string;
-}
 
 type Result<T, U> = NonNullable<Data<T> | Err<U>>;
 

--- a/node/client.go
+++ b/node/client.go
@@ -251,8 +251,7 @@ func toClientActionReturnType(model *proto.Model, op *proto.Action) string {
 	case proto.ActionType_ACTION_TYPE_GET:
 		return model.Name + " | null"
 	case proto.ActionType_ACTION_TYPE_LIST:
-		// TODO: type PageInfo properly
-		return "{results: " + model.Name + "[], pageInfo: any}"
+		return "{results: " + model.Name + "[], pageInfo: PageInfo}"
 	case proto.ActionType_ACTION_TYPE_DELETE:
 		return "string"
 	case proto.ActionType_ACTION_TYPE_READ, proto.ActionType_ACTION_TYPE_WRITE:
@@ -444,6 +443,13 @@ type Err<U> = {
   data?: never;
   error: U;
 };
+
+type PageInfo = {
+    first?: number;
+    after?: string;
+    last?: number;
+    before?: string;
+}
 
 type Result<T, U> = NonNullable<Data<T> | Err<U>>;
 

--- a/node/client_test.go
+++ b/node/client_test.go
@@ -161,7 +161,7 @@ model Person {
 
 	expected := `
 listPeople: (i: ListPeopleInput) => {
-	return this.client.rawRequest<{results: Person[], pageInfo: any}>("listPeople", i);
+	return this.client.rawRequest<{results: Person[], pageInfo: PageInfo}>("listPeople", i);
 },`
 
 	runWriterTest(t, schema, expected, func(s *proto.Schema, w *codegen.Writer) {
@@ -187,7 +187,7 @@ createPerson: (i?: CreatePersonInput) => {
 	return this.client.rawRequest<Person>("createPerson", i);
 },
 listPeople: (i?: ListPeopleInput) => {
-	return this.client.rawRequest<{results: Person[], pageInfo: any}>("listPeople", i);
+	return this.client.rawRequest<{results: Person[], pageInfo: PageInfo}>("listPeople", i);
 }`
 
 	runWriterTest(t, schema, expected, func(s *proto.Schema, w *codegen.Writer) {
@@ -210,7 +210,7 @@ model Person {
 
 	expected := `
 listPeople: (i?: ListPeopleInput) => {
-	return this.client.rawRequest<{results: Person[], pageInfo: any}>("listPeople", i);
+	return this.client.rawRequest<{results: Person[], pageInfo: PageInfo}>("listPeople", i);
 }`
 
 	runWriterTest(t, schema, expected, func(s *proto.Schema, w *codegen.Writer) {
@@ -233,7 +233,7 @@ model Person {
 
 	expected := `
 listPeople: (i: ListPeopleInput) => {
-	return this.client.rawRequest<{results: Person[], pageInfo: any}>("listPeople", i);
+	return this.client.rawRequest<{results: Person[], pageInfo: PageInfo}>("listPeople", i);
 }`
 
 	runWriterTest(t, schema, expected, func(s *proto.Schema, w *codegen.Writer) {


### PR DESCRIPTION
## Fixed `pageInfo` typing in TypeScript client

The list actions's `pageInfo` property was of type `any`, but it has now been typed properly.