### PR TITLE
fix: issue affecting `delete` actions with row based permission checks & re-enable all integration tests

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -63,10 +63,6 @@ func TestIntegration(t *gotest.T) {
 	otel.SetTextMapPropagator(propagation.TraceContext{})
 
 	for _, e := range entries {
-		if e.Name() != "set_backlinks" {
-			continue
-		}
-
 		t.Run(e.Name(), func(t *gotest.T) {
 			testDir := filepath.Join("./testdata", e.Name())
 

--- a/integration/testdata/audit_logs/tests.test.ts
+++ b/integration/testdata/audit_logs/tests.test.ts
@@ -121,7 +121,10 @@ test("delete action - audit table populated", async () => {
 });
 
 test("create action with identity - audit table populated", async () => {
-  const identity = await models.identity.create({ email: "keelson@keel.xyz" });
+  const identity = await models.identity.create({
+    email: "keelson@keel.xyz",
+    issuer: "https://keel.so",
+  });
 
   const wedding = await actions.withIdentity(identity).createWedding({
     name: "Mary & Bob",
@@ -141,7 +144,10 @@ test("create action with identity - audit table populated", async () => {
 });
 
 test("update action with identity - audit table populated", async () => {
-  const identity = await models.identity.create({ email: "keelson@keel.xyz" });
+  const identity = await models.identity.create({
+    email: "keelson@keel.xyz",
+    issuer: "https://keel.so",
+  });
 
   const { id } = await actions.createWedding({
     name: "Mary & Bob",
@@ -165,7 +171,10 @@ test("update action with identity - audit table populated", async () => {
 });
 
 test("delete action with identity - audit table populated", async () => {
-  const identity = await models.identity.create({ email: "keelson@keel.xyz" });
+  const identity = await models.identity.create({
+    email: "keelson@keel.xyz",
+    issuer: "https://keel.so",
+  });
 
   const wedding = await actions.createWedding({
     name: "Mary & Bob",
@@ -188,7 +197,10 @@ test("delete action with identity - audit table populated", async () => {
 });
 
 test("nested create action - audit table populated", async () => {
-  const identity = await models.identity.create({ email: "mary@keel.xyz" });
+  const identity = await models.identity.create({
+    email: "mary@keel.xyz",
+    issuer: "https://keel.so",
+  });
 
   const wedding = await actions.withIdentity(identity).createWeddingWithGuests({
     name: "Mary & Bob",
@@ -270,8 +282,14 @@ test("nested create action - audit table populated", async () => {
 });
 
 test("built-in actions with multiple identities - audit table populated", async () => {
-  const keelson = await models.identity.create({ email: "keelson@keel.xyz" });
-  const weave = await models.identity.create({ email: "weave@keel.xyz" });
+  const keelson = await models.identity.create({
+    email: "keelson@keel.xyz",
+    issuer: "https://keel.so",
+  });
+  const weave = await models.identity.create({
+    email: "weave@keel.xyz",
+    issuer: "https://keel.so",
+  });
 
   const wedding = await actions.withIdentity(keelson).createWedding({
     name: "Mary & Bob",
@@ -310,7 +328,10 @@ test("built-in actions with multiple identities - audit table populated", async 
 });
 
 test("hook function - audit table populated", async () => {
-  const identity = await models.identity.create({ email: "keelson@keel.xyz" });
+  const identity = await models.identity.create({
+    email: "keelson@keel.xyz",
+    issuer: "https://keel.so",
+  });
 
   const guest = await actions.withIdentity(identity).inviteGuest({
     firstName: "Keelson",
@@ -366,7 +387,10 @@ test("hook function - audit table populated", async () => {
 });
 
 test("write function with identity - audit table populated", async () => {
-  const identity = await models.identity.create({ email: "keelson@keel.xyz" });
+  const identity = await models.identity.create({
+    email: "keelson@keel.xyz",
+    issuer: "https://keel.so",
+  });
 
   const wedding = await actions.createWedding({
     name: "Mary & Bob",
@@ -413,7 +437,10 @@ test("write function with identity - audit table populated", async () => {
 });
 
 test("write function with error and rollback - model and audit table empty", async () => {
-  const identity = await models.identity.create({ email: "keelson@keel.xyz" });
+  const identity = await models.identity.create({
+    email: "keelson@keel.xyz",
+    issuer: "https://keel.so",
+  });
 
   const wedding = await actions.createWedding({
     name: "Mary & Bob",
@@ -439,7 +466,10 @@ test("write function with error and rollback - model and audit table empty", asy
 });
 
 test("job function with identity - audit table populated", async () => {
-  const identity = await models.identity.create({ email: "keelson@keel.xyz" });
+  const identity = await models.identity.create({
+    email: "keelson@keel.xyz",
+    issuer: "https://keel.so",
+  });
 
   const wedding = await actions.createWedding({
     name: "Mary & Bob",
@@ -529,7 +559,10 @@ test("job function with identity - audit table populated", async () => {
 });
 
 test("job function with error and no rollback - audit table is not rolled back", async () => {
-  const identity = await models.identity.create({ email: "keelson@keel.xyz" });
+  const identity = await models.identity.create({
+    email: "keelson@keel.xyz",
+    issuer: "https://keel.so",
+  });
 
   const wedding = await actions.createWedding({
     name: "Mary & Bob",
@@ -621,7 +654,10 @@ test("job function with error and no rollback - audit table is not rolled back",
 });
 
 test("job function using kysely with identity - audit table populated", async () => {
-  const identity = await models.identity.create({ email: "keelson@keel.xyz" });
+  const identity = await models.identity.create({
+    email: "keelson@keel.xyz",
+    issuer: "https://keel.so",
+  });
 
   const wedding = await actions.createWedding({
     name: "Mary & Bob",
@@ -715,11 +751,12 @@ test("job function using kysely with identity - audit table populated", async ()
 test("identity model - audit table populated", async () => {
   await models.identity.create({
     email: "user@keel.xyz",
-    password: "1234",
+    issuer: "https://keel.so",
   });
 
   const identity = await models.identity.findOne({
     email: "user@keel.xyz",
+    issuer: "https://keel.so",
   });
 
   expect(identity).not.toBeNull();

--- a/integration/testdata/events_basic/subscribers/verifyUpdate.ts
+++ b/integration/testdata/events_basic/subscribers/verifyUpdate.ts
@@ -5,7 +5,7 @@ export default VerifyUpdate(async (ctx: SubscriberContextAPI, event) => {
     throw new Error("name cannot be empty");
   }
 
-  if (event.target.previous == null) {
+  if (event.target.previousData == null) {
     throw new Error("previous data cannot be null");
   }
 

--- a/integration/testdata/permissions_delete_operation/tests.test.ts
+++ b/integration/testdata/permissions_delete_operation/tests.test.ts
@@ -289,7 +289,7 @@ test("identity permission - incorrect identity in context - is not authorized", 
 
 test("identity permission - no identity in context - is not authorized", async () => {
   const identity = await models.identity.create({
-    email: "user@keel.xyz",
+    email: "user3@keel.xyz",
     issuer: "https://keel.so",
   });
 

--- a/integration/testdata/permissions_get_operation/tests.test.ts
+++ b/integration/testdata/permissions_get_operation/tests.test.ts
@@ -195,7 +195,7 @@ test("identity permission - correct identity in context - is authorized", async 
   const post = await actions.withIdentity(identity).createWithIdentity({});
 
   const p = await actions
-    .withAuthToken(identity)
+    .withIdentity(identity)
     .getWithIdentityPermission({ id: post.id });
   expect(p!.id).toEqual(post.id);
 });
@@ -220,7 +220,7 @@ test("identity permission - incorrect identity in context - is not authorized", 
 
 test("identity permission - no identity in context - is not authorized", async () => {
   const identity = await models.identity.create({
-    email: "user@keel.xyz",
+    email: "user4@keel.xyz",
     issuer: "https://keel.so",
   });
 

--- a/integration/testdata/permissions_list_operation/tests.test.ts
+++ b/integration/testdata/permissions_list_operation/tests.test.ts
@@ -357,18 +357,9 @@ test("identity permission - correct identity in context - is authorized", async 
 
   await actions.withIdentity(identity1).createWithIdentity({});
 
-  await actions.withIdentity(identity1).createWithIdentity({});
-
-  const identity2 = await models.identity.create({
-    email: "anotheruser@keel.xyz",
-    issuer: "https://keel.so",
-  });
-
-  await actions.withIdentity(identity2).createWithIdentity({ isActive: false });
-
   await expect(
     actions
-      .withIdentity(identity2)
+      .withIdentity(identity1)
       .listWithIdentityPermission({ where: { isActive: { equals: true } } })
   ).not.toHaveAuthorizationError();
 });

--- a/integration/testdata/set_backlinks/tests.test.ts
+++ b/integration/testdata/set_backlinks/tests.test.ts
@@ -30,7 +30,7 @@ test("create - @set with backlinks and 1:M nested create", async () => {
     isActive: true,
   });
   const identity = await models.identity.create({ email: "keelson@keel.so" });
-  
+
   const user = await models.user.create({
     name: "Keelson",
     identityId: identity.id,

--- a/integration/testdata/set_backlinks/tests.test.ts
+++ b/integration/testdata/set_backlinks/tests.test.ts
@@ -30,7 +30,7 @@ test("create - @set with backlinks and 1:M nested create", async () => {
     isActive: true,
   });
   const identity = await models.identity.create({ email: "keelson@keel.so" });
-  console.log(identity);
+  
   const user = await models.user.create({
     name: "Keelson",
     identityId: identity.id,

--- a/runtime/actions/delete.go
+++ b/runtime/actions/delete.go
@@ -28,9 +28,19 @@ func Delete(scope *Scope, input map[string]any) (res *string, err error) {
 	case canResolveEarly && !authorised:
 		return nil, common.NewPermissionError()
 	case !canResolveEarly:
-		query.AppendSelect(IdField())
-		query.AppendDistinctOn(IdField())
-		rows, err := query.SelectStatement().ExecuteToSingle(scope.Context)
+		authQuery := NewQuery(scope.Model)
+		err := authQuery.applyImplicitFilters(scope, input)
+		if err != nil {
+			return nil, err
+		}
+
+		err = authQuery.applyExplicitFilters(scope, input)
+		if err != nil {
+			return nil, err
+		}
+		authQuery.AppendSelect(IdField())
+		authQuery.AppendDistinctOn(IdField())
+		rows, err := authQuery.SelectStatement().ExecuteToSingle(scope.Context)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
* Re-enabling the complete integration test suite. 
* Fixing a few typos in some integration tests.
* Fixing an issue which caused unexpected errors for `delete` actions that would require row based permission checks.