### PR TITLE
fix: non-ksuid id for identity

### DIFF
--- a/integration/testdata/identity_and_authentication/tests.test.ts
+++ b/integration/testdata/identity_and_authentication/tests.test.ts
@@ -664,3 +664,21 @@ test("create and authenticate - email exists for another issuer - success", asyn
 
   expect(created2).toEqual(false);
 });
+
+test('identity with custom non-ksuid id', async () => {
+  const johnDoe = await models.identity.create({
+    id: 'john',
+    email: 'john@example.com',
+  });
+
+  const post = await models.post.create({
+    title: 'example post',
+    identityId: johnDoe.id,
+  });
+
+  const fetchedRecord = await actions.withIdentity(johnDoe).getPostRequiresIdentity({ id: post.id });
+  expect(fetchedRecord).toEqual(post);
+
+  const fetchedIdentity = await models.identity.findOne({ id: "john" });
+  expect(fetchedIdentity).toEqual(johnDoe);
+});

--- a/integration/testdata/identity_and_authentication/tests.test.ts
+++ b/integration/testdata/identity_and_authentication/tests.test.ts
@@ -665,20 +665,22 @@ test("create and authenticate - email exists for another issuer - success", asyn
   expect(created2).toEqual(false);
 });
 
-test('identity with custom non-ksuid id', async () => {
+test("identity with custom non-ksuid id", async () => {
   const johnDoe = await models.identity.create({
-    id: 'john',
-    email: 'john@example.com',
+    id: "not-a-ksuid",
+    email: "john@example.com",
   });
 
   const post = await models.post.create({
-    title: 'example post',
+    title: "example post",
     identityId: johnDoe.id,
   });
 
-  const fetchedRecord = await actions.withIdentity(johnDoe).getPostRequiresIdentity({ id: post.id });
+  const fetchedRecord = await actions
+    .withIdentity(johnDoe)
+    .getPostRequiresIdentity({ id: post.id });
   expect(fetchedRecord).toEqual(post);
 
-  const fetchedIdentity = await models.identity.findOne({ id: "john" });
+  const fetchedIdentity = await models.identity.findOne({ id: "not-a-ksuid" });
   expect(fetchedIdentity).toEqual(johnDoe);
 });

--- a/packages/functions-runtime/src/ModelAPI.test.js
+++ b/packages/functions-runtime/src/ModelAPI.test.js
@@ -71,6 +71,19 @@ test("ModelAPI.create", async () => {
   expect(KSUID.parse(row.id).string).toEqual(row.id);
 });
 
+test("ModelAPI.create - non-ksuid id", async () => {
+  const row = await personAPI.create({
+    id: "not-a-ksuid",
+    name: "Jim",
+    married: false,
+    favouriteNumber: 10,
+  });
+  expect(row.name).toEqual("Jim");
+  expect(row.married).toEqual(false);
+  expect(row.favouriteNumber).toEqual(10);
+  expect(row.id).toEqual(row.id);
+});
+
 test("ModelAPI.create - throws if not not null constraint violation", async () => {
   await expect(
     authorAPI.create({

--- a/runtime/actions/identity.go
+++ b/runtime/actions/identity.go
@@ -3,10 +3,8 @@ package actions
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
-	"github.com/segmentio/ksuid"
 	"github.com/teamkeel/keel/proto"
 	"github.com/teamkeel/keel/runtime/auth"
 	"github.com/teamkeel/keel/runtime/oauth"
@@ -246,9 +244,6 @@ func mapToIdentity(values map[string]any) (*auth.Identity, error) {
 	id, ok := values["id"].(string)
 	if !ok {
 		return nil, errors.New("id for identity is required")
-	}
-	if _, err := ksuid.Parse(id); err != nil {
-		return nil, fmt.Errorf("id for identity cannot be parsed: %s", values["id"])
 	}
 
 	externalId, ok := values["externalId"].(string)

--- a/runtime/oauth/access_token.go
+++ b/runtime/oauth/access_token.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
-	"github.com/segmentio/ksuid"
 	"github.com/teamkeel/keel/runtime/common"
 	"github.com/teamkeel/keel/runtime/runtimectx"
 )
@@ -114,10 +113,9 @@ func ValidateAccessToken(ctx context.Context, tokenString string) (string, strin
 		return "", "", ErrInvalidToken
 	}
 
-	identifier, err := ksuid.Parse(claims.Subject)
-	if err != nil {
-		return "", "", err
+	if claims.Subject == "" {
+		return "", "", errors.New("the identity id in the subject claim is required")
 	}
 
-	return identifier.String(), claims.Issuer, nil
+	return claims.Subject, claims.Issuer, nil
 }

--- a/runtime/oauth/access_token.go
+++ b/runtime/oauth/access_token.go
@@ -114,7 +114,7 @@ func ValidateAccessToken(ctx context.Context, tokenString string) (string, strin
 	}
 
 	if claims.Subject == "" {
-		return "", "", errors.New("the identity id in the subject claim is required")
+		return "", "", errors.New("subject claim cannot be empty")
 	}
 
 	return claims.Subject, claims.Issuer, nil


### PR DESCRIPTION
### Identity `id` field could not be non-ksuid

This issue https://github.com/teamkeel/keel/issues/1371 has revealed a bug when setting a custom, non-ksuid `id` for the Identity model.  An error in the runtime would occur when parsing the Identity row for authentication and authorization purposes as it was still expecting KSUID format.  This has now been relaxed.