### PR TITLE
fix: check for cli updates

### DIFF
--- a/cmd/program/views.go
+++ b/cmd/program/views.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/charmbracelet/bubbles/table"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/teamkeel/keel/colors"
@@ -13,6 +14,7 @@ import (
 	"github.com/teamkeel/keel/db"
 	"github.com/teamkeel/keel/migrations"
 	"github.com/teamkeel/keel/node"
+	"github.com/teamkeel/keel/runtime"
 	"github.com/teamkeel/keel/schema"
 	"github.com/teamkeel/keel/schema/validation/errorhandling"
 )
@@ -33,6 +35,16 @@ func renderRun(m *Model) string {
 		b.WriteString("Connect to your database using: ")
 		b.WriteString(colors.Cyan(fmt.Sprintf("psql -Atx \"%s\"", m.DatabaseConnInfo.String())).Highlight().String())
 		b.WriteString("\n")
+	}
+
+	if m.LatestVersion != nil {
+		currentVersion, _ := semver.NewVersion(runtime.GetVersion())
+		if currentVersion != nil && currentVersion.LessThan(m.LatestVersion) {
+			b.WriteString("\n")
+			b.WriteString(colors.Red(fmt.Sprintf("❗️ Your version of Keel is outdated. Please update to v%s with: ", m.LatestVersion.String())).String())
+			b.WriteString(colors.Red("npm install -g keel").String())
+			b.WriteString("\n")
+		}
 	}
 
 	b.WriteString("\n")
@@ -126,6 +138,7 @@ func renderRun(m *Model) string {
 				b.WriteString(colors.White(fmt.Sprintf(" (%s)", values[1])).String())
 			}
 		}
+
 	}
 
 	b.WriteString("\n")

--- a/cmd/program/views.go
+++ b/cmd/program/views.go
@@ -41,8 +41,7 @@ func renderRun(m *Model) string {
 		currentVersion, _ := semver.NewVersion(runtime.GetVersion())
 		if currentVersion != nil && currentVersion.LessThan(m.LatestVersion) {
 			b.WriteString("\n")
-			b.WriteString(colors.Red(fmt.Sprintf("Your version of Keel is outdated. Please update to v%s by running this command:", m.LatestVersion.String())).String())
-
+			b.WriteString(colors.Red(fmt.Sprintf("There is a new version of Keel available. Please update to v%s by running this command:", m.LatestVersion.String())).String())
 			b.WriteString("\n")
 			b.WriteString(colors.White("$ ").String())
 			b.WriteString(colors.Yellow("npm install -g keel").String())
@@ -119,7 +118,7 @@ func renderRun(m *Model) string {
 		}
 
 		b.WriteString("\n")
-		b.WriteString("Live Console: ")
+		b.WriteString("Local development console: ")
 		b.WriteString(colors.Blue("https://console.keel.so/local").Highlight().String())
 		b.WriteString("\n")
 
@@ -129,7 +128,6 @@ func renderRun(m *Model) string {
 			b.WriteString(colors.White(" endpoints:").String())
 
 			endpoints := [][]string{
-				{"graphiql", "GraphiQL Playground"},
 				{"graphql", "GraphQL"},
 				{"json", "JSON"},
 				{"rpc", "JSON-RPC"},

--- a/cmd/program/views.go
+++ b/cmd/program/views.go
@@ -108,12 +108,11 @@ func renderRun(m *Model) string {
 			}
 			b.WriteString("\n")
 		}
-		b.WriteString("\n")
 	}
 
 	if m.Status == StatusRunning {
 		if len(m.Schema.Apis) == 0 {
-			b.WriteString(colors.Yellow("\n - Your schema doesn't have any API's defined in it").String())
+			b.WriteString(colors.Yellow("\n - Your schema doesn't have any API's defined in it\n").String())
 		}
 
 		b.WriteString("\n")
@@ -125,24 +124,26 @@ func renderRun(m *Model) string {
 			b.WriteString("\n")
 			b.WriteString(api.Name)
 			b.WriteString(colors.White(" endpoints:").String())
+
 			endpoints := [][]string{
 				{"graphiql", "GraphiQL Playground"},
 				{"graphql", "GraphQL"},
 				{"json", "JSON"},
 				{"rpc", "JSON-RPC"},
 			}
+
 			for _, values := range endpoints {
 				b.WriteString("\n")
 				b.WriteString(" - ")
 				b.WriteString(colors.Blue(fmt.Sprintf("http://localhost:%s/%s/%s", m.Port, strings.ToLower(api.Name), values[0])).Highlight().String())
 				b.WriteString(colors.White(fmt.Sprintf(" (%s)", values[1])).String())
 			}
+			b.WriteString("\n")
 		}
-
 	}
 
 	b.WriteString("\n")
-	b.WriteString(colors.White(" - press ").String())
+	b.WriteString(colors.White("Press ").String())
 	b.WriteString("q")
 	b.WriteString(colors.White(" to quit").String())
 	b.WriteString("\n")

--- a/cmd/program/views.go
+++ b/cmd/program/views.go
@@ -41,8 +41,11 @@ func renderRun(m *Model) string {
 		currentVersion, _ := semver.NewVersion(runtime.GetVersion())
 		if currentVersion != nil && currentVersion.LessThan(m.LatestVersion) {
 			b.WriteString("\n")
-			b.WriteString(colors.Red(fmt.Sprintf("❗️ Your version of Keel is outdated. Please update to v%s with: ", m.LatestVersion.String())).String())
-			b.WriteString(colors.Red("npm install -g keel").String())
+			b.WriteString(colors.Red(fmt.Sprintf("Your version of Keel is outdated. Please update to v%s by running this command:", m.LatestVersion.String())).String())
+
+			b.WriteString("\n")
+			b.WriteString(colors.White("$ ").String())
+			b.WriteString(colors.Yellow("npm install -g keel").String())
 			b.WriteString("\n")
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 )
 
 require (
+	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/PaesslerAG/gval v1.0.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg6
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=


### PR DESCRIPTION
## Check for CLI updates on `keel run`

When a newer version is available on the `latest` distribution channel on NPM, then the following message is shown:

<img width="1017" alt="image" src="https://github.com/teamkeel/keel/assets/6212830/2a28eab1-3d42-4429-a681-5f32c5e20cdf">

Note that this check is asynchronous and will fail silently if something goes wrong.

Also improved the API endpoint sections:

<img width="417" alt="image" src="https://github.com/teamkeel/keel/assets/6212830/1fca078f-5ad7-4b3d-bc4c-d9cb9ce13a7f">
