### PR TITLE
fix: dates without ms not parsed in test sdk

### DIFF
--- a/packages/testing-runtime/src/Executor.mjs
+++ b/packages/testing-runtime/src/Executor.mjs
@@ -110,7 +110,7 @@ export class Executor {
   }
 }
 
-const dateFormat = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:(\d{2}(?:\.\d*))Z$/;
+const dateFormat = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:(\d{2}(?:\.\d*)?)Z$/;
 
 function reviver(key, value) {
   if (typeof value === "string" && dateFormat.test(value)) {


### PR DESCRIPTION
### Dates without a millisecond component not parsed correctly

The testing SDK (i.e. `await actions.createThing(...)`) is not correctly parsing date and timestamp values which have no millisecond component.  For example, `2024-02-01T00:00:00Z` would be parsed as a string and not a `Date`.  I have now made the millisecond component optional in the reviver.