### PR TITLE
chore: setup keel console auth providers

### DIFF
--- a/cmd/program/commands.go
+++ b/cmd/program/commands.go
@@ -74,6 +74,18 @@ func LoadSchema(dir, environment string) tea.Cmd {
 			b.Config = &config.ProjectConfig{}
 		}
 
+		// Add the OIDC auth provider used on the Console's internal tools
+		configErr = b.Config.Auth.AddOidcProvider(consoleAuthProviderName1, consoleAuthProviderIssuer1, consoleAuthProviderClientId1)
+		if configErr != nil {
+			err = configErr
+		}
+
+		// Add the OIDC auth provider used on the Console's internal tools
+		configErr = b.Config.Auth.AddOidcProvider(consoleAuthProviderName2, consoleAuthProviderIssuer2, consoleAuthProviderClientId2)
+		if configErr != nil {
+			err = configErr
+		}
+
 		invalid, invalidSecrets := b.Config.ValidateSecrets(secrets)
 		if invalid {
 			err = fmt.Errorf("missing secrets from local config in ~/.keel/config.yaml: %s", strings.Join(invalidSecrets, ", "))

--- a/cmd/program/model.go
+++ b/cmd/program/model.go
@@ -59,8 +59,15 @@ const (
 )
 
 const (
-	consoleAuthProviderIssuer   = "https://auth.keel.xyz/"
-	consoleAuthProviderClientId = "KvnOmNPy17WtMGBseDZRw3Hgn0ZOQpDd"
+	consoleAuthProviderName1     = "keel_console_auth_1"
+	consoleAuthProviderIssuer1   = "https://auth.keel.xyz/"
+	consoleAuthProviderClientId1 = "KvnOmNPy17WtMGBseDZRw3Hgn0ZOQpDd"
+)
+
+const (
+	consoleAuthProviderName2     = "keel_console_auth_2"
+	consoleAuthProviderIssuer2   = "https://auth.staging.keel.xyz/"
+	consoleAuthProviderClientId2 = "mXXReYQdTSIm2UhTRzMkYmMQGU1GC6wp"
 )
 
 var tracer = otel.Tracer("github.com/teamkeel/keel/db")
@@ -317,6 +324,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				http.MethodHead,
 				http.MethodGet,
 				http.MethodPost,
+
 				http.MethodPut,
 				http.MethodPatch,
 				http.MethodDelete,
@@ -447,12 +455,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		ctx = runtimectx.WithSecrets(ctx, m.Secrets)
 		ctx = runtimectx.WithOAuthConfig(ctx, &m.Config.Auth)
 
-		// Add the OIDC auth provider used on the Console's internal tools
-		err := m.Config.Auth.AddOidcProvider("keel_console_auth", consoleAuthProviderIssuer, consoleAuthProviderClientId)
-		if err != nil {
-			span.RecordError(err)
-		}
-
 		mailClient := mail.NewSMTPClientFromEnv()
 		if mailClient != nil {
 			ctx = runtimectx.WithMailClient(ctx, mailClient)
@@ -474,7 +476,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Synchronous event handling for keel run.
 		// TODO: make asynchronous
-		ctx, err = events.WithEventHandler(ctx, func(ctx context.Context, subscriber string, event *events.Event, traceparent string) error {
+		ctx, err := events.WithEventHandler(ctx, func(ctx context.Context, subscriber string, event *events.Event, traceparent string) error {
 			return runtime.NewSubscriberHandler(m.Schema).RunSubscriber(ctx, subscriber, event)
 		})
 		if err != nil {

--- a/config/auth.go
+++ b/config/auth.go
@@ -95,7 +95,7 @@ func (c *AuthConfig) AddOidcProvider(name string, issuerUrl string, clientId str
 	}
 	for _, v := range c.Providers {
 		if v.Name == name {
-			return fmt.Errorf(ConfigAuthProviderNameExists, name)
+			return fmt.Errorf(ConfigAuthProviderDuplicateErrorString, name)
 		}
 	}
 	if invalidUrl(issuerUrl) {

--- a/config/auth.go
+++ b/config/auth.go
@@ -21,6 +21,8 @@ const (
 
 const ProviderSecretPrefix = "AUTH_PROVIDER_SECRET_"
 
+const ReservedProviderNamePrefix = "keel_"
+
 const (
 	GoogleProvider        = "google"
 	FacebookProvider      = "facebook"
@@ -90,6 +92,11 @@ func (c *AuthConfig) RefreshTokenRotationEnabled() bool {
 func (c *AuthConfig) AddOidcProvider(name string, issuerUrl string, clientId string) error {
 	if invalidName(name) {
 		return fmt.Errorf(ConfigAuthProviderInvalidName, name)
+	}
+	for _, v := range c.Providers {
+		if v.Name == name {
+			return fmt.Errorf(ConfigAuthProviderNameExists, name)
+		}
 	}
 	if invalidUrl(issuerUrl) {
 		return fmt.Errorf("invalid issuerUrl: %s", issuerUrl)
@@ -275,6 +282,18 @@ func findAuthProviderDuplicateName(providers []Provider) []Provider {
 	}
 
 	return duplicates
+}
+
+// findAuthProviderReservedName checks for reserved names
+func findAuthProviderReservedName(providers []Provider) []Provider {
+	invalid := []Provider{}
+	for _, p := range providers {
+		if strings.HasPrefix(strings.ToLower(p.Name), ReservedProviderNamePrefix) {
+			invalid = append(invalid, p)
+		}
+	}
+
+	return invalid
 }
 
 // findAuthProviderInvalidType checks for invalid provider types

--- a/config/config.go
+++ b/config/config.go
@@ -138,6 +138,8 @@ const (
 	ConfigReservedNameErrorString                    = "environment variable %s cannot start with %s as it is reserved"
 	ConfigAuthTokenExpiryMustBePositive              = "%s token lifespan cannot be negative or zero for field: %s"
 	ConfigAuthProviderInvalidName                    = "auth provider name '%s' must only include alphanumeric characters and underscores, and cannot start with a number"
+	ConfigAuthProviderNameExists                     = "auth provider name '%s' has already been defined"
+	ConfigAuthProviderReservedPrefex                 = "cannot use reserved 'keel_' prefix in auth provider name: %s"
 	ConfigAuthProviderMissingFieldAtIndexErrorString = "auth provider at index %v is missing field: %s"
 	ConfigAuthProviderMissingFieldErrorString        = "auth provider '%s' is missing field: %s"
 	ConfigAuthProviderInvalidTypeErrorString         = "auth provider '%s' has invalid type '%s' which must be one of: %s"
@@ -303,6 +305,17 @@ func Validate(config *ProjectConfig) *ConfigErrors {
 		errors = append(errors, &ConfigError{
 			Type:    "duplicate",
 			Message: fmt.Sprintf(ConfigAuthProviderDuplicateErrorString, p.Name),
+		})
+	}
+
+	reservedNames := findAuthProviderReservedName(config.Auth.Providers)
+	for _, p := range reservedNames {
+		if p.Name == "" {
+			continue
+		}
+		errors = append(errors, &ConfigError{
+			Type:    "reserved",
+			Message: fmt.Sprintf(ConfigAuthProviderReservedPrefex, p.Name),
 		})
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -138,7 +138,6 @@ const (
 	ConfigReservedNameErrorString                    = "environment variable %s cannot start with %s as it is reserved"
 	ConfigAuthTokenExpiryMustBePositive              = "%s token lifespan cannot be negative or zero for field: %s"
 	ConfigAuthProviderInvalidName                    = "auth provider name '%s' must only include alphanumeric characters and underscores, and cannot start with a number"
-	ConfigAuthProviderNameExists                     = "auth provider name '%s' has already been defined"
 	ConfigAuthProviderReservedPrefex                 = "cannot use reserved 'keel_' prefix in auth provider name: %s"
 	ConfigAuthProviderMissingFieldAtIndexErrorString = "auth provider at index %v is missing field: %s"
 	ConfigAuthProviderMissingFieldErrorString        = "auth provider '%s' is missing field: %s"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -293,10 +293,24 @@ func TestAddOidcProvider(t *testing.T) {
 	assert.Len(t, byIssuer, 1)
 }
 
+func TestAddOidcProviderReservedPrefix(t *testing.T) {
+	_, err := Load("fixtures/test_auth_reserved_prefix.yaml")
+	assert.ErrorContains(t, err, "cannot use reserved 'keel_' prefix in auth provider name: keel_client")
+	assert.ErrorContains(t, err, "cannot use reserved 'keel_' prefix in auth provider name: KEEL_CLIENT")
+}
+
 func TestAddOidcProviderInvalidName(t *testing.T) {
 	auth := &AuthConfig{}
 	err := auth.AddOidcProvider("my client", "https://mycustomoidc.com", "1234")
 	assert.ErrorContains(t, err, "auth provider name 'my client' must only include alphanumeric characters and underscores, and cannot start with a number")
+}
+
+func TestAddOidcProviderAlreadyExists(t *testing.T) {
+	auth := &AuthConfig{}
+	err := auth.AddOidcProvider("my_client", "https://mycustomoidc.com", "1234")
+	assert.NoError(t, err)
+	err = auth.AddOidcProvider("my_client", "https://anothercustomoidc.com", "abcd")
+	assert.ErrorContains(t, err, "auth provider name 'my_client' has already been defined")
 }
 
 func TestGetCallbackUrl_Localhost(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -310,7 +310,7 @@ func TestAddOidcProviderAlreadyExists(t *testing.T) {
 	err := auth.AddOidcProvider("my_client", "https://mycustomoidc.com", "1234")
 	assert.NoError(t, err)
 	err = auth.AddOidcProvider("my_client", "https://anothercustomoidc.com", "abcd")
-	assert.ErrorContains(t, err, "auth provider name 'my_client' has already been defined")
+	assert.ErrorContains(t, err, "auth provider name 'my_client' has been defined more than once, but must be unique")
 }
 
 func TestGetCallbackUrl_Localhost(t *testing.T) {

--- a/config/fixtures/test_auth_reserved_prefix.yaml
+++ b/config/fixtures/test_auth_reserved_prefix.yaml
@@ -1,0 +1,16 @@
+auth:
+  tokens:
+    accessTokenExpiry: 3600
+    refreshTokenExpiry: 604800
+    refreshTokenRotationEnabled: false
+
+  redirectUrl: http://localhost:8000/signedin
+
+  providers:
+    - type: google
+      name: keel_client
+      clientId: foo_1
+
+    - type: google
+      name: KEEL_CLIENT
+      clientId: foo_1

--- a/runtime/apis/authapi/providers_endpoint.go
+++ b/runtime/apis/authapi/providers_endpoint.go
@@ -2,7 +2,9 @@ package authapi
 
 import (
 	"net/http"
+	"strings"
 
+	cfg "github.com/teamkeel/keel/config"
 	"github.com/teamkeel/keel/proto"
 	"github.com/teamkeel/keel/runtime/common"
 	"github.com/teamkeel/keel/runtime/runtimectx"
@@ -28,6 +30,10 @@ func ProvidersHandler(schema *proto.Schema) common.HandlerFunc {
 		providers := []ProviderResponse{}
 
 		for _, p := range config.Providers {
+			if strings.HasPrefix(strings.ToLower(p.Name), cfg.ReservedProviderNamePrefix) {
+				continue
+			}
+
 			authUrl, err := p.GetAuthorizeUrl()
 			if err != nil {
 				return common.InternalServerErrorResponse(ctx, err)


### PR DESCRIPTION
## CLI support for Keel Console auth providers

 - The CLI is setup with Keel's auth providers for Local Console support
 - `keel_` prefix now reserved for provider names (validation included)
 - `keel_`  providers omitted from `/auth/providers/` response