### PR TITLE
fix: api model action code completions

### DIFF
--- a/schema/completions/completions.go
+++ b/schema/completions/completions.go
@@ -1089,25 +1089,6 @@ func getParentModelName(t *TokensAtPosition) string {
 	return ""
 }
 
-// getApiModelName name returns the user-defined name of the
-// model that `t` is within in an `api` block
-func getApiModelName(t *TokensAtPosition) string {
-	for {
-		t = t.StartOfBlock()
-		if t == nil {
-			break
-		}
-
-		if t.ValueAt(-2) == parser.KeywordModel {
-			return t.ValueAt(-1)
-		}
-
-		t = t.Prev()
-	}
-
-	return ""
-}
-
 var identRegex = regexp.MustCompile("^[a-zA-Z]+$")
 
 // getPreviousIdents returns the idents that are part of the same

--- a/schema/completions/completions_test.go
+++ b/schema/completions/completions_test.go
@@ -1539,7 +1539,6 @@ func TestOnCompletions(t *testing.T) {
 }
 
 func TestRoleCompletions(t *testing.T) {
-
 	cases := []testCase{
 		{
 			name: "role-keyword",
@@ -1619,6 +1618,115 @@ func TestAPICompletions(t *testing.T) {
 			}
 			`,
 			expected: []string{"Identity", "Person"},
+		},
+		{
+			name: "actions-keyword",
+			schema: `
+			model Person {}
+
+			api Test {
+				models {
+					Person {
+						<Cursor>
+					}
+				}
+			}
+			`,
+			expected: []string{"actions"},
+		},
+		{
+			name: "api-action-names",
+			schema: `
+			model Person {
+				actions {
+					get getPerson(id)
+					create createPerson() @function
+				}
+			}
+
+			api Api {
+				models {
+					Person {
+						actions {
+							<Cursor>
+						}
+					}
+				}
+			}
+			`,
+			expected: []string{"getPerson", "createPerson"},
+		},
+		{
+			name: "api-action-names-multiple-actions",
+			schema: `
+			model Person {
+				actions {
+					get getPerson(id)
+					create createPerson() @function
+				}
+			}
+			api Api {
+				models {
+					Person {
+						actions {
+							getPerson
+							<Cursor>
+						}
+					}
+				}
+			}
+			`,
+			expected: []string{"getPerson", "createPerson"},
+		},
+		{
+			name: "api-action-names-multiple-models",
+			schema: `
+			model Person {
+				actions {
+					get getPerson(id)
+					create createPerson() @function
+				}
+			}
+			model Company {
+				actions {
+					write writeCompany(Any) returns (Any)
+				}
+			}
+			api Api {
+				models {
+					Person {
+						actions {
+							getPerson
+						}
+					}
+					Company {
+						actions {
+							<Cursor>
+						}
+					}
+				}
+			}
+			`,
+			expected: []string{"writeCompany"},
+		}, {
+			name: "api-action-names-model-not-exists",
+			schema: `
+			model Person {
+				actions {
+					get getPerson(id)
+				}
+			}
+			api Api {
+				models {
+					NotExists {
+						actions {
+							<Cursor>
+						}
+					}
+				}
+			}
+			`,
+			expected: []string{},
 		},
 	}
 


### PR DESCRIPTION
### Code completions for API model actions

Intended for use by the VS Code extension.

Suggests `actions` in an opened model block:

```
api MyApi {
  models {
    Author {
       <<--  actions
    }
  }
}
```

Suggests action names in an opened actions block:

```
api MyApi {
  models {
    Author {
       actions {
           <<-- getAuthor, createAuthor, etc.
       }
    }
  }
}
```