### PR TITLE
fix: getschemaactive returning null

### DIFF
--- a/cmd/program/model.go
+++ b/cmd/program/model.go
@@ -462,7 +462,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case RpcRequestMsg:
 		ctx := msg.r.Context()
 		ctx = db.WithDatabase(ctx, m.Database)
-		ctx = context.WithValue(ctx, "schema", m.Schema)
+		ctx = rpcApi.WithSchema(ctx, m.Schema)
 		r := msg.r.WithContext(ctx)
 		w := msg.w
 

--- a/cmd/program/model.go
+++ b/cmd/program/model.go
@@ -187,7 +187,7 @@ func (m *Model) Init() tea.Cmd {
 	m.functionsLogCh = make(chan tea.Msg, 1)
 	m.watcherCh = make(chan tea.Msg, 1)
 	m.Environment = "development"
-	m.RpcHandler = rpc.NewAPIServer(rpcApi.NewRpcApiServer(m.Schema), twirp.WithServerPathPrefix("/rpc"))
+	m.RpcHandler = rpc.NewAPIServer(&rpcApi.Server{}, twirp.WithServerPathPrefix("/rpc"))
 	m.RpcPort = "34087"
 
 	m.Status = StatusCheckingDependencies
@@ -462,6 +462,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case RpcRequestMsg:
 		ctx := msg.r.Context()
 		ctx = db.WithDatabase(ctx, m.Database)
+		ctx = context.WithValue(ctx, "schema", m.Schema)
 		r := msg.r.WithContext(ctx)
 		w := msg.w
 

--- a/rpc/rpcApi/schema.go
+++ b/rpc/rpcApi/schema.go
@@ -10,20 +10,16 @@ import (
 	"github.com/twitchtv/twirp"
 )
 
-func NewRpcApiServer(schema *proto.Schema) *Server {
-	return &Server{
-		Schema: schema,
-	}
-}
-
-type Server struct {
-	Schema *proto.Schema
-}
+type Server struct{}
 
 func (s *Server) GetActiveSchema(ctx context.Context, req *rpc.GetSchemaRequest) (*rpc.GetSchemaResponse, error) {
 	schema, ok := ctx.Value("schema").(*proto.Schema)
 	if !ok {
-		return nil, twirp.NewError(twirp.NotFound, "schema not found")
+		return nil, twirp.NewError(twirp.Internal, "schema not valid")
+	}
+
+	if schema == nil {
+		schema = &proto.Schema{}
 	}
 
 	return &rpc.GetSchemaResponse{


### PR DESCRIPTION
Fix for bug introduced in https://github.com/teamkeel/keel/pull/1359 which had not been released. The RPC Api's GetActiveSchema was always returning null.