### PR TITLE
fix: semver action node version

### DIFF
--- a/.github/workflows/semantic_release.yml
+++ b/.github/workflows/semantic_release.yml
@@ -27,6 +27,6 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
-        node-version: 18.12.1
+        node-version: 20.9.0
     - name: release
       run: npx semantic-release

--- a/.github/workflows/semantic_release.yml
+++ b/.github/workflows/semantic_release.yml
@@ -29,4 +29,4 @@ jobs:
       with:
         node-version: 20.9.0
     - name: release
-      run: npx semantic-release
+      run: npx semantic-release@23


### PR DESCRIPTION
Latest semantic version requires >=v20 of node.  Also fixed semantic-version to v23 so that future build do not unexpectently fail.