### PR TITLE
fix: add console auth provider on cli

### DIFF
--- a/rpc/rpcApi/context.go
+++ b/rpc/rpcApi/context.go
@@ -31,12 +31,12 @@ func WithTraceVerbosity(ctx context.Context, verbose bool) context.Context {
 	return context.WithValue(ctx, traceVerbosityKey, verbose)
 }
 
-func GetTraceVerbosity(ctx context.Context) (bool, error) {
+func GetTraceVerbosity(ctx context.Context) bool {
 	v := ctx.Value(traceVerbosityKey)
-	verbose, ok := v.(bool)
+	verbose, has := v.(bool)
 
-	if !ok {
-		return false, errors.New("trace verbosity in the context has wrong value type")
+	if !has {
+		return false
 	}
-	return verbose, nil
+	return verbose
 }

--- a/rpc/rpcApi/server.go
+++ b/rpc/rpcApi/server.go
@@ -67,10 +67,7 @@ func (s *Server) RunSQLQuery(ctx context.Context, input *rpc.SQLQueryInput) (*rp
 func (s *Server) ListTraces(ctx context.Context, input *rpc.ListTracesRequest) (*rpc.ListTracesResponse, error) {
 	traces := localTraceExporter.Summary()
 
-	verbose, err := GetTraceVerbosity(ctx)
-	if err != nil {
-		return nil, err
-	}
+	verbose := GetTraceVerbosity(ctx)
 
 	list := []*rpc.TraceItem{}
 


### PR DESCRIPTION
### Local Console auth token fix

When using the local Console we are getting failed token requests because the Console's auth provider has not been configured in the customer's keelconfig.yaml.  We therefore add this to the configuration.  Note that we are only adding it for ID Token authentication and therefore no client secret is required.