### PR TITLE
fix: error filtering for local console monitoring

### DIFF
--- a/rpc/rpcApi/server.go
+++ b/rpc/rpcApi/server.go
@@ -72,7 +72,6 @@ func (s *Server) ListTraces(ctx context.Context, input *rpc.ListTracesRequest) (
 	list := []*rpc.TraceItem{}
 
 	for k, v := range traces {
-
 		if input.After != nil && v.StartTime.Before(input.After.AsTime()) {
 			continue
 		}
@@ -81,8 +80,26 @@ func (s *Server) ListTraces(ctx context.Context, input *rpc.ListTracesRequest) (
 			continue
 		}
 
-		if !verbose {
+		if input.Filters != nil {
+			filteredOut := false
+			for _, f := range input.Filters {
+				switch f.Field {
+				case "error":
+					if f.Value == "true" && !v.HasError {
+						filteredOut = true
+						break
+					} else if f.Value == "false" && v.HasError {
+						filteredOut = true
+						break
+					}
+				}
+			}
+			if filteredOut {
+				continue
+			}
+		}
 
+		if !verbose {
 			if v.Type != "request" {
 				continue
 			}


### PR DESCRIPTION
### Error trace filtering for Local Console monitoring

The CLI's RPC API exposes endpoints for use by the Local Console.  The `ListTraces` endpoints now filters traces by the "error" filter.