### PR TITLE
chore: keelconfig includes auth section on keel init

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -190,7 +190,11 @@ func initStepTemplate(state *InitState) {
 
 		state.files = append(state.files, &codegen.GeneratedFile{
 			Path: "keelconfig.yaml",
-			Contents: `# Visit https://docs.keel.so/envvars for more information about environment variables
+			Contents: `
+# Visit https://docs.keel.so/authentication/getting-started for more information about authentication
+auth:
+
+# Visit https://docs.keel.so/envvars for more information about environment variables
 environment:
 
 # Visit https://docs.keel.so/secrets for more information about secrets


### PR DESCRIPTION
## Including auth section in keelconfig.yaml

When running `keel init`, the keelconfig now generates to this:

```
# Visit https://docs.keel.so/authentication/getting-started for more information about authentication
auth:

# Visit https://docs.keel.so/envvars for more information about environment variables
environment:

# Visit https://docs.keel.so/secrets for more information about secrets
secrets:
```