### PR TITLE
fix: allow additionalProperties on anyOf options

### DIFF
--- a/runtime/jsonschema/jsonschema.go
+++ b/runtime/jsonschema/jsonschema.go
@@ -205,7 +205,7 @@ func JSONSchemaForMessage(ctx context.Context, schema *proto.Schema, action *pro
 				jsonSchemaOption := JSONSchema{
 					Type:                 "object",
 					Properties:           map[string]JSONSchema{},
-					AdditionalProperties: boolPtr(false),
+					AdditionalProperties: boolPtr(anyOfConditions),
 				}
 
 				prop := jsonSchemaForField(ctx, schema, action, field.Type, field.Nullable)

--- a/runtime/jsonschema/jsonschema_test.go
+++ b/runtime/jsonschema/jsonschema_test.go
@@ -696,6 +696,11 @@ func TestValidateRequest(t *testing.T) {
 					request: `{"where": {"releaseDate": {"after": "1999-12-07"}}}`,
 				},
 				{
+					name:    "date valid format with two filters",
+					opName:  "listBooks",
+					request: `{"where": {"releaseDate": {"after": "1999-12-07", "before": "1999-11-07"}}}`,
+				},
+				{
 					name:    "date valid format with date and time component",
 					opName:  "listBooks",
 					request: `{"where": {"releaseDate": {"after": "1999-12-07T12:33:43.22Z"}}}`,

--- a/runtime/jsonschema/testdata/list.json
+++ b/runtime/jsonschema/testdata/list.json
@@ -42,7 +42,7 @@
             "properties": {
               "equals": { "type": ["string", "null"], "format": "date" }
             },
-            "additionalProperties": false,
+            "additionalProperties": true,
             "required": ["equals"],
             "title": "equals"
           },
@@ -51,7 +51,7 @@
             "properties": {
               "notEquals": { "type": ["string", "null"], "format": "date" }
             },
-            "additionalProperties": false,
+            "additionalProperties": true,
             "required": ["notEquals"],
             "title": "notEquals"
           },
@@ -60,7 +60,7 @@
             "properties": {
               "before": { "type": "string", "format": "date" }
             },
-            "additionalProperties": false,
+            "additionalProperties": true,
             "required": ["before"],
             "title": "before"
           },
@@ -69,7 +69,7 @@
             "properties": {
               "onOrBefore": { "type": "string", "format": "date" }
             },
-            "additionalProperties": false,
+            "additionalProperties": true,
             "required": ["onOrBefore"],
             "title": "onOrBefore"
           },
@@ -78,7 +78,7 @@
             "properties": {
               "after": { "type": "string", "format": "date" }
             },
-            "additionalProperties": false,
+            "additionalProperties": true,
             "required": ["after"],
             "title": "after"
           },
@@ -87,7 +87,7 @@
             "properties": {
               "onOrAfter": { "type": "string", "format": "date" }
             },
-            "additionalProperties": false,
+            "additionalProperties": true,
             "required": ["onOrAfter"],
             "title": "onOrAfter"
           }
@@ -162,7 +162,7 @@
             "properties": {
               "equals": { "type": ["number", "null"] }
             },
-            "additionalProperties": false,
+            "additionalProperties": true,
             "required": ["equals"],
             "title": "equals"
           },
@@ -171,7 +171,7 @@
             "properties": {
               "notEquals": { "type": ["number", "null"] }
             },
-            "additionalProperties": false,
+            "additionalProperties": true,
             "required": ["notEquals"],
             "title": "notEquals"
           },
@@ -180,7 +180,7 @@
             "properties": {
               "lessThan": { "type": "number" }
             },
-            "additionalProperties": false,
+            "additionalProperties": true,
             "required": ["lessThan"],
             "title": "lessThan"
           },
@@ -189,7 +189,7 @@
             "properties": {
               "lessThanOrEquals": { "type": "number" }
             },
-            "additionalProperties": false,
+            "additionalProperties": true,
             "required": ["lessThanOrEquals"],
             "title": "lessThanOrEquals"
           },
@@ -198,7 +198,7 @@
             "properties": {
               "greaterThan": { "type": "number" }
             },
-            "additionalProperties": false,
+            "additionalProperties": true,
             "required": ["greaterThan"],
             "title": "greaterThan"
           },
@@ -207,7 +207,7 @@
             "properties": {
               "greaterThanOrEquals": { "type": "number" }
             },
-            "additionalProperties": false,
+            "additionalProperties": true,
             "required": ["greaterThanOrEquals"],
             "title": "greaterThanOrEquals"
           },
@@ -216,7 +216,7 @@
             "properties": {
               "oneOf": { "type": "array", "items": { "type": "number" } }
             },
-            "additionalProperties": false,
+            "additionalProperties": true,
             "required": ["oneOf"],
             "title": "oneOf"
           }
@@ -329,7 +329,7 @@
             "properties": {
               "before": { "type": "string", "format": "date-time" }
             },
-            "additionalProperties": false,
+            "additionalProperties": true,
             "required": ["before"],
             "title": "before"
           },
@@ -338,7 +338,7 @@
             "properties": {
               "after": { "type": "string", "format": "date-time" }
             },
-            "additionalProperties": false,
+            "additionalProperties": true,
             "required": ["after"],
             "title": "after"
           }


### PR DESCRIPTION
Currently `anyOf` options are set to have `additionalProperties: false` which stops the client from sending a request with multiple filters.