### PR TITLE
fix: typo in error message

### DIFF
--- a/schema/testdata/errors/actions_no_bare_model_as_input.keel
+++ b/schema/testdata/errors/actions_no_bare_model_as_input.keel
@@ -4,20 +4,20 @@ model Book {
     }
 
     actions {
-        //expect-error:36:42:ActionInputError:'author' refers to a model which cannot used as an input
+        //expect-error:36:42:ActionInputError:'author' refers to a model which cannot be used as an input
         create createBooks() with (author)
-        //expect-error:38:44:ActionInputError:'author' refers to a model which cannot used as an input
+        //expect-error:38:44:ActionInputError:'author' refers to a model which cannot be used as an input
         update updateBooks(id) with (author)
-        //expect-error:24:30:ActionInputError:'author' refers to a model which cannot used as an input
+        //expect-error:24:30:ActionInputError:'author' refers to a model which cannot be used as an input
         list listBooks(author)
     }
 
     actions {
-        //expect-error:44:50:ActionInputError:'author' refers to a model which cannot used as an input
+        //expect-error:44:50:ActionInputError:'author' refers to a model which cannot be used as an input
         create createBooksFunction() with (author)
-        //expect-error:46:52:ActionInputError:'author' refers to a model which cannot used as an input
+        //expect-error:46:52:ActionInputError:'author' refers to a model which cannot be used as an input
         update updateBooksFunction(id) with (author)
-        //expect-error:32:38:ActionInputError:'author' refers to a model which cannot used as an input
+        //expect-error:32:38:ActionInputError:'author' refers to a model which cannot be used as an input
         list listBooksFunction(author)
     }
 }

--- a/schema/testdata/errors/unique_input_bare_model.keel
+++ b/schema/testdata/errors/unique_input_bare_model.keel
@@ -7,7 +7,7 @@ model Book {
     }
 
     actions {
-        //expect-error:25:31:ActionInputError:'author' refers to a model which cannot used as an input
+        //expect-error:25:31:ActionInputError:'author' refers to a model which cannot be used as an input
         get getByAuthor(author)
     }
 }

--- a/schema/validation/rules/actions/actions.go
+++ b/schema/validation/rules/actions/actions.go
@@ -193,7 +193,7 @@ func ActionModelInputsRule(asts []*parser.AST) (errs errorhandling.ValidationErr
 					errorhandling.NewValidationErrorWithDetails(
 						errorhandling.ActionInputError,
 						errorhandling.ErrorDetails{
-							Message: fmt.Sprintf("'%s' refers to a model which cannot used as an input", input.Type.ToString()),
+							Message: fmt.Sprintf("'%s' refers to a model which cannot be used as an input", input.Type.ToString()),
 							Hint:    fmt.Sprintf("Inputs must target fields on models only, e.g %s.id", input.Type.ToString()),
 						},
 						input.Type,


### PR DESCRIPTION
![image (3)](https://github.com/teamkeel/keel/assets/1662143/46dba69a-3421-4418-8dbf-02d400cb6f82)

The error message should say “which cannot **be** used as an input” instead.