### PR TITLE
fix: add BooleanQueryInput to oneOf conditions and create anyOf grouping

### DIFF
--- a/runtime/jsonschema/jsonschema_test.go
+++ b/runtime/jsonschema/jsonschema_test.go
@@ -716,7 +716,7 @@ func TestValidateRequest(t *testing.T) {
 					opName:  "listBooksByPublisherDateFounded",
 					request: `{"where": {"author": { "publisher": { "dateFounded": null}}}}`,
 					errors: map[string][]string{
-						"where.author.publisher.dateFounded": {`Invalid type. Expected: object, given: null`},
+						"where.author.publisher.dateFounded": {`Must validate at least one schema (anyOf)`, `Invalid type. Expected: object, given: null`},
 					},
 				},
 				{
@@ -735,9 +735,9 @@ func TestValidateRequest(t *testing.T) {
 						"where.id":        {`Must validate one and only one schema (oneOf)`, `Invalid type. Expected: object, given: null`},
 						"where.title":     {`Must validate one and only one schema (oneOf)`, `Invalid type. Expected: object, given: null`},
 						"where.genre":     {`Must validate one and only one schema (oneOf)`, `Invalid type. Expected: object, given: null`},
-						"where.price":     {`Invalid type. Expected: object, given: null`},
-						"where.available": {`Invalid type. Expected: object, given: null`},
-						"where.createdAt": {`Invalid type. Expected: object, given: null`},
+						"where.price":     {`Must validate at least one schema (anyOf)`, `Invalid type. Expected: object, given: null`},
+						"where.available": {`Must validate one and only one schema (oneOf)`, `Invalid type. Expected: object, given: null`},
+						"where.createdAt": {`Must validate at least one schema (anyOf)`, `Invalid type. Expected: object, given: null`},
 					},
 				},
 				{
@@ -771,6 +771,7 @@ func TestValidateRequest(t *testing.T) {
 					opName:  "listBooks",
 					request: `{"where": {"createdAt": {"after": "not-a-date-time"}}}`,
 					errors: map[string][]string{
+						"where.createdAt":       {`Must validate at least one schema (anyOf)`},
 						"where.createdAt.after": {`Does not match format 'date-time'`},
 					},
 				},
@@ -779,6 +780,7 @@ func TestValidateRequest(t *testing.T) {
 					opName:  "listBooks",
 					request: `{"where": {"releaseDate": {"after": "12:00:00Z"}}}`,
 					errors: map[string][]string{
+						"where.releaseDate":       {`Must validate at least one schema (anyOf)`},
 						"where.releaseDate.after": {`Does not match format 'date'`},
 					},
 				},
@@ -787,6 +789,7 @@ func TestValidateRequest(t *testing.T) {
 					opName:  "listBooks",
 					request: `{"where": {"releaseDate": {"after": "not-a-date-time"}}}`,
 					errors: map[string][]string{
+						"where.releaseDate":       {`Must validate at least one schema (anyOf)`},
 						"where.releaseDate.after": {`Does not match format 'date'`},
 					},
 				},

--- a/runtime/jsonschema/testdata/list.json
+++ b/runtime/jsonschema/testdata/list.json
@@ -12,24 +12,86 @@
   "components": {
     "schemas": {
       "BooleanQueryInput": {
-        "type": "object",
-        "properties": {
-          "equals": { "type": ["boolean", "null"] },
-          "notEquals": { "type": ["boolean", "null"] }
-        },
-        "additionalProperties": false
+        "unevaluatedProperties": false,
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "equals": { "type": ["boolean", "null"] }
+            },
+            "additionalProperties": false,
+            "required": ["equals"],
+            "title": "equals"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "notEquals": { "type": ["boolean", "null"] }
+            },
+            "additionalProperties": false,
+            "required": ["notEquals"],
+            "title": "notEquals"
+          }
+        ]
       },
       "DateQueryInput": {
-        "type": "object",
-        "properties": {
-          "after": { "type": "string", "format": "date" },
-          "before": { "type": "string", "format": "date" },
-          "equals": { "type": ["string", "null"], "format": "date" },
-          "notEquals": { "type": ["string", "null"], "format": "date" },
-          "onOrAfter": { "type": "string", "format": "date" },
-          "onOrBefore": { "type": "string", "format": "date" }
-        },
-        "additionalProperties": false
+        "unevaluatedProperties": false,
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "equals": { "type": ["string", "null"], "format": "date" }
+            },
+            "additionalProperties": false,
+            "required": ["equals"],
+            "title": "equals"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "notEquals": { "type": ["string", "null"], "format": "date" }
+            },
+            "additionalProperties": false,
+            "required": ["notEquals"],
+            "title": "notEquals"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "before": { "type": "string", "format": "date" }
+            },
+            "additionalProperties": false,
+            "required": ["before"],
+            "title": "before"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "onOrBefore": { "type": "string", "format": "date" }
+            },
+            "additionalProperties": false,
+            "required": ["onOrBefore"],
+            "title": "onOrBefore"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "after": { "type": "string", "format": "date" }
+            },
+            "additionalProperties": false,
+            "required": ["after"],
+            "title": "after"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "onOrAfter": { "type": "string", "format": "date" }
+            },
+            "additionalProperties": false,
+            "required": ["onOrAfter"],
+            "title": "onOrAfter"
+          }
+        ]
       },
       "HobbyQueryInput": {
         "unevaluatedProperties": false,
@@ -93,17 +155,72 @@
         ]
       },
       "IntQueryInput": {
-        "type": "object",
-        "properties": {
-          "equals": { "type": ["number", "null"] },
-          "greaterThan": { "type": "number" },
-          "greaterThanOrEquals": { "type": "number" },
-          "lessThan": { "type": "number" },
-          "lessThanOrEquals": { "type": "number" },
-          "notEquals": { "type": ["number", "null"] },
-          "oneOf": { "type": "array", "items": { "type": "number" } }
-        },
-        "additionalProperties": false
+        "unevaluatedProperties": false,
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "equals": { "type": ["number", "null"] }
+            },
+            "additionalProperties": false,
+            "required": ["equals"],
+            "title": "equals"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "notEquals": { "type": ["number", "null"] }
+            },
+            "additionalProperties": false,
+            "required": ["notEquals"],
+            "title": "notEquals"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "lessThan": { "type": "number" }
+            },
+            "additionalProperties": false,
+            "required": ["lessThan"],
+            "title": "lessThan"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "lessThanOrEquals": { "type": "number" }
+            },
+            "additionalProperties": false,
+            "required": ["lessThanOrEquals"],
+            "title": "lessThanOrEquals"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "greaterThan": { "type": "number" }
+            },
+            "additionalProperties": false,
+            "required": ["greaterThan"],
+            "title": "greaterThan"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "greaterThanOrEquals": { "type": "number" }
+            },
+            "additionalProperties": false,
+            "required": ["greaterThanOrEquals"],
+            "title": "greaterThanOrEquals"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "oneOf": { "type": "array", "items": { "type": "number" } }
+            },
+            "additionalProperties": false,
+            "required": ["oneOf"],
+            "title": "oneOf"
+          }
+        ]
       },
       "StringQueryInput": {
         "unevaluatedProperties": false,
@@ -205,12 +322,27 @@
         ]
       },
       "TimestampQueryInput": {
-        "type": "object",
-        "properties": {
-          "after": { "type": "string", "format": "date-time" },
-          "before": { "type": "string", "format": "date-time" }
-        },
-        "additionalProperties": false
+        "unevaluatedProperties": false,
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "before": { "type": "string", "format": "date-time" }
+            },
+            "additionalProperties": false,
+            "required": ["before"],
+            "title": "before"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "after": { "type": "string", "format": "date-time" }
+            },
+            "additionalProperties": false,
+            "required": ["after"],
+            "title": "after"
+          }
+        ]
       }
     }
   }


### PR DESCRIPTION
Updates the remaining input query messages using either `oneOf` or `anyOf` options in the open api schema.
- `BooleanQueryInput` message is now set to use `oneOf`
- `DateQueryInput`, `TimestampQueryInput` and `IntQueryInput` now use `anyOf` - this is so that we can allow group these inputs together in the Console Tools UI, but also allow more than one of their filters to be set.