### PR TITLE
fix: ignore .git folder from hot reloading when running `keel run`

### DIFF
--- a/cmd/program/commands.go
+++ b/cmd/program/commands.go
@@ -576,6 +576,7 @@ func StartWatcher(dir string, ch chan tea.Msg, filter []string) tea.Cmd {
 		ignored := []string{
 			"node_modules/",
 			".build/",
+			".git/",
 		}
 
 		w.AddFilterHook(func(info os.FileInfo, fullPath string) error {


### PR DESCRIPTION
When running git commands in a Keel project directory (or any subpath for that matter), keel run will refresh by reloading and starting up the project again. This PR addresses this issue by ignoring the `.git` folder form the watched files.