### PR TITLE
fix: add browser support to generated auth client

### DIFF
--- a/node/templates/client/core.ts
+++ b/node/templates/client/core.ts
@@ -171,8 +171,13 @@ export class Core {
         return null;
       }
 
-      const base64Payload = token.split(".")[1];
-      const payload = atob(base64Payload);
+      let payload;
+      try {
+        const base64Payload = token.split(".")[1];
+        payload = atob(base64Payload);
+      } catch (e) {
+        throw new Error("jwt token could not be parsed: " + e.message);
+      }
 
       var obj = JSON.parse(payload);
       if (obj !== null && typeof obj === "object") {
@@ -183,7 +188,7 @@ export class Core {
         return new Date(exp * 1000);
       }
 
-      throw new Error("jwt token could not be parsed");
+      throw new Error("jwt token could not be parsed from json");
     },
 
     /**

--- a/node/templates/client/core.ts
+++ b/node/templates/client/core.ts
@@ -171,9 +171,8 @@ export class Core {
         return null;
       }
 
-      const payload = Buffer.from(token.split(".")[1], "base64").toString(
-        "utf8"
-      );
+      const base64Payload = token.split(".")[1];
+      const payload = atob(base64Payload);
 
       var obj = JSON.parse(payload);
       if (obj !== null && typeof obj === "object") {


### PR DESCRIPTION
## Add browser support to generated auth client

Using `atob` to decode the JWT instead of `Buffer` will mean the generated client can be used in the browser.