### PR TITLE
fix: propagate error messages for httpjson in test environment

### DIFF
--- a/runtime/apis/httpjson/httpjson.go
+++ b/runtime/apis/httpjson/httpjson.go
@@ -16,6 +16,7 @@ import (
 	"github.com/teamkeel/keel/runtime/common"
 	"github.com/teamkeel/keel/runtime/jsonschema"
 	"github.com/teamkeel/keel/runtime/openapi"
+	"github.com/teamkeel/keel/runtime/runtimectx"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -144,6 +145,10 @@ func NewErrorResponse(ctx context.Context, err error, data map[string]any) commo
 	code := common.ErrInternal
 	message := "error executing request"
 	httpCode := http.StatusInternalServerError
+
+	if runtimectx.GetEnv(ctx) == "test" {
+		message = fmt.Sprintf("%s (%s)", message, err.Error())
+	}
 
 	var runtimeError common.RuntimeError
 	if errors.As(err, &runtimeError) {


### PR DESCRIPTION
## Problem

Errors in tests lack context. Check the issue https://github.com/teamkeel/keel/issues/1371

![image](https://github.com/teamkeel/keel/assets/17473315/ac9d6f70-fc8f-4ab5-a760-186f31299bbb)

## Solution

Propagate errors in a test environment

<img width="888" alt="image" src="https://github.com/teamkeel/keel/assets/17473315/1fff3733-4398-4f34-bd2e-c31dd98b9a37">
