### PR TITLE
fix: notequals for id in modelapi

### DIFF
--- a/integration/testdata/built_in_actions/main.test.ts
+++ b/integration/testdata/built_in_actions/main.test.ts
@@ -58,6 +58,20 @@ test("list action - equals", async () => {
   expect(posts.results.length).toEqual(2);
 });
 
+test("list action - notEquals on id", async () => {
+  await models.post.create({ title: "apple", subTitle: "def" });
+  const orange = await models.post.create({ title: "orange", subTitle: "efg" });
+
+  const posts = await actions.listPosts({
+    where: {
+      id: { notEquals: orange.id },
+    },
+  });
+
+  expect(posts.results.length).toEqual(1);
+  expect(posts.results[0].title).toEqual("apple");
+});
+
 test("list action - notEquals with string", async () => {
   await models.post.create({ title: "apple", subTitle: "def" });
   await models.post.create({ title: "orange", subTitle: "efg" });

--- a/integration/testdata/functions_model_api/main.test.ts
+++ b/integration/testdata/functions_model_api/main.test.ts
@@ -338,3 +338,23 @@ test("create - nested has-many two-levels", async () => {
   });
   expect(dbReadings.length).toBe(4);
 });
+
+test("findMany - notEquals", async () => {
+  const dickens = await models.author.create({
+    name: "Charles Dickens",
+  });
+  const tolkien = await models.author.create({
+    name: "J.R.R. Tolkien",
+  });
+
+  const authors = await models.author.findMany({
+    where: {
+      id: {
+        notEquals: dickens.id,
+      },
+    },
+  });
+
+  expect(authors.length).toBe(1);
+  expect(authors[0].id).equals(tolkien.id);
+});

--- a/packages/functions-runtime/src/ModelAPI.test.js
+++ b/packages/functions-runtime/src/ModelAPI.test.js
@@ -271,6 +271,26 @@ test("ModelAPI.findMany - oneOf", async () => {
   expect(rows.map((x) => x.id).sort()).toEqual([billy.id, sally.id].sort());
 });
 
+test("ModelAPI.findMany - notEquals on id", async () => {
+  const p1 = await personAPI.create({
+    id: KSUID.randomSync().string,
+    favouriteNumber: 1,
+  });
+  const p2 = await personAPI.create({
+    id: KSUID.randomSync().string,
+    favouriteNumber: 2,
+  });
+  const rows = await personAPI.findMany({
+    where: {
+      id: {
+        notEquals: p1.id,
+      },
+    },
+  });
+  expect(rows.length).toEqual(1);
+  expect(rows[0].id).toEqual(p2.id);
+});
+
 test("ModelAPI.findMany - greaterThan", async () => {
   await personAPI.create({
     id: KSUID.randomSync().string,

--- a/packages/functions-runtime/src/index.d.ts
+++ b/packages/functions-runtime/src/index.d.ts
@@ -1,5 +1,6 @@
 export type IDWhereCondition = {
   equals?: string | null;
+  notEquals?: string | null;
   oneOf?: string[] | null;
 };
 
@@ -8,8 +9,8 @@ export type StringWhereCondition = {
   endsWith?: string | null;
   oneOf?: string[] | null;
   contains?: string | null;
-  notEquals?: string | null;
   equals?: string | null;
+  notEquals?: string | null;
 };
 
 export type BooleanWhereCondition = {


### PR DESCRIPTION
### notEquals for `id` field on the ModelAPI

Fix for issue reported here: https://discord.com/channels/1135925644098809907/1135931890621239326/1198899132283236366

