### PR TITLE
fix: local tracing for functions runtime

### DIFF
--- a/cmd/program/model.go
+++ b/cmd/program/model.go
@@ -208,10 +208,6 @@ func (m *Model) Init() tea.Cmd {
 	m.RpcPort = "34087"
 	m.TracePort = "4318"
 
-	// if !m.CustomTracing {
-	// 	StartTraceServer(m.TracePort)
-	// }
-
 	m.Status = StatusCheckingDependencies
 	return CheckDependencies()
 }

--- a/cmd/program/model.go
+++ b/cmd/program/model.go
@@ -119,8 +119,9 @@ type Model struct {
 	Mode int
 
 	// Port to run the runtime servers on in ModeRun
-	Port    string
-	RpcPort string
+	Port      string
+	RpcPort   string
+	TracePort string
 
 	// If true then the database will be reset. Only
 	// applies to ModeRun.
@@ -205,6 +206,11 @@ func (m *Model) Init() tea.Cmd {
 	m.Environment = "development"
 	m.RpcHandler = rpc.NewAPIServer(&rpcApi.Server{}, twirp.WithServerPathPrefix("/rpc"))
 	m.RpcPort = "34087"
+	m.TracePort = "4318"
+
+	// if !m.CustomTracing {
+	// 	StartTraceServer(m.TracePort)
+	// }
 
 	m.Status = StatusCheckingDependencies
 	return CheckDependencies()
@@ -281,6 +287,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			NextMsgCommand(m.runtimeRequestsCh),
 			NextMsgCommand(m.rpcRequestsCh),
 			LoadSchema(m.ProjectDir, m.Environment),
+		}
+
+		if !m.CustomTracing {
+			cmds = append(cmds, StartTraceServer(m.TracePort))
 		}
 
 		if m.Mode == ModeRun {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -48,7 +48,7 @@ func init() {
 
 	if enabledDebugFlags == "true" {
 		runCmd.Flags().StringVar(&flagNodePackagesPath, "node-packages-path", "", "path to local @teamkeel npm packages")
-		runCmd.Flags().BoolVar(&flagTracing, "tracing", false, "trace instead with an OTEL collector (e.g. jaeger) on localhost:4318")
+		runCmd.Flags().BoolVar(&flagTracing, "custom-tracing", false, "trace instead with an OTEL collector (e.g. jaeger) on localhost:4318")
 		runCmd.Flags().BoolVar(&flagVerboseTracing, "verbose-tracing", false, "display all events in tracing")
 	}
 }

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,3 +1,8 @@
+# Run the following to set up the database instance use for tests:
+#    docker compose up -d
+# Run the following to also provision Jaeger for local tracing:
+#    docker compose --profile tracing up -d
+
 services:
   postgres:
     image: postgres:15
@@ -12,6 +17,7 @@ services:
   jaeger:
     image: jaegertracing/all-in-one:1.45
     restart: always
+    profiles: [tracing]
     environment:
       - COLLECTOR_OTLP_ENABLED=true
     ports:


### PR DESCRIPTION
## Local traces for functions runtime

Local Console monitoring was not yet capturing functions runtime tracing.  This PR will ensure that all traces are captured.

<img width="1313" alt="image" src="https://github.com/teamkeel/keel/assets/6212830/cd58f310-6727-410a-8d14-77c1d3ec48e0">

Also renamed the tracing flag to `custom-tracing`, which feels more appropriate.  Enabling this flag with disable Keel tracing and let you run your own OTEL receiver on localhost:4318
