### PR TITLE
chore: enforce correct number of args for each command

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"os"
-
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 	"github.com/teamkeel/keel/cmd/program"
@@ -16,7 +14,8 @@ var flagClientApiName string
 var clientCmd = &cobra.Command{
 	Use:   "client",
 	Short: "Generates client SDK for a Keel project",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		model := &program.GenerateClientModel{
 			ProjectDir: flagProjectDir,
 			Package:    flagClientPackage,
@@ -27,12 +26,10 @@ var clientCmd = &cobra.Command{
 
 		_, err := tea.NewProgram(model).Run()
 		if err != nil {
-			panic(err)
+			return err
 		}
 
-		if model.Err != nil {
-			os.Exit(1)
-		}
+		return model.Err
 	},
 }
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -16,6 +16,7 @@ import (
 var generateCmd = &cobra.Command{
 	Use:   "generate",
 	Short: "Generates supporting SDK for a Keel schema and scaffolds missing custom functions",
+	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		logPrefix := colors.Green("|").String()
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
 	"github.com/teamkeel/keel/cmd/program"
@@ -11,12 +9,7 @@ import (
 var runCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Run your Keel App for development",
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) > 0 {
-			return fmt.Errorf("unexpected arguments: %v", args)
-		}
-		return nil
-	},
+	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		packageManager, err := resolvePackageManager(flagProjectDir, false)
 		if err == promptui.ErrAbort {

--- a/cmd/secrets.go
+++ b/cmd/secrets.go
@@ -35,11 +35,8 @@ var secretsListCmd = &cobra.Command{
 	Short: "List all secrets for your Keel App",
 	Long: `The list command will list all secrets that are
 stored in your cli config usually found at ~/.keel/config.yaml.`,
-
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) > 0 {
-			return program.RenderError(errors.New("Too many arguments"))
-		}
 
 		secrets, err := program.LoadSecrets(flagProjectDir, flagEnvironment)
 		if err != nil {
@@ -60,15 +57,8 @@ var secretsSetCmd = &cobra.Command{
 	Use:   "set <key> <value>",
 	Short: "Set a secret for your Keel App",
 	Long:  "The set command will set a secret for your Keel App. The default environment is development.",
-
+	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 2 {
-			return program.RenderError(errors.New("Not enough arguments, please provide a key and value"))
-		}
-		if len(args) > 2 {
-			return program.RenderError(errors.New("Too many arguments"))
-		}
-
 		key := args[0]
 		value := args[1]
 
@@ -87,15 +77,8 @@ var secretsRemoveCmd = &cobra.Command{
 	Use:   "remove <key>",
 	Short: "Remove a secret for your Keel App",
 	Long:  "The remove command will remove a secret for your Keel App. The default environment is development.",
-
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
-			return program.RenderError(errors.New("Not enough arguments, please provide a key"))
-		}
-		if len(args) > 1 {
-			return program.RenderError(errors.New("Too many arguments"))
-		}
-
 		key := args[0]
 
 		err := program.RemoveSecret(flagProjectDir, flagEnvironment, key)

--- a/cmd/secrets.go
+++ b/cmd/secrets.go
@@ -37,6 +37,10 @@ var secretsListCmd = &cobra.Command{
 stored in your cli config usually found at ~/.keel/config.yaml.`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) > 0 {
+			return program.RenderError(errors.New("Too many arguments"))
+		}
+
 		secrets, err := program.LoadSecrets(flagProjectDir, flagEnvironment)
 		if err != nil {
 			return program.RenderError(err)
@@ -61,6 +65,9 @@ var secretsSetCmd = &cobra.Command{
 		if len(args) < 2 {
 			return program.RenderError(errors.New("Not enough arguments, please provide a key and value"))
 		}
+		if len(args) > 2 {
+			return program.RenderError(errors.New("Too many arguments"))
+		}
 
 		key := args[0]
 		value := args[1]
@@ -84,6 +91,9 @@ var secretsRemoveCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return program.RenderError(errors.New("Not enough arguments, please provide a key"))
+		}
+		if len(args) > 1 {
+			return program.RenderError(errors.New("Too many arguments"))
 		}
 
 		key := args[0]

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -24,6 +24,7 @@ import (
 var testCmd = &cobra.Command{
 	Use:   "test",
 	Short: "Run tests",
+	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// We still need a tracing provider for auditing and events,
 		// even if the data is not being exported.

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -14,11 +14,8 @@ import (
 var validateCmd = &cobra.Command{
 	Use:   "validate",
 	Short: "Validate your project",
+	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) > 0 {
-			return fmt.Errorf("unexpected arguments: %v", args)
-		}
-
 		b := schema.Builder{}
 		_, err := b.MakeFromDirectory(flagProjectDir)
 		if err == nil {


### PR DESCRIPTION
Consolidate CLI commands arguments validation by enforcing the required number of args; e.g:

```
user@pc> keel secrets remove 
Error: accepts 1 arg(s), received 0
Usage:
  keel secrets remove <key> [flags]
...
```

```
user@pc> keel run project  -d ./../starter
Error: unknown command "project" for "keel run"
Usage:
  keel run [flags]
...
```

```
user@pc> keel secrets set TEST "value" dev
Error: accepts 2 arg(s), received 3
Usage:
  keel secrets set <key> <value> [flags]
```
