### PR TITLE
feat: previous state in event payload

### DIFF
--- a/auditing/auditing.go
+++ b/auditing/auditing.go
@@ -44,6 +44,7 @@ type AuditLog struct {
 	EventProcessedAt time.Time
 }
 
+// Previous return the previous log entry for the given data row.
 func Previous(ctx context.Context, log *AuditLog) (*AuditLog, error) {
 	database, err := db.GetDatabase(ctx)
 	if err != nil {
@@ -57,14 +58,11 @@ func Previous(ctx context.Context, log *AuditLog) (*AuditLog, error) {
 		return nil, err
 	}
 
-	for _, row := range result.Rows {
-		if row["id"] == log.Id {
-			continue
-		}
-		return fromRow(row)
+	if len(result.Rows) != 1 {
+		return nil, nil
 	}
 
-	return nil, nil
+	return fromRow(result.Rows[0])
 }
 
 // ProcessEventsFromAuditTrail inspects the audit table for logs which need to be

--- a/auditing/auditing.go
+++ b/auditing/auditing.go
@@ -44,7 +44,7 @@ type AuditLog struct {
 	EventProcessedAt time.Time
 }
 
-// Previous return the previous log entry for the given data row.
+// Previous returns the previous log entry for the given data row.
 func Previous(ctx context.Context, log *AuditLog) (*AuditLog, error) {
 	database, err := db.GetDatabase(ctx)
 	if err != nil {

--- a/events/events.go
+++ b/events/events.go
@@ -39,9 +39,9 @@ type EventTarget struct {
 	Id string `json:"id"`
 	// The type of event target, e.g. Employee
 	Type string `json:"type"`
-	// The data relevant to this target type.
+	// The model data at the time of the event.
 	Data map[string]any `json:"data"`
-	// The previous state of the data.
+	// The previous state of the model data before the event.
 	PreviousData map[string]any `json:"previousData"`
 }
 

--- a/events/events.go
+++ b/events/events.go
@@ -42,7 +42,7 @@ type EventTarget struct {
 	// The data relevant to this target type.
 	Data map[string]any `json:"data"`
 	// The previous state of the data.
-	Previous map[string]any `json:"previous"`
+	PreviousData map[string]any `json:"previousData"`
 }
 
 // The event handler function to be executed for each subscriber event generated.
@@ -156,10 +156,10 @@ func SendEvents(ctx context.Context, schema *proto.Schema) error {
 				OccurredAt: time.Now().UTC(),
 				IdentityId: identityId,
 				Target: &EventTarget{
-					Id:       log.Data["id"].(string),
-					Type:     strcase.ToCamel(log.TableName),
-					Data:     toLowerCamelMap(log.Data),
-					Previous: toLowerCamelMap(previous),
+					Id:           log.Data["id"].(string),
+					Type:         strcase.ToCamel(log.TableName),
+					Data:         toLowerCamelMap(log.Data),
+					PreviousData: toLowerCamelMap(previous),
 				},
 			}
 

--- a/events/events.go
+++ b/events/events.go
@@ -41,6 +41,8 @@ type EventTarget struct {
 	Type string `json:"type"`
 	// The data relevant to this target type.
 	Data map[string]any `json:"data"`
+	// The previous state of the data.
+	Previous map[string]any `json:"previous"`
 }
 
 // The event handler function to be executed for each subscriber event generated.
@@ -136,15 +138,28 @@ func SendEvents(ctx context.Context, schema *proto.Schema) error {
 			return fmt.Errorf("event '%s' must have at least one subscriber", eventName)
 		}
 
+		var previous map[string]any
+		if log.Op != Created {
+			p, err := auditing.Previous(ctx, log)
+			if err != nil {
+				return err
+			}
+
+			if p != nil {
+				previous = p.Data
+			}
+		}
+
 		for _, subscriber := range subscribers {
 			event := &Event{
 				EventName:  eventName,
 				OccurredAt: time.Now().UTC(),
 				IdentityId: identityId,
 				Target: &EventTarget{
-					Id:   log.Data["id"].(string),
-					Type: strcase.ToCamel(log.TableName),
-					Data: toLowerCamelMap(log.Data),
+					Id:       log.Data["id"].(string),
+					Type:     strcase.ToCamel(log.TableName),
+					Data:     toLowerCamelMap(log.Data),
+					Previous: toLowerCamelMap(previous),
 				},
 			}
 
@@ -181,6 +196,10 @@ func eventNameFromAudit(tableName string, op string) (string, error) {
 }
 
 func toLowerCamelMap(m map[string]any) map[string]any {
+	if m == nil {
+		return nil
+	}
+
 	res := map[string]any{}
 	for key, value := range m {
 		res[casing.ToLowerCamel(key)] = value

--- a/integration/testdata/events_basic/subscribers/verifyUpdate.ts
+++ b/integration/testdata/events_basic/subscribers/verifyUpdate.ts
@@ -5,6 +5,10 @@ export default VerifyUpdate(async (ctx: SubscriberContextAPI, event) => {
     throw new Error("name cannot be empty");
   }
 
+  if (event.target.previous == null) {
+    throw new Error("previous data cannot be null");
+  }
+
   if (!event.target.data.verifiedUpdate) {
     await models.person.update(
       { id: event.target.data.id },

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -133,6 +133,7 @@ func (m *Migrations) Apply(ctx context.Context, dryRun bool) error {
 
 	// For now, we do this here but this could belong in our proto once we start on the database indexing work.
 	sql.WriteString("CREATE INDEX IF NOT EXISTS idx_keel_audit_trace_id ON keel_audit USING HASH(trace_id);\n")
+	sql.WriteString("CREATE INDEX IF NOT EXISTS idx_keel_audit_table_name_data_id_created_at ON keel_audit (table_name, (data->>'id'), created_at);\n")
 
 	// Data migration when migrating to new authentication methods.
 	sql.WriteString("UPDATE identity SET issuer = 'https://keel.so' WHERE issuer = 'keel';\n")

--- a/node/codegen_test.go
+++ b/node/codegen_test.go
@@ -1540,6 +1540,7 @@ export interface VerifyEmailMemberUpdatedEventTarget {
 	id: string;
 	type: string;
 	data: Member;
+	previous: Member;
 }
 export type SendWelcomeEmailEvent = (SendWelcomeEmailMemberCreatedEvent);
 export interface SendWelcomeEmailMemberCreatedEvent {
@@ -1808,6 +1809,7 @@ export interface VerifyEmailClubHouseUpdatedEventTarget {
 	id: string;
 	type: string;
 	data: sdk.ClubHouse;
+	previous: sdk.ClubHouse;
 }
 declare class ActionExecutor {
 	withIdentity(identity: sdk.Identity): ActionExecutor;

--- a/node/codegen_test.go
+++ b/node/codegen_test.go
@@ -1540,7 +1540,7 @@ export interface VerifyEmailMemberUpdatedEventTarget {
 	id: string;
 	type: string;
 	data: Member;
-	previous: Member;
+	previousData: Member;
 }
 export type SendWelcomeEmailEvent = (SendWelcomeEmailMemberCreatedEvent);
 export interface SendWelcomeEmailMemberCreatedEvent {
@@ -1809,7 +1809,7 @@ export interface VerifyEmailClubHouseUpdatedEventTarget {
 	id: string;
 	type: string;
 	data: sdk.ClubHouse;
-	previous: sdk.ClubHouse;
+	previousData: sdk.ClubHouse;
 }
 declare class ActionExecutor {
 	withIdentity(identity: sdk.Identity): ActionExecutor;

--- a/runtime/runtime_events_test.go
+++ b/runtime/runtime_events_test.go
@@ -110,6 +110,7 @@ func TestCreateEvent(t *testing.T) {
 	require.NotNil(t, events[0].Target)
 	require.Equal(t, wedding["id"], events[0].Target.Id)
 	require.Equal(t, "Wedding", events[0].Target.Type)
+	require.Nil(t, events[0].Target.Previous)
 
 	data := typed.New(events[0].Target.Data)
 	require.Equal(t, wedding["id"], data.String("id"))
@@ -180,6 +181,20 @@ func TestUpdateEvent(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, wedding["updatedAt"], updatedAt)
 	require.Equal(t, updatedWedding["updatedAt"], updatedAt)
+
+	previous := typed.New(events[0].Target.Previous)
+	require.Equal(t, wedding["id"], previous.String("id"))
+	require.Equal(t, wedding["name"], previous.String("name"))
+	require.NotEqual(t, updatedWedding["name"], previous.String("name"))
+
+	previousCreatedAt, err := time.Parse("2006-01-02T15:04:05.999999999-07:00", previous.String("createdAt"))
+	require.NoError(t, err)
+	require.Equal(t, wedding["createdAt"], previousCreatedAt)
+
+	previousUpdatedAt, err := time.Parse("2006-01-02T15:04:05.999999999-07:00", previous.String("updatedAt"))
+	require.NoError(t, err)
+	require.Equal(t, wedding["updatedAt"], previousUpdatedAt)
+	require.NotEqual(t, updatedWedding["updatedAt"], previousUpdatedAt)
 }
 
 func TestDeleteEvent(t *testing.T) {
@@ -229,6 +244,18 @@ func TestDeleteEvent(t *testing.T) {
 	updatedAt, err := time.Parse("2006-01-02T15:04:05.999999999-07:00", data.String("updatedAt"))
 	require.NoError(t, err)
 	require.Equal(t, wedding["updatedAt"], updatedAt)
+
+	previous := typed.New(events[0].Target.Previous)
+	require.Equal(t, wedding["id"], previous.String("id"))
+	require.Equal(t, wedding["name"], previous.String("name"))
+
+	previousCreatedAt, err := time.Parse("2006-01-02T15:04:05.999999999-07:00", previous.String("createdAt"))
+	require.NoError(t, err)
+	require.Equal(t, wedding["createdAt"], previousCreatedAt)
+
+	previousUpdatedAt, err := time.Parse("2006-01-02T15:04:05.999999999-07:00", previous.String("updatedAt"))
+	require.NoError(t, err)
+	require.Equal(t, wedding["updatedAt"], previousUpdatedAt)
 }
 
 func TestNoIdentityEvent(t *testing.T) {
@@ -340,6 +367,7 @@ func TestMultipleEvents(t *testing.T) {
 
 	require.Equal(t, "wedding_invitee.updated", verifyDetailsEvent[1].EventName)
 	require.Equal(t, "Adam", verifyDetailsEvent[1].Target.Data["firstName"])
+	require.Equal(t, "Dave", verifyDetailsEvent[1].Target.Previous["firstName"])
 }
 
 func TestAuditTableEventCreatedAtUpdated(t *testing.T) {

--- a/runtime/runtime_events_test.go
+++ b/runtime/runtime_events_test.go
@@ -110,7 +110,7 @@ func TestCreateEvent(t *testing.T) {
 	require.NotNil(t, events[0].Target)
 	require.Equal(t, wedding["id"], events[0].Target.Id)
 	require.Equal(t, "Wedding", events[0].Target.Type)
-	require.Nil(t, events[0].Target.Previous)
+	require.Nil(t, events[0].Target.PreviousData)
 
 	data := typed.New(events[0].Target.Data)
 	require.Equal(t, wedding["id"], data.String("id"))
@@ -182,7 +182,7 @@ func TestUpdateEvent(t *testing.T) {
 	require.NotEqual(t, wedding["updatedAt"], updatedAt)
 	require.Equal(t, updatedWedding["updatedAt"], updatedAt)
 
-	previous := typed.New(events[0].Target.Previous)
+	previous := typed.New(events[0].Target.PreviousData)
 	require.Equal(t, wedding["id"], previous.String("id"))
 	require.Equal(t, wedding["name"], previous.String("name"))
 	require.NotEqual(t, updatedWedding["name"], previous.String("name"))
@@ -245,7 +245,7 @@ func TestDeleteEvent(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, wedding["updatedAt"], updatedAt)
 
-	previous := typed.New(events[0].Target.Previous)
+	previous := typed.New(events[0].Target.PreviousData)
 	require.Equal(t, wedding["id"], previous.String("id"))
 	require.Equal(t, wedding["name"], previous.String("name"))
 
@@ -367,7 +367,7 @@ func TestMultipleEvents(t *testing.T) {
 
 	require.Equal(t, "wedding_invitee.updated", verifyDetailsEvent[1].EventName)
 	require.Equal(t, "Adam", verifyDetailsEvent[1].Target.Data["firstName"])
-	require.Equal(t, "Dave", verifyDetailsEvent[1].Target.Previous["firstName"])
+	require.Equal(t, "Dave", verifyDetailsEvent[1].Target.PreviousData["firstName"])
 }
 
 func TestAuditTableEventCreatedAtUpdated(t *testing.T) {

--- a/schema/makeproto.go
+++ b/schema/makeproto.go
@@ -1384,7 +1384,7 @@ func (scm *Builder) makeSubscriberInputMessages() {
 			if event.ActionType != proto.ActionType_ACTION_TYPE_CREATE {
 				eventTargetMessage.Fields = append(eventTargetMessage.Fields, &proto.MessageField{
 					MessageName: eventTargetMessage.Name,
-					Name:        "previous",
+					Name:        "previousData",
 					Type: &proto.TypeInfo{
 						Type:      proto.Type_TYPE_MODEL,
 						ModelName: wrapperspb.String(event.ModelName),

--- a/schema/makeproto.go
+++ b/schema/makeproto.go
@@ -1381,6 +1381,17 @@ func (scm *Builder) makeSubscriberInputMessages() {
 				},
 			})
 
+			if event.ActionType != proto.ActionType_ACTION_TYPE_CREATE {
+				eventTargetMessage.Fields = append(eventTargetMessage.Fields, &proto.MessageField{
+					MessageName: eventTargetMessage.Name,
+					Name:        "previous",
+					Type: &proto.TypeInfo{
+						Type:      proto.Type_TYPE_MODEL,
+						ModelName: wrapperspb.String(event.ModelName),
+					},
+				})
+			}
+
 			message.Type.UnionNames = append(message.Type.UnionNames, wrapperspb.String(eventMessage.Name))
 			scm.proto.Messages = append(scm.proto.Messages, eventMessage)
 			scm.proto.Messages = append(scm.proto.Messages, eventTargetMessage)

--- a/schema/testdata/proto/attribute_on/proto.json
+++ b/schema/testdata/proto/attribute_on/proto.json
@@ -112,7 +112,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -149,7 +151,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -280,7 +284,9 @@
       "name": "SendWelcomeMailEvent",
       "type": {
         "type": "TYPE_UNION",
-        "unionNames": ["SendWelcomeMailMemberCreatedEvent"]
+        "unionNames": [
+          "SendWelcomeMailMemberCreatedEvent"
+        ]
       }
     },
     {
@@ -481,6 +487,14 @@
             "type": "TYPE_MODEL",
             "modelName": "Member"
           }
+        },
+        {
+          "messageName": "VerifyEmailMemberUpdatedEventTarget",
+          "name": "previous",
+          "type": {
+            "type": "TYPE_MODEL",
+            "modelName": "Member"
+          }
         }
       ]
     },
@@ -607,6 +621,14 @@
             "type": "TYPE_MODEL",
             "modelName": "Employee"
           }
+        },
+        {
+          "messageName": "VerifyEmailEmployeeUpdatedEventTarget",
+          "name": "previous",
+          "type": {
+            "type": "TYPE_MODEL",
+            "modelName": "Employee"
+          }
         }
       ]
     },
@@ -614,7 +636,9 @@
       "name": "SendGoodbyeMailEvent",
       "type": {
         "type": "TYPE_UNION",
-        "unionNames": ["SendGoodbyeMailMemberDeletedEvent"]
+        "unionNames": [
+          "SendGoodbyeMailMemberDeletedEvent"
+        ]
       }
     },
     {
@@ -677,6 +701,14 @@
             "type": "TYPE_MODEL",
             "modelName": "Member"
           }
+        },
+        {
+          "messageName": "SendGoodbyeMailMemberDeletedEventTarget",
+          "name": "previous",
+          "type": {
+            "type": "TYPE_MODEL",
+            "modelName": "Member"
+          }
         }
       ]
     }
@@ -685,7 +717,9 @@
     {
       "name": "sendWelcomeMail",
       "inputMessageName": "SendWelcomeMailEvent",
-      "eventNames": ["member.created"]
+      "eventNames": [
+        "member.created"
+      ]
     },
     {
       "name": "verifyEmail",
@@ -700,7 +734,9 @@
     {
       "name": "sendGoodbyeMail",
       "inputMessageName": "SendGoodbyeMailEvent",
-      "eventNames": ["member.deleted"]
+      "eventNames": [
+        "member.deleted"
+      ]
     }
   ],
   "events": [

--- a/schema/testdata/proto/attribute_on/proto.json
+++ b/schema/testdata/proto/attribute_on/proto.json
@@ -490,7 +490,7 @@
         },
         {
           "messageName": "VerifyEmailMemberUpdatedEventTarget",
-          "name": "previous",
+          "name": "previousData",
           "type": {
             "type": "TYPE_MODEL",
             "modelName": "Member"
@@ -624,7 +624,7 @@
         },
         {
           "messageName": "VerifyEmailEmployeeUpdatedEventTarget",
-          "name": "previous",
+          "name": "previousData",
           "type": {
             "type": "TYPE_MODEL",
             "modelName": "Employee"
@@ -704,7 +704,7 @@
         },
         {
           "messageName": "SendGoodbyeMailMemberDeletedEventTarget",
-          "name": "previous",
+          "name": "previousData",
           "type": {
             "type": "TYPE_MODEL",
             "modelName": "Member"


### PR DESCRIPTION
## Previous model state in event payload

The event payload for update and delete events types now include the full state of the model _before_ the mutation which triggered the event.  

For example, this is what the definition would look like for an event on a `create` and `update` action:

```ts
export type VerifyEmailEvent = (VerifyEmailMemberCreatedEvent | VerifyEmailMemberUpdatedEvent);

// Note that the create event target does NOT include previousData
export interface VerifyEmailMemberCreatedEvent {
  eventName: "member.created";
  occurredAt: Date;
  identityId?: string;
  target: VerifyEmailMemberCreatedEventTarget;
}
export interface VerifyEmailMemberCreatedEventTarget {
  id: string;
  type: string;
  data: Member;
}

// Note that the update event target DOES include previousData
export interface VerifyEmailMemberUpdatedEvent {
  eventName: "member.updated";
  occurredAt: Date;
  identityId?: string;
  target: VerifyEmailMemberUpdatedEventTarget;
}
export interface VerifyEmailMemberUpdatedEventTarget {
  id: string;
  type: string;
  data: Member;
  previousData: Member;
}
```