### PR TITLE
fix: concurrent map reads on upload trace

### DIFF
--- a/cmd/database/database.go
+++ b/cmd/database/database.go
@@ -435,9 +435,9 @@ func connectAndWaitForDbServer(serverConnectionInfo *db.ConnectionInfo) (server 
 		return nil, err
 	}
 
-	// ping() the database for 5 seconds until it is available.
+	// ping() the database for 10 seconds until it is available.
 	var pingError error
-	for i := 0; i < 20; i++ {
+	for i := 0; i < 40; i++ {
 		if pingError = server.Ping(); pingError == nil {
 			break
 		}

--- a/cmd/database/database.go
+++ b/cmd/database/database.go
@@ -435,9 +435,9 @@ func connectAndWaitForDbServer(serverConnectionInfo *db.ConnectionInfo) (server 
 		return nil, err
 	}
 
-	// ping() the database for 10 seconds until it is available.
+	// ping() the database for 5 seconds until it is available.
 	var pingError error
-	for i := 0; i < 40; i++ {
+	for i := 0; i < 20; i++ {
 		if pingError = server.Ping(); pingError == nil {
 			break
 		}

--- a/cmd/localTraceExporter/client.go
+++ b/cmd/localTraceExporter/client.go
@@ -86,7 +86,6 @@ func (c *client) UploadTraces(ctx context.Context, protoSpans []*tracepb.Resourc
 		for _, scopedSpans := range scopedSpans {
 			for _, span := range scopedSpans.Spans {
 				traceID := hex.EncodeToString(span.TraceId)
-
 				traces[traceID] = append(traces[traceID], span)
 
 				c.updateTraceSummary(traceID, span)


### PR DESCRIPTION
When pummeling the local CLI running Keel with lots of events, I am able to produce the following panic in the local trace exporter:

```
fatal error: concurrent map read and map write
```

This is because we're concurrently reading and writing to a dictionary.  The fix just includes moving the mutex up.