### PR TITLE
chore: update auth openapi definition for token request

### DIFF
--- a/runtime/apis/authapi/openapi_definition.go
+++ b/runtime/apis/authapi/openapi_definition.go
@@ -217,6 +217,7 @@ func OAuthOpenApiSchema() common.HandlerFunc {
 						},
 					},
 					Required:             []string{"grant_type", "username", "password"},
+					Title:                "Password",
 					AdditionalProperties: &boolFalse,
 				},
 				{
@@ -230,6 +231,7 @@ func OAuthOpenApiSchema() common.HandlerFunc {
 						},
 					},
 					Required:             []string{"grant_type", "subject_token"},
+					Title:                "Token Exchange",
 					AdditionalProperties: &boolFalse,
 				},
 				{
@@ -243,6 +245,7 @@ func OAuthOpenApiSchema() common.HandlerFunc {
 						},
 					},
 					Required:             []string{"grant_type", "code"},
+					Title:                "Authorization Code",
 					AdditionalProperties: &boolFalse,
 				},
 				{
@@ -256,6 +259,7 @@ func OAuthOpenApiSchema() common.HandlerFunc {
 						},
 					},
 					Required:             []string{"grant_type", "refresh_token"},
+					Title:                "Refresh Token",
 					AdditionalProperties: &boolFalse,
 				},
 			},

--- a/runtime/apis/authapi/openapi_definition.go
+++ b/runtime/apis/authapi/openapi_definition.go
@@ -17,6 +17,7 @@ func OAuthOpenApiSchema() common.HandlerFunc {
 		ctx := r.Context()
 
 		boolTrue := true
+		boolFalse := false
 
 		definition := openapi.OpenAPI{
 			OpenAPI: openapi.OpenApiSpecificationVersion,
@@ -199,7 +200,8 @@ func OAuthOpenApiSchema() common.HandlerFunc {
 		}
 
 		definition.Components.Schemas["TokenRequest"] = jsonschema.JSONSchema{
-			Type: "object",
+			Type:                  "object",
+			UnevaluatedProperties: &boolFalse,
 			OneOf: []jsonschema.JSONSchema{
 				{
 					Type: "object",
@@ -215,7 +217,7 @@ func OAuthOpenApiSchema() common.HandlerFunc {
 						},
 					},
 					Required:             []string{"grant_type", "username", "password"},
-					AdditionalProperties: &boolTrue,
+					AdditionalProperties: &boolFalse,
 				},
 				{
 					Type: "object",
@@ -228,7 +230,7 @@ func OAuthOpenApiSchema() common.HandlerFunc {
 						},
 					},
 					Required:             []string{"grant_type", "subject_token"},
-					AdditionalProperties: &boolTrue,
+					AdditionalProperties: &boolFalse,
 				},
 				{
 					Type: "object",
@@ -241,7 +243,7 @@ func OAuthOpenApiSchema() common.HandlerFunc {
 						},
 					},
 					Required:             []string{"grant_type", "code"},
-					AdditionalProperties: &boolTrue,
+					AdditionalProperties: &boolFalse,
 				},
 				{
 					Type: "object",
@@ -254,7 +256,7 @@ func OAuthOpenApiSchema() common.HandlerFunc {
 						},
 					},
 					Required:             []string{"grant_type", "refresh_token"},
-					AdditionalProperties: &boolTrue,
+					AdditionalProperties: &boolFalse,
 				},
 			},
 		}


### PR DESCRIPTION
This should fix the issue we have when translating the openapi auth schema to a form for authenticating in the API explorer.