### PR TITLE
build: verbose tracing flag

### DIFF
--- a/cmd/localTraceExporter/client.go
+++ b/cmd/localTraceExporter/client.go
@@ -41,6 +41,7 @@ type TraceSummary struct {
 	HasError  bool
 	Duration  time.Duration
 	RootName  string
+	Type      string
 }
 
 // NewClient creates a client that stores the spans in memory.
@@ -120,6 +121,12 @@ func (c *client) updateTraceSummary(traceID string, span *tracepb.Span) {
 
 	if span.ParentSpanId == nil {
 		summary.RootName = span.Name
+
+		for _, attr := range span.Attributes {
+			if attr.Key == "type" {
+				summary.Type = attr.Value.GetStringValue()
+			}
+		}
 	}
 
 	if span.Status.Code == tracepb.Status_STATUS_CODE_ERROR {

--- a/cmd/localTraceExporter/export.go
+++ b/cmd/localTraceExporter/export.go
@@ -10,8 +10,3 @@ import (
 func New(ctx context.Context) (*otlptrace.Exporter, error) {
 	return otlptrace.New(ctx, NewClient())
 }
-
-// NewUnstarted constructs a new Exporter and does not start it.
-func NewUnstarted() *otlptrace.Exporter {
-	return otlptrace.NewUnstarted(NewClient())
-}

--- a/cmd/program/model.go
+++ b/cmd/program/model.go
@@ -142,6 +142,10 @@ type Model struct {
 	// This does mean that the Console Monitoring page will not reflect any traces.
 	CustomTracing bool
 
+	// If true, do not filter events in the local trace exporter.
+	// This will then show all system events in the local console.
+	VerboseTracing bool
+
 	// Model state - used in View()
 	Status            int
 	Err               error

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ var (
 	flagPattern          string
 	flagTracing          bool
 	flagVersion          bool
+	flagVerboseTracing   bool
 )
 
 var rootCmd = &cobra.Command{

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -49,5 +49,6 @@ func init() {
 	if enabledDebugFlags == "true" {
 		runCmd.Flags().StringVar(&flagNodePackagesPath, "node-packages-path", "", "path to local @teamkeel npm packages")
 		runCmd.Flags().BoolVar(&flagTracing, "tracing", false, "trace instead with an OTEL collector (e.g. jaeger) on localhost:4318")
+		runCmd.Flags().BoolVar(&flagVerboseTracing, "verbose-tracing", false, "display all events in tracing")
 	}
 }

--- a/rpc/rpcApi/context.go
+++ b/rpc/rpcApi/context.go
@@ -8,8 +8,10 @@ import (
 )
 
 type schemaContextKey string
+type traceVerbosityContextKey string
 
 var schemaKey schemaContextKey = "schema"
+var traceVerbosityKey traceVerbosityContextKey = "verboseTraces"
 
 func GetSchema(ctx context.Context) (*proto.Schema, error) {
 	v := ctx.Value(schemaKey)
@@ -23,4 +25,18 @@ func GetSchema(ctx context.Context) (*proto.Schema, error) {
 
 func WithSchema(ctx context.Context, schema *proto.Schema) context.Context {
 	return context.WithValue(ctx, schemaKey, schema)
+}
+
+func WithTraceVerbosity(ctx context.Context, verbose bool) context.Context {
+	return context.WithValue(ctx, traceVerbosityKey, verbose)
+}
+
+func GetTraceVerbosity(ctx context.Context) (bool, error) {
+	v := ctx.Value(traceVerbosityKey)
+	verbose, ok := v.(bool)
+
+	if !ok {
+		return false, errors.New("trace verbosity in the context has wrong value type")
+	}
+	return verbose, nil
 }

--- a/runtime/auth/auth.go
+++ b/runtime/auth/auth.go
@@ -16,7 +16,6 @@ import (
 	"github.com/patrickmn/go-cache"
 	"github.com/pquerna/cachecontrol"
 	"github.com/teamkeel/keel/runtime/runtimectx"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -65,7 +64,7 @@ type HTTPClient interface {
 }
 
 func init() {
-	HttpClient = &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
+	HttpClient = &http.Client{}
 	RequestCache = cache.New(5*time.Minute, 10*time.Minute)
 	JwkCache = jwk.NewCache(context.Background())
 }


### PR DESCRIPTION
* By default only show request traces in the local console
* Use `verbose-tracing` flag for run command to include all system events