### PR TITLE
build: keel on npm

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
         ref:
-          description: "Branch, tag or SHA to release"
+          description: "Branch, tag or SHA to release (e.g. main)"
           required: true
           type: string
 jobs:

--- a/.github/workflows/npm_release.yml
+++ b/.github/workflows/npm_release.yml
@@ -1,0 +1,89 @@
+name: Publish NPM packages
+run-name: Publish NPM packages ${{ github.ref_name }}
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Keel tag to publish (e.g. v0.370.0)"
+        required: true
+        type: string
+      publishTag:
+        description: "NPM distribution tag"
+        required: true
+        default: "next"
+        type: string
+
+jobs:
+  publish_npm_dependencies:
+    name: NPM Publish Matrix
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package:
+          [
+            "wasm",
+            "functions-runtime",
+            "testing-runtime",
+            "client-react",
+            "client-react-query",
+            "keel"
+          ]
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "1.20"
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.12.1
+          token: ${{ secrets.NPM_TOKEN }} 
+
+      - uses: pnpm/action-setup@v2.4.0
+        with:
+          version: 8.10.0
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+
+      - name: Install Go deps
+        if: ${{ matrix.package  == 'wasm' }}
+        run: go mod download
+
+      - name: Generate wasm binary
+        if: ${{ matrix.package  == 'wasm' }}
+        run: make wasm
+
+      - name: Install ${{ matrix.package }} publish dependencies
+        working-directory: ./packages/${{ matrix.package }}
+        run: pnpm install --frozen-lockfile
+
+      - uses: mad9000/actions-find-and-replace-string@2
+        id: make_package_version
+        with:
+          source: ${{ github.ref_name }}
+          find: 'v'        
+          replace: ''
+
+      - name: "Update NPM version ${{ matrix.package }}"
+        uses: reedyuk/npm-version@1.2.1
+        with:
+          version: ${{ steps.make_package_version.outputs.value }}
+          package: ./packages/${{ matrix.package }}
+
+      - name: NPM Publish ${{ matrix.package }}
+        uses: JS-DevTools/npm-publish@v2
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          tag: prerelease
+          package: ./packages/${{ matrix.package }}
+          dry-run: false
+          strategy: all
+          ignore-scripts: false
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/semantic_release.yml
+++ b/.github/workflows/semantic_release.yml
@@ -1,0 +1,32 @@
+name: Semantic Release
+
+on: 
+  push:
+    branches: 
+      - next
+      - prerelease
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch"   
+        required: true
+        default: main
+        type: string
+        
+env:
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+jobs:
+  semantic-release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        ref: "${{ inputs.branch }}"
+        fetch-depth: 0
+    - name: Setup Node
+      uses: actions/setup-node@v2
+      with:
+        node-version: 18.12.1
+    - name: release
+      run: npx semantic-release

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,40 +3,25 @@ before:
     - go mod tidy
     - go generate ./...
 builds:
-  - env:
+  - main: ./cmd/keel
+    id: "keel"
+    binary: keel
+    env:
       - CGO_ENABLED=0
     goos:
       - linux
       - windows
       - darwin
-    main: ./cmd/keel
     ldflags:
       - -s -w -X 'github.com/teamkeel/keel/runtime.Version={{.Version}}' -X 'github.com/teamkeel/keel/cmd.enabledDebugFlags=false'
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - builds:
+     - keel
 release:
   github:
     owner: teamkeel
-    name: cli
-  prerelease: auto
-brews:
-  - name: "{{ .Env.HOMEBREW_ALIAS }}"
-    url_template: "https://github.com/teamkeel/cli/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-    homepage: "https://github.com/teamkeel/cli"
-    skip_upload: auto
-    install: |
-      bin.install "cli" => "{{ .Env.HOMEBREW_ALIAS }}"
-    tap:
-      owner: teamkeel
-      name: "{{ .Env.HOMEBREW_REPO }}"
+    name: keel
+  mode: append
+  prerelease: true
 checksum:
   name_template: "checksums.txt"
-snapshot:
-  name_template: "{{ incpatch .Version }}-next"
-changelog:
-  sort: asc

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,20 @@
+{
+  "branches": [
+    { "name": "main" }, 
+    { "name": "next", "prerelease": true }, 
+    { "name": "prerelease", "prerelease": true }
+  ],
+  "repositoryUrl": "https://github.com/teamkeel/keel",
+  "debug": true,
+  "dryRun": false,
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/git",
+    [
+      "@semantic-release/exec",
+      {
+        "publishCmd": "goreleaser release --clean"
+      }
+    ]
+  ]
+} 

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,6 @@ require (
 	github.com/teamkeel/graphql v0.8.2-0.20230531102419-995b8ab035b6
 	github.com/twitchtv/twirp v8.1.3+incompatible
 	github.com/xeipuuv/gojsonschema v1.2.0
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1
 	go.opentelemetry.io/otel v1.21.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.21.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.21.0
@@ -68,7 +67,6 @@ require (
 	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
-	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-logr/logr v1.3.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,6 @@ github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwo
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
-github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
-github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
@@ -402,8 +400,6 @@ github.com/teamkeel/graphql v0.8.2-0.20230531102419-995b8ab035b6/go.mod h1:5td34
 github.com/thoas/go-funk v0.9.1 h1:O549iLZqPpTUQ10ykd26sZhzD+rmR5pWhuElrhbC20M=
 github.com/tkuchiki/go-timezone v0.2.0 h1:yyZVHtQRVZ+wvlte5HXvSpBkR0dPYnPEIgq9qqAqltk=
 github.com/tkuchiki/go-timezone v0.2.0/go.mod h1:b1Ean9v2UXtxSq4TZF0i/TU9NuoWa9hOzOKoGCV2zqY=
-github.com/twitchtv/twirp v7.2.0+incompatible h1:cXERdTtJqg8+OZdPCPGG2xWW8g+IKQ6zYjQTk9tWcCk=
-github.com/twitchtv/twirp v7.2.0+incompatible/go.mod h1:RRJoFSAmTEh2weEqWtpPE3vFK5YBhA6bqp2l1kfCC5A=
 github.com/twitchtv/twirp v8.1.3+incompatible h1:+F4TdErPgSUbMZMwp13Q/KgDVuI7HJXP61mNV3/7iuU=
 github.com/twitchtv/twirp v8.1.3+incompatible/go.mod h1:RRJoFSAmTEh2weEqWtpPE3vFK5YBhA6bqp2l1kfCC5A=
 github.com/urfave/cli/v2 v2.8.1/go.mod h1:Z41J9TPoffeoqP0Iza0YbAhGvymRdZAd2uPmZ5JxRdY=
@@ -427,8 +423,6 @@ go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.5/go.mod h1:5pWMHQbX5EPX2/62yrJeAkowc+lfs/XD7Uxpq3pI6kk=
-go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1 h1:aFJWCqJMNjENlcleuuOkGAPH82y0yULBScfXcIEdS24=
-go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1/go.mod h1:sEGXWArGqc3tVa+ekntsN65DmVbVeW+7lTKTjZF3/Fo=
 go.opentelemetry.io/otel v1.21.0 h1:hzLeKBZEL7Okw2mGzZ0cc4k/A7Fta0uoPgaJCr8fsFc=
 go.opentelemetry.io/otel v1.21.0/go.mod h1:QZzNPQPm1zLX4gZK4cMi+71eaorMSGT3A4znnUvNNEo=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.21.0 h1:cl5P5/GIfFh4t6xyruOgJP5QiA1pw4fYYdv6nc6CBWw=

--- a/packages/keel/package.json
+++ b/packages/keel/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "keel",
+  "version": "0.377.2-build-keel-npm-package.4",
+  "description": "Your production-grade backend from one file",
+  "author": "Keel (www.keel.so)",
+  "license": "ASL (Apache 2.0)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/teamkeel/keel.git"
+  },
+  "scripts": {
+    "postinstall": "node scripts/setup.js install",
+    "preuninstall": "node scripts/setup.js uninstall"
+  },
+  "files": [
+    "scripts/setup.js"
+  ],
+  "bin": {
+    "keel": "./keel"
+  },
+  "goBinary": {
+    "name": "keel",
+    "path": "./bin",
+    "url": "https://github.com/teamkeel/keel/releases/download/v{{version}}/keel_{{version}}_{{platform}}_{{arch}}.tar.gz"
+  },
+  "dependencies": {
+    "follow-redirects": "^1.15.5",
+    "mkdirp": "^3.0.1",
+    "tar": "^6.2.0"
+  }
+}

--- a/packages/keel/pnpm-lock.yaml
+++ b/packages/keel/pnpm-lock.yaml
@@ -1,0 +1,117 @@
+lockfileVersion: "6.0"
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+dependencies:
+  follow-redirects:
+    specifier: ^1.15.5
+    version: 1.15.5
+  mkdirp:
+    specifier: ^3.0.1
+    version: 3.0.1
+  tar:
+    specifier: ^6.2.0
+    version: 6.2.0
+
+packages:
+  /chownr@2.0.0:
+    resolution:
+      {
+        integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==,
+      }
+    engines: { node: ">=10" }
+    dev: false
+
+  /follow-redirects@1.15.5:
+    resolution:
+      {
+        integrity: sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==,
+      }
+    engines: { node: ">=4.0" }
+    peerDependencies:
+      debug: "*"
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dev: false
+
+  /fs-minipass@2.1.0:
+    resolution:
+      {
+        integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==,
+      }
+    engines: { node: ">= 8" }
+    dependencies:
+      minipass: 3.3.6
+    dev: false
+
+  /minipass@3.3.6:
+    resolution:
+      {
+        integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==,
+      }
+    engines: { node: ">=8" }
+    dependencies:
+      yallist: 4.0.0
+    dev: false
+
+  /minipass@5.0.0:
+    resolution:
+      {
+        integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==,
+      }
+    engines: { node: ">=8" }
+    dev: false
+
+  /minizlib@2.1.2:
+    resolution:
+      {
+        integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==,
+      }
+    engines: { node: ">= 8" }
+    dependencies:
+      minipass: 3.3.6
+      yallist: 4.0.0
+    dev: false
+
+  /mkdirp@1.0.4:
+    resolution:
+      {
+        integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==,
+      }
+    engines: { node: ">=10" }
+    hasBin: true
+    dev: false
+
+  /mkdirp@3.0.1:
+    resolution:
+      {
+        integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==,
+      }
+    engines: { node: ">=10" }
+    hasBin: true
+    dev: false
+
+  /tar@6.2.0:
+    resolution:
+      {
+        integrity: sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==,
+      }
+    engines: { node: ">=10" }
+    dependencies:
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      minipass: 5.0.0
+      minizlib: 2.1.2
+      mkdirp: 1.0.4
+      yallist: 4.0.0
+    dev: false
+
+  /yallist@4.0.0:
+    resolution:
+      {
+        integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==,
+      }
+    dev: false

--- a/packages/keel/scripts/setup.js
+++ b/packages/keel/scripts/setup.js
@@ -196,16 +196,6 @@ function install(callback) {
       "error",
       callback.bind(null, "Error downloading from URL: " + opts.url)
     );
-
-  // let req = request({ uri: opts.url });
-  // req.on('error', callback.bind(null, "Error downloading from URL: " + opts.url));
-  // req.on('response', function(res) {
-  //     if (res.statusCode !== 200) {
-  //         return callback("Error downloading binary. HTTP Status Code: " + res.statusCode);
-  //     }
-
-  //     req.pipe(ungz).pipe(untar);
-  // });
 }
 
 function uninstall(callback) {

--- a/packages/keel/scripts/setup.js
+++ b/packages/keel/scripts/setup.js
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+
+"use strict";
+
+const { https } = require("follow-redirects"),
+  path = require("path"),
+  tar = require("tar"),
+  zlib = require("zlib"),
+  mkdirp = require("mkdirp"),
+  fs = require("fs"),
+  exec = require("child_process").exec;
+
+// Mapping from Node's `process.arch` to Golang's `$GOARCH`
+const ARCH_MAPPING = {
+  ia32: "386",
+  x64: "amd64",
+  arm: "arm",
+  arm64: "arm64",
+};
+
+// Mapping between Node's `process.platform` to Golang's
+const PLATFORM_MAPPING = {
+  darwin: "darwin",
+  linux: "linux",
+  win32: "windows",
+  freebsd: "freebsd",
+};
+
+function getInstallationPath(callback) {
+  // `npm prefix -g` will output the path where the `bin` folder is available
+  exec("npm prefix -g", function (err, stdout, stderr) {
+    let dir = null;
+    if (err || stderr || !stdout || stdout.length === 0) {
+      // We couldn't infer path from `npm prefix`. Let's try to get it from
+      // Environment variables set by NPM when it runs.
+      // npm_config_prefix points to NPM's installation directory where `bin` folder is available
+      // Ex: /Users/foo/.nvm/versions/node/v4.3.0
+      let env = process.env;
+      if (env && env.npm_config_prefix) {
+        dir = path.join(env.npm_config_prefix, "bin");
+      }
+    } else {
+      dir = path.join(stdout.trim(), "bin");
+    }
+
+    mkdirp.sync(dir);
+
+    callback(null, dir);
+  });
+}
+
+function verifyAndPlaceBinary(binName, binPath, callback) {
+  if (!fs.existsSync(path.join(binPath, binName))) {
+    return callback(
+      `Downloaded binary does not contain the binary specified in configuration - ${binName}`
+    );
+  }
+
+  getInstallationPath(function (err, installationPath) {
+    if (err) {
+      return callback(
+        "Error getting binary installation path from `npm root -g`"
+      );
+    }
+
+    // Move the binary file
+    fs.renameSync(
+      path.join(binPath, binName),
+      path.join(installationPath, binName)
+    );
+
+    callback(null);
+  });
+}
+
+function validateConfiguration(packageJson) {
+  if (!packageJson.version) {
+    return "'version' property must be specified";
+  }
+
+  if (!packageJson.goBinary || typeof packageJson.goBinary !== "object") {
+    return "'goBinary' property must be defined and be an object";
+  }
+
+  if (!packageJson.goBinary.name) {
+    return "'name' property is necessary";
+  }
+
+  if (!packageJson.goBinary.path) {
+    return "'path' property is necessary";
+  }
+
+  if (!packageJson.goBinary.url) {
+    return "'url' property is required";
+  }
+}
+
+function parsePackageJson() {
+  if (!(process.arch in ARCH_MAPPING)) {
+    console.error(
+      "Installation is not supported for this architecture: " + process.arch
+    );
+    return;
+  }
+
+  if (!(process.platform in PLATFORM_MAPPING)) {
+    console.error(
+      "Installation is not supported for this platform: " + process.platform
+    );
+    return;
+  }
+
+  const packageJsonPath = path.join(".", "package.json");
+  if (!fs.existsSync(packageJsonPath)) {
+    console.error(
+      "Unable to find package.json. " +
+        "Please run this script at root of the package you want to be installed"
+    );
+    return;
+  }
+
+  let packageJson = JSON.parse(fs.readFileSync(packageJsonPath));
+  let error = validateConfiguration(packageJson);
+  if (error && error.length > 0) {
+    console.error("Invalid package.json: " + error);
+    return;
+  }
+
+  // We have validated the config. It exists in all its glory
+  let binName = packageJson.goBinary.name;
+  let binPath = packageJson.goBinary.path;
+  let url = packageJson.goBinary.url;
+  let version = packageJson.version;
+  if (version[0] === "v") version = version.substr(1); // strip the 'v' if necessary v0.0.1 => 0.0.1
+
+  // Binary name on Windows has .exe suffix
+  if (process.platform === "win32") {
+    binName += ".exe";
+  }
+
+  // Interpolate variables in URL, if necessary
+  url = url.replace(/{{arch}}/g, ARCH_MAPPING[process.arch]);
+  url = url.replace(/{{platform}}/g, PLATFORM_MAPPING[process.platform]);
+  url = url.replace(/{{version}}/g, version);
+  url = url.replace(/{{bin_name}}/g, binName);
+
+  return {
+    binName: binName,
+    binPath: binPath,
+    url: url,
+    version: version,
+  };
+}
+
+/**
+ * Reads the configuration from application's package.json,
+ * validates properties, downloads the binary, untars, and stores at
+ * ./bin in the package's root. NPM already has support to install binary files
+ * specific locations when invoked with "npm install -g"
+ *
+ *  See: https://docs.npmjs.com/files/package.json#bin
+ */
+function install(callback) {
+  let opts = parsePackageJson();
+  if (!opts) return callback("Invalid inputs");
+
+  console.log(opts);
+
+  mkdirp.sync(opts.binPath);
+  let ungz = zlib.createGunzip();
+  let untar = tar.extract({ cwd: opts.binPath });
+
+  ungz.on("error", callback);
+  untar.on("error", callback);
+
+  // First we will Un-GZip, then we will untar. So once untar is completed,
+  // binary is downloaded into `binPath`. Verify the binary and call it good
+  untar.on(
+    "end",
+    verifyAndPlaceBinary.bind(null, opts.binName, opts.binPath, callback)
+  );
+
+  console.log("Downloading from URL: " + opts.url);
+
+  const request = https
+    .get(opts.url, function (response) {
+      if (response.statusCode !== 200) {
+        return callback(
+          "Error downloading binary. HTTP Status Code: " + response.statusCode
+        );
+      }
+
+      response.pipe(ungz).pipe(untar);
+    })
+    .on(
+      "error",
+      callback.bind(null, "Error downloading from URL: " + opts.url)
+    );
+
+  // let req = request({ uri: opts.url });
+  // req.on('error', callback.bind(null, "Error downloading from URL: " + opts.url));
+  // req.on('response', function(res) {
+  //     if (res.statusCode !== 200) {
+  //         return callback("Error downloading binary. HTTP Status Code: " + res.statusCode);
+  //     }
+
+  //     req.pipe(ungz).pipe(untar);
+  // });
+}
+
+function uninstall(callback) {
+  let opts = parsePackageJson();
+  getInstallationPath(function (err, installationPath) {
+    if (err) callback("Error finding binary installation directory");
+
+    try {
+      fs.unlinkSync(path.join(installationPath, opts.binName));
+    } catch (ex) {
+      // Ignore errors when deleting the file.
+    }
+
+    return callback(null);
+  });
+}
+
+// Parse command line arguments and call the right method
+let actions = {
+  install: install,
+  uninstall: uninstall,
+};
+
+let argv = process.argv;
+if (argv && argv.length > 2) {
+  let cmd = process.argv[2];
+  if (!actions[cmd]) {
+    console.log("`install` and `uninstall` are the only supported commands");
+    process.exit(1);
+  }
+
+  actions[cmd](function (err) {
+    if (err) {
+      console.error(err);
+      process.exit(1);
+    } else {
+      process.exit(0);
+    }
+  });
+}


### PR DESCRIPTION
## Keel on NPM

We are moving away from Homebrew to using NPM as the package manage for the Keel CLI.  This pull request sets the foundation for this with some major changes to our release processes.

 - Better use of semantic release and a `.releaserc` config.
 - Prerelease branches `next` and `prerelease` with appropriate versioning (e.g. `0.377.2-prerelease.1`).
 - Cleaned up Goreleaser and reworked it not to release to Homebrew.
 - Go binaries now as release artifacts in this repository (and not in teamkeel/cli anymore).
 - Keel NPM package.  The package is smart and will only retrieve the platform-dependency binaries from GitHub release during an `npm install`.