### PR TITLE
fix: update auth openapi schema with default value

### DIFF
--- a/runtime/apis/authapi/openapi_definition.go
+++ b/runtime/apis/authapi/openapi_definition.go
@@ -200,14 +200,14 @@ func OAuthOpenApiSchema() common.HandlerFunc {
 		}
 
 		definition.Components.Schemas["TokenRequest"] = jsonschema.JSONSchema{
-			Type:                  "object",
 			UnevaluatedProperties: &boolFalse,
 			OneOf: []jsonschema.JSONSchema{
 				{
 					Type: "object",
 					Properties: map[string]jsonschema.JSONSchema{
 						"grant_type": {
-							Const: "password",
+							Const:   "password",
+							Default: "password",
 						},
 						"username": {
 							Type: "string",
@@ -224,7 +224,8 @@ func OAuthOpenApiSchema() common.HandlerFunc {
 					Type: "object",
 					Properties: map[string]jsonschema.JSONSchema{
 						"grant_type": {
-							Const: "token_exchange",
+							Const:   "token_exchange",
+							Default: "token_exchange",
 						},
 						"subject_token": {
 							Type: "string",
@@ -238,7 +239,8 @@ func OAuthOpenApiSchema() common.HandlerFunc {
 					Type: "object",
 					Properties: map[string]jsonschema.JSONSchema{
 						"grant_type": {
-							Const: "authorization_code",
+							Const:   "authorization_code",
+							Default: "authorization_code",
 						},
 						"code": {
 							Type: "string",
@@ -252,7 +254,8 @@ func OAuthOpenApiSchema() common.HandlerFunc {
 					Type: "object",
 					Properties: map[string]jsonschema.JSONSchema{
 						"grant_type": {
-							Const: "refresh_token",
+							Const:   "refresh_token",
+							Default: "refresh_token",
 						},
 						"refresh_token": {
 							Type: "string",

--- a/runtime/jsonschema/jsonschema.go
+++ b/runtime/jsonschema/jsonschema.go
@@ -64,6 +64,7 @@ type JSONSchema struct {
 	OneOf                 []JSONSchema          `json:"oneOf,omitempty"`
 	AnyOf                 []JSONSchema          `json:"anyOf,omitempty"`
 	Title                 string                `json:"title,omitempty"`
+	Default               string                `json:"default,omitempty"`
 
 	// For arrays
 	Items *JSONSchema `json:"items,omitempty"`


### PR DESCRIPTION
This change is required for when we use the open api schema, we can hide the `grant_type` input field from showing in the UI, as a default value (the const) is already set. 