### PR TITLE
fix: keel init panic when choosing not to git init

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -318,11 +318,12 @@ func initStepGit(state *InitState) {
 	}
 
 	_, err := starter.Run()
-	if err != nil {
+	confirmed := !errors.Is(err, promptui.ErrAbort)
+	if err != nil && confirmed {
 		panic(err)
 	}
 
-	state.initGitRepo = true
+	state.initGitRepo = confirmed
 }
 
 func initStepCreateProject(state *InitState) {


### PR DESCRIPTION
### Fixing `keel init` panic when selecting 'N' to instantiating a git repo

Previously, this would occur when choosing not to initialise git.  In fact, any entry other that y/Y would cause this panic.  With this fix, any entry other than y/Y will be regarded as n/N.

<img width="690" alt="image" src="https://github.com/teamkeel/keel/assets/6212830/ec979d4e-503d-4722-a750-4620039fbc33">
