### PR TITLE
fix: create action validation for optional input on required field

### DIFF
--- a/schema/testdata/errors/create_missing_identity.keel
+++ b/schema/testdata/errors/create_missing_identity.keel
@@ -5,7 +5,7 @@ model Todo {
     }
 
     actions {
-        //expect-error:16:26:ActionInputError:the identity field of Todo is not set as part of this create operation
+        //expect-error:16:26:ActionInputError:the identity field of Todo is not set as part of this create action
         create createTodo() with (name)
     }
 }

--- a/schema/testdata/errors/create_missing_identity_nested.keel
+++ b/schema/testdata/errors/create_missing_identity_nested.keel
@@ -12,7 +12,7 @@ model Post {
     }
 
     actions {
-        //expect-error:16:26:ActionInputError:the identity field of Profile is not set as part of this create operation
+        //expect-error:16:26:ActionInputError:the identity field of Profile is not set as part of this create action
         create createPost() with (body, profile.name)
     }
 }
@@ -23,7 +23,7 @@ model Comment {
     }
 
     actions {
-        //expect-error:16:29:ActionInputError:the identity field of Profile is not set as part of this create operation
+        //expect-error:16:29:ActionInputError:the identity field of Profile is not set as part of this create action
         create createComment() with (post.body, post.profile.name)
     }
 }

--- a/schema/testdata/errors/field_required_with_optional_input.keel
+++ b/schema/testdata/errors/field_required_with_optional_input.keel
@@ -1,0 +1,10 @@
+model StockLocation {
+    fields {
+        title Text
+    }
+
+    actions {
+        //expect-error:16:35:E034:required field 'title' must be set by a non-optional input, a @set expression or with @default
+        create createStockLocation() with (title?)
+    }
+}

--- a/schema/testdata/errors/operation_create_missing_inputs.keel
+++ b/schema/testdata/errors/operation_create_missing_inputs.keel
@@ -2,10 +2,11 @@ model Person {
     fields {
         name Text
         age Number
+        notRequired Text?
     }
 
     actions {
-        //expect-error:16:28:E034:create actions must accept all required fields that have no default value
+        //expect-error:16:28:E034:required field 'age' must be set by a non-optional input, a @set expression or with @default
         create createPerson() with (name)
     }
 }

--- a/schema/testdata/errors/operations_unused_inputs.keel
+++ b/schema/testdata/errors/operations_unused_inputs.keel
@@ -4,7 +4,7 @@ model Person {
     }
 
     actions {
-        //expect-error:16:28:E034:create actions must accept all required fields that have no default value
+        //expect-error:16:28:E034:required field 'name' must be set by a non-optional input, a @set expression or with @default
         //expect-error:37:47:ActionInputError:personName is not used. Labelled inputs must be used in the action, for example in a @set or @where attribute
         create createPerson() with (personName: name)
         //expect-error:39:49:ActionInputError:personName is not used. Labelled inputs must be used in the action, for example in a @set or @where attribute

--- a/schema/testdata/errors/relationships_create_nested_missing_all_fields.keel
+++ b/schema/testdata/errors/relationships_create_nested_missing_all_fields.keel
@@ -8,12 +8,12 @@ model House {
     }
 
     actions {
-        //expect-error:16:27:E034:create actions must accept all required fields that have no default value
-        //expect-error:16:27:E034:create actions must accept all required fields that have no default value
-        //expect-error:16:27:E034:create actions must accept all required fields that have no default value
-        //expect-error:16:27:E034:create actions must accept all required fields that have no default value
-        //expect-error:16:27:E034:create actions must accept all required fields that have no default value
-        //expect-error:16:27:E034:create actions must accept all required fields that have no default value
+        //expect-error:16:27:E034:required field 'houseNumber' must be set by a non-optional input, a @set expression or with @default
+        //expect-error:16:27:E034:required field 'waterConnection.supplierCo' must be set by a non-optional input, a @set expression or with @default
+        //expect-error:16:27:E034:required field 'waterConnection.region' must be set by a non-optional input, a @set expression or with @default
+        //expect-error:16:27:E034:required field 'owner.ownerName' must be set by a non-optional input, a @set expression or with @default
+        //expect-error:16:27:E034:required field 'owner.pet.typeOfAnimal' must be set by a non-optional input, a @set expression or with @default
+        //expect-error:16:27:E034:required field 'owner.pet.favouriteToy.whatIsIt' must be set by a non-optional input, a @set expression or with @default
         create createHouse() with (houseName)
     }
 }

--- a/schema/testdata/errors/relationships_create_nested_missing_some_fields.keel
+++ b/schema/testdata/errors/relationships_create_nested_missing_some_fields.keel
@@ -8,8 +8,8 @@ model House {
     }
 
     actions {
-        //expect-error:16:27:E034:create actions must accept all required fields that have no default value
-        //expect-error:16:27:E034:create actions must accept all required fields that have no default value
+        //expect-error:16:27:E034:required field 'owner.pet.typeOfAnimal' must be set by a non-optional input, a @set expression or with @default
+        //expect-error:16:27:E034:required field 'owner.pet.favouriteToy.whatIsIt' must be set by a non-optional input, a @set expression or with @default
         create createHouse() with (
             houseName,
             houseNumber,

--- a/schema/testdata/errors/relationships_create_nested_misspelled_field.keel
+++ b/schema/testdata/errors/relationships_create_nested_misspelled_field.keel
@@ -8,7 +8,7 @@ model House {
     }
 
     actions {
-        //expect-error:16:27:E034:create actions must accept all required fields that have no default value
+        //expect-error:16:27:E034:required field 'owner.ownerName' must be set by a non-optional input, a @set expression or with @default
         create createHouse() with (
             houseName,
             houseNumber,

--- a/schema/testdata/errors/relationships_create_nested_recognizes_non_create.keel
+++ b/schema/testdata/errors/relationships_create_nested_recognizes_non_create.keel
@@ -8,10 +8,10 @@ model House {
     }
 
     actions {
-        //expect-error:16:27:E034:create actions must accept all required fields that have no default value
-        //expect-error:16:27:E034:create actions must accept all required fields that have no default value
-        //expect-error:16:27:E034:create actions must accept all required fields that have no default value
-        //expect-error:16:27:E034:create actions must accept all required fields that have no default value
+        //expect-error:16:27:E034:required field 'houseNumber' must be set by a non-optional input, a @set expression or with @default
+        //expect-error:16:27:E034:required field 'owner.ownerName' must be set by a non-optional input, a @set expression or with @default
+        //expect-error:16:27:E034:required field 'owner.pet.typeOfAnimal' must be set by a non-optional input, a @set expression or with @default
+        //expect-error:16:27:E034:required field 'owner.pet.favouriteToy.whatIsIt' must be set by a non-optional input, a @set expression or with @default
         create createHouse() with (houseName, waterConnection.id)
     }
 }

--- a/schema/testdata/errors/relationships_create_nested_undertands_optional.keel
+++ b/schema/testdata/errors/relationships_create_nested_undertands_optional.keel
@@ -8,11 +8,11 @@ model House {
     }
 
     actions {
-        //expect-error:16:27:E034:create actions must accept all required fields that have no default value
-        //expect-error:16:27:E034:create actions must accept all required fields that have no default value
-        //expect-error:16:27:E034:create actions must accept all required fields that have no default value
-        //expect-error:16:27:E034:create actions must accept all required fields that have no default value
-        //expect-error:16:27:E034:create actions must accept all required fields that have no default value
+        //expect-error:16:27:E034:required field 'houseNumber' must be set by a non-optional input, a @set expression or with @default
+        //expect-error:16:27:E034:required field 'waterConnection.supplierCo' must be set by a non-optional input, a @set expression or with @default
+        //expect-error:16:27:E034:required field 'waterConnection.region' must be set by a non-optional input, a @set expression or with @default
+        //expect-error:16:27:E034:required field 'owner.ownerName' must be set by a non-optional input, a @set expression or with @default
+        //expect-error:16:27:E034:required field 'owner.pet.typeOfAnimal' must be set by a non-optional input, a @set expression or with @default
         create createHouse() with (houseName)
     }
 }

--- a/schema/validation/errorhandling/errors.go
+++ b/schema/validation/errorhandling/errors.go
@@ -51,7 +51,6 @@ const (
 	ErrorClashingImplicitInput               = "E043"
 	ErrorMissingRelationshipField            = "E044"
 	ErrorAmbiguousRelationship               = "E045"
-	ErrorCreateActionMissingInputAliases     = "E046"
 	ErrorModelNotFound                       = "E047"
 	ErrorExpressionFieldTypeMismatch         = "E048"
 	ErrorExpressionMultipleConditions        = "E049"

--- a/schema/validation/errorhandling/errors.yml
+++ b/schema/validation/errorhandling/errors.yml
@@ -89,8 +89,8 @@ en:
     message: "create actions cannot take read inputs"
     hint: "maybe add {{ .Input }} to the with() inputs"
   E034:
-    message: "create actions must accept all required fields that have no default value"
-    hint: "maybe add {{ .FieldName }} to the with() inputs or a @set expression"
+    message: "required field '{{ .FieldName }}' must be set by a non-optional input, a @set expression or with @default"
+    hint: "To learn more about create action inputs, visit https://docs.keel.so/actions#create"
   E035:
     message: "{{ .Input }} is not a unique field. {{ .ActionType }} actions take only unique inputs"
     hint: ""
@@ -123,9 +123,6 @@ en:
   E045:
     message: "The @relation attribute must be used as more than one field on the {{ .ModelA }} model references {{ .ModelB }}"
     hint: "Define the @relation attribute on this field to indicate which field on {{ .ModelA }} it references"
-  E046:
-    message: "create actions must accept all required fields that have no default value"
-    hint: "maybe add one of {{ .WithNames }} to with() inputs, or one of {{ .SetNames }} to a @set expression"
   E047:
     message: "api '{{ .API }}' has an unrecognised model {{ .Model }}"
     hint: ""


### PR DESCRIPTION
### Validation for optional input on required field on create actions

For example, the following should not pass validation because `title` is a required field.

```
model StockLocation {
    fields {
        title Text
    }

    actions {
        create createStockLocation() with (title?)
    }
}
```

This will now fail validations with the following:

 > required field 'title' must be set by a non-optional input, a @set expression or with @default
