### PR TITLE
fix: client token refresh improvements

### DIFF
--- a/integration/testdata/client_password_grant/keelClient.ts
+++ b/integration/testdata/client_password_grant/keelClient.ts
@@ -1,13 +1,145 @@
+// GENERATED DO NOT EDIT
+
+type RequestHeaders = globalThis.Record<string, string>;
+
+// Refresh the token EXPIRY_BUFFER_IN_MS seconds before it expires
+const EXPIRY_BUFFER_IN_MS = 60000;
+
+export type Config = {
+  baseUrl: string;
+  headers?: RequestHeaders;
+  refreshToken?: TokenStore;
+  accessToken?: TokenStore;
+};
+
+// Result types
+
+export type APIResult<T> = Result<T, APIError>;
+
+type Data<T> = {
+  data: T;
+  error?: never;
+};
+
+type Err<U> = {
+  data?: never;
+  error: U;
+};
+
+type Result<T, U> = NonNullable<Data<T> | Err<U>>;
+
+// Error types
+
+/* 400 */
+type BadRequestError = {
+  type: "bad_request";
+  message: string;
+  requestId?: string;
+};
+
+/* 401 */
+type UnauthorizedError = {
+  type: "unauthorized";
+  message: string;
+  requestId?: string;
+};
+
+/* 403 */
+type ForbiddenError = {
+  type: "forbidden";
+  message: string;
+  requestId?: string;
+};
+
+/* 404 */
+type NotFoundError = {
+  type: "not_found";
+  message: string;
+  requestId?: string;
+};
+
+/* 500 */
+type InternalServerError = {
+  type: "internal_server_error";
+  message: string;
+  requestId?: string;
+};
+
+/* Unhandled/unexpected errors */
+type UnknownError = {
+  type: "unknown";
+  message: string;
+  error?: unknown;
+  requestId?: string;
+};
+
+export type APIError =
+  | UnauthorizedError
+  | ForbiddenError
+  | NotFoundError
+  | BadRequestError
+  | InternalServerError
+  | UnknownError;
+
+// Auth
+
+export interface TokenStore {
+  set(token: string | null): void;
+  get(): string | null;
+}
+
+export type Provider = {
+  name: string;
+  type: string;
+  authorizeUrl: string;
+};
+
+export type PasswordGrant = {
+  grant_type: "password";
+  username: string;
+  password: string;
+};
+
+export type TokenExchangeGrant = {
+  grant_type: "token_exchange";
+  subject_token: string;
+};
+
+export type AuthorizationCodeGrant = {
+  grant_type: "authorization_code";
+  code: string;
+};
+
+export type RefreshGrant = {
+  grant_type: "refresh_token";
+  refresh_token: string;
+};
+
+export type TokenRequest =
+  | PasswordGrant
+  | TokenExchangeGrant
+  | AuthorizationCodeGrant
+  | RefreshGrant;
+
+export class TokenError extends Error {
+  errorDescription: string;
+  constructor(error: string, errorDescription: string) {
+    super();
+    this.message = error;
+    this.errorDescription = errorDescription;
+  }
+}
+
 export class Core {
   constructor(private config: Config) {}
 
   ctx = {
     /**
-     * @deprecated This has been deprecated. See https://docs.keel.so/apis/client
+     * @deprecated This has been deprecated in favour of using the APIClient.auth which handles sessions implicitly
      */
     token: "",
     /**
-     * @deprecated This has been deprecated. See https://docs.keel.so/apis/client
+     * @deprecated This has been deprecated in favour of APIClient.auth.isAuthenticated()
      */
     isAuthenticated: false,
   };
@@ -31,7 +163,7 @@ export class Core {
       return this;
     },
     /**
-     * @deprecated This has been deprecated. See https://docs.keel.so/apis/client
+     * @deprecated This has been deprecated in favour of the APIClient.auth authenticate helper functions
      */
     setToken: (value: string): Core => {
       this.ctx.token = value;
@@ -39,7 +171,7 @@ export class Core {
       return this;
     },
     /**
-     * @deprecated This has been deprecated. See https://docs.keel.so/apis/client
+     * @deprecated This has been deprecated in favour of APIClient.auth.logout()
      */
     clearToken: (): Core => {
       this.ctx.token = "";
@@ -400,3 +532,107 @@ export class InMemoryStore implements TokenStore {
     this.token = token;
   };
 }
+
+// API
+
+export class APIClient extends Core {
+  constructor(config: Config) {
+    super(config);
+  }
+
+  private actions = {
+    allPosts: (i?: AllPostsInput) => {
+      return this.client.rawRequest<{ results: Post[]; pageInfo: PageInfo }>(
+        "allPosts",
+        i
+      );
+    },
+    authenticate: (i: AuthenticateInput) => {
+      return this.client
+        .rawRequest<AuthenticateResponse>("authenticate", i)
+        .then((res) => {
+          if (res.data && res.data.token) this.client.setToken(res.data.token);
+          return res;
+        });
+    },
+    requestPasswordReset: (i: RequestPasswordResetInput) => {
+      return this.client.rawRequest<RequestPasswordResetResponse>(
+        "requestPasswordReset",
+        i
+      );
+    },
+    resetPassword: (i: ResetPasswordInput) => {
+      return this.client.rawRequest<ResetPasswordResponse>("resetPassword", i);
+    },
+  };
+
+  api = {
+    queries: {
+      allPosts: this.actions.allPosts,
+    },
+    mutations: {
+      authenticate: this.actions.authenticate,
+      requestPasswordReset: this.actions.requestPasswordReset,
+      resetPassword: this.actions.resetPassword,
+    },
+  };
+}
+
+// API Types
+
+export interface AllPostsWhere {}
+export interface AllPostsInput {
+  where?: AllPostsWhere;
+  first?: number;
+  after?: string;
+  last?: number;
+  before?: string;
+}
+export interface EmailPasswordInput {
+  email: string;
+  password: string;
+}
+export interface AuthenticateInput {
+  createIfNotExists?: boolean;
+  emailPassword: EmailPasswordInput;
+}
+export interface AuthenticateResponse {
+  identityCreated: boolean;
+  token: string;
+}
+export interface RequestPasswordResetInput {
+  email: string;
+  redirectUrl: string;
+}
+export interface RequestPasswordResetResponse {}
+export interface ResetPasswordInput {
+  token: string;
+  password: string;
+}
+export interface ResetPasswordResponse {}
+export interface Post {
+  title: string;
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+  identityId: string | null;
+}
+export interface Identity {
+  email: string | null;
+  emailVerified: boolean;
+  password: any | null;
+  externalId: string | null;
+  issuer: string | null;
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+export type SortDirection = "asc" | "desc" | "ASC" | "DESC";
+
+type PageInfo = {
+  count: number;
+  endCursor: string;
+  hasNextPage: boolean;
+  startCursor: string;
+  totalCount: number;
+};

--- a/integration/testdata/client_password_grant/keelconfig.yaml
+++ b/integration/testdata/client_password_grant/keelconfig.yaml
@@ -1,0 +1,4 @@
+auth:
+  tokens:
+    accessTokenExpiry: 61 # An extra 60 to cater for the buffer built into the keelClient refresh cycle
+    refreshTokenExpiry: 4

--- a/integration/testdata/client_password_grant/main.test.ts
+++ b/integration/testdata/client_password_grant/main.test.ts
@@ -1,0 +1,190 @@
+import { actions, models, resetDatabase } from "@teamkeel/testing";
+import { test, expect, beforeEach, beforeAll } from "vitest";
+import { APIClient } from "./keelClient";
+
+const baseUrl = process.env.KEEL_TESTING_CLIENT_API_URL!;
+
+beforeEach(resetDatabase);
+
+test("authenticateWithPassword", async () => {
+  const store = new TokenStore();
+  const client = new APIClient({ baseUrl }, store.getTokens, store.setTokens);
+
+  await client.auth.authenticateWithPassword("user@example.com", "1234");
+  expect(await client.auth.isAuthenticated()).toBeTruthy();
+  expect(await client.auth.expiresAt()).not.toBeNull();
+  expect((await client.auth.expiresAt()!) > new Date()).toBeTruthy();
+  expect(store.accessToken).not.toBeNull();
+  expect(store.refreshToken).not.toBeNull();
+
+  await client.auth.authenticateWithPassword("user@example.com", "oops");
+  expect(await client.auth.isAuthenticated()).not.toBeTruthy();
+  expect(await client.auth.expiresAt()).toBeNull();
+  expect(store.accessToken).toBeNull();
+  expect(store.refreshToken).toBeNull();
+
+  await models.post.create({ title: "Test" });
+  const response1 = await client.api.queries.allPosts();
+  expect(response1.error!.type).toEqual("forbidden");
+
+  await client.auth.authenticateWithPassword("user@example.com", "1234");
+  expect(await client.auth.isAuthenticated()).toBeTruthy();
+  expect(await client.auth.expiresAt()).not.toBeNull();
+  expect((await client.auth.expiresAt()!) > new Date()).toBeTruthy();
+  expect(store.accessToken).not.toBeNull();
+  expect(store.refreshToken).not.toBeNull();
+
+  const response2 = await client.api.queries.allPosts();
+  expect(response2.data?.results).toHaveLength(1);
+});
+
+test("valid access token", async () => {
+  const store = new TokenStore();
+  const client = new APIClient({ baseUrl }, store.getTokens, store.setTokens);
+
+  await client.auth.authenticateWithPassword("user@example.com", "1234");
+  expect(await client.auth.isAuthenticated()).toBeTruthy();
+
+  expect(store.accessToken).not.toBeNull();
+  expect(store.refreshToken).not.toEqual("");
+});
+
+test("valid refresh token", async () => {
+  const store = new TokenStore();
+  const client = new APIClient({ baseUrl }, store.getTokens, store.setTokens);
+
+  await client.auth.authenticateWithPassword("user@example.com", "1234");
+  expect(await client.auth.isAuthenticated()).toBeTruthy();
+
+  expect(store.refreshToken).not.toBeNull();
+  expect(store.refreshToken).not.toEqual("");
+});
+
+test("refreshing successfully", async () => {
+  const store = new TokenStore();
+  const client = new APIClient({ baseUrl }, store.getTokens, store.setTokens);
+
+  await client.auth.authenticateWithPassword("user@example.com", "1234");
+  expect(await client.auth.isAuthenticated()).toBeTruthy();
+
+  const accessToken = store.accessToken;
+  const refreshToken = store.refreshToken;
+
+  expect(accessToken).not.toBeNull();
+  expect(refreshToken).not.toBeNull();
+
+  const expiry1 = client.auth.expiresAt();
+  expect(expiry1).not.toBeNull();
+
+  await delay(1000);
+  const refreshed = await client.auth.refresh();
+  expect(refreshed).toBeTruthy();
+
+  expect(store.accessToken).not.toBeNull();
+  expect(store.refreshToken).not.toBeNull();
+  expect(store.accessToken).not.toEqual(accessToken);
+  expect(store.refreshToken).not.toEqual(refreshToken);
+
+  const expiry2 = client.auth.expiresAt();
+  expect(expiry1?.getTime()).lessThan(expiry2!.getTime());
+});
+
+test("logout successfully", async () => {
+  const store = new TokenStore();
+  const client = new APIClient({ baseUrl }, store.getTokens, store.setTokens);
+
+  await client.auth.authenticateWithPassword("user@example.com", "1234");
+  expect(await client.auth.isAuthenticated()).toBeTruthy();
+
+  await client.auth.logout();
+
+  expect(store.accessToken).toBeNull();
+  expect(store.refreshToken).toBeNull();
+
+  expect(await client.auth.expiresAt()).toBeNull();
+  expect(await client.auth.isAuthenticated()).not.toBeTruthy();
+});
+
+test("logout revokes refresh token successfully", async () => {
+  const store = new TokenStore();
+  const client = new APIClient({ baseUrl }, store.getTokens, store.setTokens);
+
+  await client.auth.authenticateWithPassword("user@example.com", "1234");
+  expect(await client.auth.isAuthenticated()).toBeTruthy();
+
+  await client.auth.logout();
+
+  const accessToken = store.accessToken;
+  const refreshToken = store.refreshToken;
+
+  expect(store.accessToken).toBeNull();
+  expect(store.refreshToken).toBeNull();
+
+  expect(await client.auth.expiresAt()).toBeNull();
+  expect(await client.auth.isAuthenticated()).not.toBeTruthy();
+
+  store.setTokens(accessToken, refreshToken);
+
+  const refresh = await client.auth.refresh();
+  expect(refresh).not.toBeTruthy();
+  expect(await client.auth.isAuthenticated()).not.toBeTruthy();
+
+  expect(store.accessToken).toBeNull();
+  expect(store.refreshToken).toBeNull();
+});
+
+test("authentication flow with default token store", async () => {
+  const client = new APIClient({ baseUrl });
+
+  await client.auth.authenticateWithPassword("user@example.com", "1234");
+  expect(await client.auth.isAuthenticated()).toBeTruthy();
+  expect(await client.auth.expiresAt()).not.toBeNull();
+  expect((await client.auth.expiresAt()!) > new Date()).toBeTruthy();
+
+  await client.auth.authenticateWithPassword("user@example.com", "oops");
+  expect(await client.auth.isAuthenticated()).not.toBeTruthy();
+  expect(await client.auth.expiresAt()).toBeNull();
+
+  await client.auth.authenticateWithPassword("user@example.com", "1234");
+  expect(await client.auth.isAuthenticated()).toBeTruthy();
+  expect(await client.auth.expiresAt()).not.toBeNull();
+  expect((await client.auth.expiresAt()!) > new Date()).toBeTruthy();
+
+  const expiry1 = client.auth.expiresAt();
+
+  await delay(1000);
+  const refreshed = await client.auth.refresh();
+  expect(refreshed).toBeTruthy();
+  expect(await client.auth.isAuthenticated()).toBeTruthy();
+
+  const expiry2 = client.auth.expiresAt();
+  expect(expiry1?.getTime()).lessThan(expiry2!.getTime());
+
+  await client.auth.logout();
+  expect(await client.auth.isAuthenticated()).not.toBeTruthy();
+
+  const refreshed2 = await client.auth.refresh();
+  expect(refreshed2).not.toBeTruthy();
+  expect(await client.auth.isAuthenticated()).not.toBeTruthy();
+});
+
+class TokenStore {
+  public accessToken: string | null = null;
+  public refreshToken: string | null = null;
+
+  getTokens = () => {
+    return {
+      accessToken: this.accessToken,
+      refreshToken: this.refreshToken,
+    };
+  };
+
+  setTokens = (accessToken: string | null, refreshToken: string | null) => {
+    this.accessToken = accessToken;
+    this.refreshToken = refreshToken;
+  };
+}
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/integration/testdata/client_password_grant/schema.keel
+++ b/integration/testdata/client_password_grant/schema.keel
@@ -1,0 +1,12 @@
+model Post {
+    fields {
+        title Text
+        identity Identity?
+    }
+
+    actions {
+        list allPosts() {
+            @permission(expression: ctx.isAuthenticated)
+        }
+    }
+}

--- a/node/client.go
+++ b/node/client.go
@@ -119,9 +119,9 @@ func writeClientApiClass(w *codegen.Writer, schema *proto.Schema, api *proto.Api
 	w.Writeln("export class APIClient extends Core {")
 
 	w.Indent()
-	w.Writeln("constructor(config: RequestConfig, getTokens = InMemoryTokenStore.getInstance().getTokens, setTokens = InMemoryTokenStore.getInstance().setTokens) {")
+	w.Writeln("constructor(config: Config) {")
 	w.Indent()
-	w.Writeln("super(config, getTokens, setTokens);")
+	w.Writeln("super(config);")
 	w.Dedent()
 	w.Writeln("}")
 	w.Writeln("")

--- a/node/client.go
+++ b/node/client.go
@@ -108,7 +108,7 @@ func generateClientSdkPackage(schema *proto.Schema, api *proto.Api) codegen.Gene
 			Contents: `{
 	"name": "@teamkeel/client",
 	"dependencies": {
-		"cross-fetch": "4.0.0"
+		"cross-fetch": "^4.0.0"
 	}
 }`,
 		},
@@ -119,9 +119,9 @@ func writeClientApiClass(w *codegen.Writer, schema *proto.Schema, api *proto.Api
 	w.Writeln("export class APIClient extends Core {")
 
 	w.Indent()
-	w.Writeln("constructor(config: RequestConfig, refreshTokenStore: TokenStore = new InMemoryTokenStore()) {")
+	w.Writeln("constructor(config: RequestConfig, getTokens = InMemoryTokenStore.getInstance().getTokens, setTokens = InMemoryTokenStore.getInstance().setTokens) {")
 	w.Indent()
-	w.Writeln("super(config, refreshTokenStore);")
+	w.Writeln("super(config, getTokens, setTokens);")
 	w.Dedent()
 	w.Writeln("}")
 	w.Writeln("")

--- a/node/client_test.go
+++ b/node/client_test.go
@@ -526,8 +526,8 @@ model Person {
 
 	expected := `
 export class APIClient extends Core {
-	constructor(config: RequestConfig, refreshTokenStore: TokenStore = new InMemoryTokenStore()) {
-		super(config, refreshTokenStore);
+	constructor(config: RequestConfig, getTokens = InMemoryTokenStore.getInstance().getTokens, setTokens = InMemoryTokenStore.getInstance().setTokens) {
+		super(config, getTokens, setTokens);
 	}
 
 	private actions = {

--- a/node/client_test.go
+++ b/node/client_test.go
@@ -526,8 +526,8 @@ model Person {
 
 	expected := `
 export class APIClient extends Core {
-	constructor(config: RequestConfig, getTokens = InMemoryTokenStore.getInstance().getTokens, setTokens = InMemoryTokenStore.getInstance().setTokens) {
-		super(config, getTokens, setTokens);
+	constructor(config: Config) {
+		super(config);
 	}
 
 	private actions = {

--- a/node/templates/client/core.ts
+++ b/node/templates/client/core.ts
@@ -336,14 +336,6 @@ export class Core {
         body: JSON.stringify(req),
       });
 
-      console.debug(
-        "Received status " +
-          result.status +
-          " from /auth/token for " +
-          req.grant_type +
-          " grant"
-      );
-
       if (result.ok) {
         const data = await result.json();
 

--- a/node/templates/client/types.d.ts
+++ b/node/templates/client/types.d.ts
@@ -90,27 +90,29 @@ export type Provider = {
   authorizeUrl: string;
 };
 
-export type AccessTokenSession = {
-  token: string;
-  expiresAt: Date;
+export type PasswordGrant = {
+  grant_type: "password";
+  username: string;
+  password: string;
 };
 
 export type TokenExchangeGrant = {
-  grant: "token_exchange";
-  subjectToken: string;
+  grant_type: "token_exchange";
+  subject_token: string;
 };
 
 export type AuthorizationCodeGrant = {
-  grant: "authorization_code";
+  grant_type: "authorization_code";
   code: string;
 };
 
 export type RefreshGrant = {
-  grant: "refresh_token";
-  refreshToken: string;
+  grant_type: "refresh_token";
+  refresh_token: string;
 };
 
-export type TokenGrant =
+export type TokenRequest =
+  | PasswordGrant
   | TokenExchangeGrant
   | AuthorizationCodeGrant
   | RefreshGrant;

--- a/node/templates/client/types.d.ts
+++ b/node/templates/client/types.d.ts
@@ -1,11 +1,13 @@
 type RequestHeaders = globalThis.Record<string, string>;
 
-// Refresh the token 60 seconds before it expires
+// Refresh the token EXPIRY_BUFFER_IN_MS seconds before it expires
 const EXPIRY_BUFFER_IN_MS = 60000;
 
-export type RequestConfig = {
+export type Config = {
   baseUrl: string;
   headers?: RequestHeaders;
+  refreshToken?: TokenStore;
+  accessToken?: TokenStore;
 };
 
 // Result types

--- a/runtime/apis/authapi/token_endpoint.go
+++ b/runtime/apis/authapi/token_endpoint.go
@@ -95,7 +95,7 @@ func TokenEndpointHandler(schema *proto.Schema) common.HandlerFunc {
 
 		grantType, hasGrantType := inputs[ArgGrantType].(string)
 		if !hasGrantType || grantType == "" {
-			return jsonErrResponse(ctx, http.StatusBadRequest, TokenErrInvalidRequest, "the grant-type field is required with either 'refresh_token', 'token_exchange', 'authorization_code' or 'password'", nil)
+			return jsonErrResponse(ctx, http.StatusBadRequest, TokenErrInvalidRequest, "the grant_type field is required with either 'refresh_token', 'token_exchange', 'authorization_code' or 'password'", nil)
 		}
 
 		span.SetAttributes(

--- a/runtime/apis/authapi/token_endpoint_test.go
+++ b/runtime/apis/authapi/token_endpoint_test.go
@@ -379,7 +379,7 @@ func TestTokenEndpointJson_MissingGrantType(t *testing.T) {
 
 	require.Equal(t, http.StatusBadRequest, httpResponse.StatusCode)
 	require.Equal(t, "invalid_request", errorResponse.Error)
-	require.Equal(t, "the grant-type field is required with either 'refresh_token', 'token_exchange', 'authorization_code' or 'password'", errorResponse.ErrorDescription)
+	require.Equal(t, "the grant_type field is required with either 'refresh_token', 'token_exchange', 'authorization_code' or 'password'", errorResponse.ErrorDescription)
 	require.True(t, common.HasContentType(httpResponse.Header, "application/json"))
 }
 
@@ -399,7 +399,7 @@ func TestTokenEndpoint_MissingGrantType(t *testing.T) {
 
 	require.Equal(t, http.StatusBadRequest, httpResponse.StatusCode)
 	require.Equal(t, "invalid_request", errorResponse.Error)
-	require.Equal(t, "the grant-type field is required with either 'refresh_token', 'token_exchange', 'authorization_code' or 'password'", errorResponse.ErrorDescription)
+	require.Equal(t, "the grant_type field is required with either 'refresh_token', 'token_exchange', 'authorization_code' or 'password'", errorResponse.ErrorDescription)
 	require.True(t, common.HasContentType(httpResponse.Header, "application/json"))
 }
 

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -33,6 +33,7 @@ import (
 )
 
 const (
+	AuthPath       = "auth"
 	ActionApiPath  = "testingactionsapi"
 	JobPath        = "testingjobs"
 	SubscriberPath = "testingsubscribers"
@@ -212,6 +213,9 @@ func Run(ctx context.Context, opts *RunnerOpts) error {
 			pathParts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
 
 			switch pathParts[0] {
+			case AuthPath:
+				r = r.WithContext(ctx)
+				runtime.NewHttpHandler(schema).ServeHTTP(w, r)
 			case ActionApiPath:
 				r = r.WithContext(ctx)
 				runtime.NewHttpHandler(schema).ServeHTTP(w, r)

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -182,6 +182,7 @@ func Run(ctx context.Context, opts *RunnerOpts) error {
 			ctx = runtimectx.WithEnv(ctx, runtimectx.KeelEnvTest)
 			ctx = db.WithDatabase(ctx, database)
 			ctx = runtimectx.WithSecrets(ctx, opts.Secrets)
+			ctx = runtimectx.WithOAuthConfig(ctx, &builder.Config.Auth)
 
 			span.SetAttributes(attribute.String("request.url", r.URL.String()))
 


### PR DESCRIPTION
## Improvements to the client auth

This is based on ongoing work with @TejasQ 

 - Added password flow auth
 - Refresh and access tokens are not storable.
 - Changed the API to get and set tokens.
 - Improved the refresh flow
 - Added some much needed tests

Not done is returning the identity when authenticating.  This will probably require us either to create a OIDC user-info endpoint or to return an ID token from the token endpoint with all the necessary user claims, which we can then parse properly in the client.