### PR TITLE
feat: password grant

### DIFF
--- a/runtime/actions/authenticate.go
+++ b/runtime/actions/authenticate.go
@@ -109,7 +109,7 @@ func Authenticate(scope *Scope, input map[string]any) (*AuthenticateResult, erro
 		return nil, err
 	}
 
-	identity, err = CreateIdentity(scope.Context, scope.Schema, emailPassword.String("email"), string(hashedBytes))
+	identity, err = CreateIdentity(scope.Context, scope.Schema, emailPassword.String("email"), string(hashedBytes), keelIssuerClaim)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/actions/identity.go
+++ b/runtime/actions/identity.go
@@ -88,15 +88,14 @@ func FindIdentityByExternalId(ctx context.Context, schema *proto.Schema, externa
 	return mapToIdentity(result)
 }
 
-// Deprecated: used by the the authenticate action which is to be deprecated.
-func CreateIdentity(ctx context.Context, schema *proto.Schema, email string, password string) (*auth.Identity, error) {
+func CreateIdentity(ctx context.Context, schema *proto.Schema, email string, password string, issuer string) (*auth.Identity, error) {
 	identityModel := proto.FindModel(schema.Models, parser.ImplicitIdentityModelName)
 
 	query := NewQuery(identityModel)
 	query.AddWriteValues(map[string]*QueryOperand{
 		"email":    Value(email),
 		"password": Value(password),
-		"issuer":   Value(keelIssuerClaim),
+		"issuer":   Value(issuer),
 	})
 	query.AppendSelect(AllFields())
 	query.AppendReturning(IdField())

--- a/runtime/apis/authapi/token_endpoint.go
+++ b/runtime/apis/authapi/token_endpoint.go
@@ -95,7 +95,7 @@ func TokenEndpointHandler(schema *proto.Schema) common.HandlerFunc {
 
 		grantType, hasGrantType := inputs[ArgGrantType].(string)
 		if !hasGrantType || grantType == "" {
-			return jsonErrResponse(ctx, http.StatusBadRequest, TokenErrInvalidRequest, "the grant-type field is required with either 'refresh_token', 'token_exchange', 'authorization_code', or 'password'", nil)
+			return jsonErrResponse(ctx, http.StatusBadRequest, TokenErrInvalidRequest, "the grant-type field is required with either 'refresh_token', 'token_exchange', 'authorization_code' or 'password'", nil)
 		}
 
 		span.SetAttributes(
@@ -257,7 +257,7 @@ func TokenEndpointHandler(schema *proto.Schema) common.HandlerFunc {
 			identityId = identity.Id
 
 		default:
-			return jsonErrResponse(ctx, http.StatusBadRequest, TokenErrUnsupportedGrantType, "the only supported grants are 'refresh_token', 'token_exchange', 'authorization_code', or 'password'", nil)
+			return jsonErrResponse(ctx, http.StatusBadRequest, TokenErrUnsupportedGrantType, "the only supported grants are 'refresh_token', 'token_exchange', 'authorization_code' or 'password'", nil)
 		}
 
 		// Generate a new access token for this identity.

--- a/runtime/apis/authapi/token_endpoint_test.go
+++ b/runtime/apis/authapi/token_endpoint_test.go
@@ -379,7 +379,7 @@ func TestTokenEndpointJson_MissingGrantType(t *testing.T) {
 
 	require.Equal(t, http.StatusBadRequest, httpResponse.StatusCode)
 	require.Equal(t, "invalid_request", errorResponse.Error)
-	require.Equal(t, "the grant-type field is required with either 'refresh_token', 'token_exchange', 'authorization_code', or 'password'", errorResponse.ErrorDescription)
+	require.Equal(t, "the grant-type field is required with either 'refresh_token', 'token_exchange', 'authorization_code' or 'password'", errorResponse.ErrorDescription)
 	require.True(t, common.HasContentType(httpResponse.Header, "application/json"))
 }
 
@@ -420,7 +420,7 @@ func TestTokenEndpoint_WrongGrantType(t *testing.T) {
 
 	require.Equal(t, http.StatusBadRequest, httpResponse.StatusCode)
 	require.Equal(t, "unsupported_grant_type", errorResponse.Error)
-	require.Equal(t, "the only supported grants are 'refresh_token', 'token_exchange' or 'authorization_code' or 'password'", errorResponse.ErrorDescription)
+	require.Equal(t, "the only supported grants are 'refresh_token', 'token_exchange', 'authorization_code' or 'password'", errorResponse.ErrorDescription)
 	require.True(t, common.HasContentType(httpResponse.Header, "application/json"))
 }
 

--- a/runtime/apis/authapi/token_endpoint_test.go
+++ b/runtime/apis/authapi/token_endpoint_test.go
@@ -399,7 +399,7 @@ func TestTokenEndpoint_MissingGrantType(t *testing.T) {
 
 	require.Equal(t, http.StatusBadRequest, httpResponse.StatusCode)
 	require.Equal(t, "invalid_request", errorResponse.Error)
-	require.Equal(t, "the grant-type field is required with either 'refresh_token', 'token_exchange', 'authorization_code', or 'password'", errorResponse.ErrorDescription)
+	require.Equal(t, "the grant-type field is required with either 'refresh_token', 'token_exchange', 'authorization_code' or 'password'", errorResponse.ErrorDescription)
 	require.True(t, common.HasContentType(httpResponse.Header, "application/json"))
 }
 
@@ -420,7 +420,7 @@ func TestTokenEndpoint_WrongGrantType(t *testing.T) {
 
 	require.Equal(t, http.StatusBadRequest, httpResponse.StatusCode)
 	require.Equal(t, "unsupported_grant_type", errorResponse.Error)
-	require.Equal(t, "the only supported grants are 'refresh_token', 'token_exchange' or 'authorization_code'", errorResponse.ErrorDescription)
+	require.Equal(t, "the only supported grants are 'refresh_token', 'token_exchange' or 'authorization_code' or 'password'", errorResponse.ErrorDescription)
 	require.True(t, common.HasContentType(httpResponse.Header, "application/json"))
 }
 

--- a/runtime/runtime_audit_test.go
+++ b/runtime/runtime_audit_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/teamkeel/keel/proto"
 	"github.com/teamkeel/keel/runtime/actions"
 	"github.com/teamkeel/keel/runtime/auth"
+	"github.com/teamkeel/keel/runtime/oauth"
 	"github.com/teamkeel/keel/testhelpers"
 	keeltesting "github.com/teamkeel/keel/testing"
 	"go.opentelemetry.io/otel/trace"
@@ -43,7 +44,7 @@ model WeddingInvitee {
 }`
 
 func withIdentity(t *testing.T, ctx context.Context, schema *proto.Schema) (context.Context, *auth.Identity) {
-	identity, err := actions.CreateIdentity(ctx, schema, "dave.new@keel.xyz", "1234")
+	identity, err := actions.CreateIdentity(ctx, schema, "dave.new@keel.xyz", "1234", oauth.KeelIssuer)
 	require.NoError(t, err)
 	return auth.WithIdentity(ctx, identity), identity
 }


### PR DESCRIPTION
## Password grant flow

The `/auth/token` endpoint now supports the [password grant](https://www.oauth.com/oauth2-servers/access-tokens/password-grant/).  It behaves in much the same way as the legacy `authenticate()` action.

We have decided to support the password grant flow.  Even though it comes with its flaws, it does allow users to get up and running very quickly.  We can discourage its use in the docs in favour of the ID Token or SSO flows.