### PR TITLE
feat: array any and all queries

### DIFF
--- a/integration/testdata/arrays/tests.test.ts
+++ b/integration/testdata/arrays/tests.test.ts
@@ -379,7 +379,7 @@ test("array fields - list action implicit querying - text", async () => {
     where: {
       texts: {
         any: {
-          equals: "Weave"
+          equals: "Weave",
         },
       },
     },
@@ -395,7 +395,7 @@ test("array fields - list action implicit querying - text", async () => {
     where: {
       texts: {
         all: {
-          equals: "Keelson"
+          equals: "Keelson",
         },
       },
     },
@@ -409,7 +409,7 @@ test("array fields - list action implicit querying - text", async () => {
       texts: {
         any: {
           equals: "Keelson",
-          notEquals: "Weave"
+          notEquals: "Weave",
         },
       },
     },
@@ -422,7 +422,7 @@ test("array fields - list action implicit querying - text", async () => {
     where: {
       texts: {
         any: {
-          notEquals: "Weave"
+          notEquals: "Weave",
         },
       },
     },
@@ -437,12 +437,12 @@ test("array fields - list action implicit querying - text", async () => {
     where: {
       texts: {
         all: {
-          notEquals: "Keelson"
+          notEquals: "Keelson",
         },
       },
     },
   });
-console.log(things11.results);
+  console.log(things11.results);
   expect(things11.results).toHaveLength(6);
   expect(things11.results[0].id).toEqual(t1.id);
   expect(things11.results[1].id).toEqual(t2.id);
@@ -450,7 +450,6 @@ console.log(things11.results);
   expect(things11.results[3].id).toEqual(t4.id);
   expect(things11.results[4].id).toEqual(t5.id);
   expect(things11.results[5].id).toEqual(t6.id);
-
 });
 
 test("array fields - list action implicit querying - number", async () => {
@@ -744,5 +743,3 @@ test("array fields - model api - create", async () => {
   ]);
   expect(thing?.enums).toEqual([MyEnum.One, MyEnum.Two, MyEnum.Three]);
 });
-
-

--- a/integration/testdata/arrays/tests.test.ts
+++ b/integration/testdata/arrays/tests.test.ts
@@ -290,6 +290,10 @@ test("array fields - list action implicit querying - text", async () => {
     texts: ["Weave", "Keel"],
   });
 
+  const t7 = await actions.createThing({
+    texts: ["Keelson", "Keelson"],
+  });
+
   const things1 = await actions.listThings({
     where: {
       texts: {
@@ -310,11 +314,12 @@ test("array fields - list action implicit querying - text", async () => {
     },
   });
 
-  expect(things2.results).toHaveLength(4);
+  expect(things2.results).toHaveLength(5);
   expect(things2.results[0].id).toEqual(t2.id);
   expect(things2.results[1].id).toEqual(t4.id);
   expect(things2.results[2].id).toEqual(t5.id);
   expect(things2.results[3].id).toEqual(t6.id);
+  expect(things2.results[4].id).toEqual(t7.id);
 
   const things3 = await actions.listThings({
     where: {
@@ -335,12 +340,13 @@ test("array fields - list action implicit querying - text", async () => {
     },
   });
 
-  expect(things4.results).toHaveLength(5);
+  expect(things4.results).toHaveLength(6);
   expect(things4.results[0].id).toEqual(t1.id);
   expect(things4.results[1].id).toEqual(t2.id);
   expect(things4.results[2].id).toEqual(t3.id);
   expect(things4.results[3].id).toEqual(t5.id);
   expect(things4.results[4].id).toEqual(t6.id);
+  expect(things4.results[5].id).toEqual(t7.id);
 
   const things5 = await actions.listThings({
     where: {
@@ -361,12 +367,90 @@ test("array fields - list action implicit querying - text", async () => {
     },
   });
 
-  expect(things6.results).toHaveLength(5);
+  expect(things6.results).toHaveLength(6);
   expect(things6.results[0].id).toEqual(t1.id);
   expect(things6.results[1].id).toEqual(t2.id);
   expect(things6.results[2].id).toEqual(t3.id);
   expect(things6.results[3].id).toEqual(t4.id);
   expect(things6.results[4].id).toEqual(t6.id);
+  expect(things6.results[5].id).toEqual(t7.id);
+
+  const things7 = await actions.listThings({
+    where: {
+      texts: {
+        any: {
+          equals: "Weave"
+        },
+      },
+    },
+  });
+
+  expect(things7.results).toHaveLength(4);
+  expect(things7.results[0].id).toEqual(t1.id);
+  expect(things7.results[1].id).toEqual(t2.id);
+  expect(things7.results[2].id).toEqual(t3.id);
+  expect(things7.results[3].id).toEqual(t6.id);
+
+  const things8 = await actions.listThings({
+    where: {
+      texts: {
+        all: {
+          equals: "Keelson"
+        },
+      },
+    },
+  });
+
+  expect(things8.results).toHaveLength(1);
+  expect(things8.results[0].id).toEqual(t7.id);
+
+  const things9 = await actions.listThings({
+    where: {
+      texts: {
+        any: {
+          equals: "Keelson",
+          notEquals: "Weave"
+        },
+      },
+    },
+  });
+
+  expect(things9.results).toHaveLength(1);
+  expect(things9.results[0].id).toEqual(t7.id);
+
+  const things10 = await actions.listThings({
+    where: {
+      texts: {
+        any: {
+          notEquals: "Weave"
+        },
+      },
+    },
+  });
+
+  expect(things10.results).toHaveLength(3);
+  expect(things10.results[0].id).toEqual(t4.id);
+  expect(things10.results[1].id).toEqual(t5.id);
+  expect(things10.results[2].id).toEqual(t7.id);
+
+  const things11 = await actions.listThings({
+    where: {
+      texts: {
+        all: {
+          notEquals: "Keelson"
+        },
+      },
+    },
+  });
+console.log(things11.results);
+  expect(things11.results).toHaveLength(6);
+  expect(things11.results[0].id).toEqual(t1.id);
+  expect(things11.results[1].id).toEqual(t2.id);
+  expect(things11.results[2].id).toEqual(t3.id);
+  expect(things11.results[3].id).toEqual(t4.id);
+  expect(things11.results[4].id).toEqual(t5.id);
+  expect(things11.results[5].id).toEqual(t6.id);
+
 });
 
 test("array fields - list action implicit querying - number", async () => {
@@ -496,51 +580,6 @@ test("array fields - list action implicit querying - timestamp", async () => {
         equals: [
           new Date(2024, 1, 1, 30, 45, 50, 0),
           new Date(2024, 1, 2, 59, 0, 0, 0),
-        ],
-      },
-    },
-  });
-
-  expect(things.results).toHaveLength(2);
-  expect(things.results[0].id).toEqual(t1.id);
-  expect(things.results[1].id).toEqual(t3.id);
-});
-
-test("array fields - list action implicit querying - date", async () => {
-  const t1 = await actions.createThing({
-    dates: [new Date(2024, 1, 1, 0, 0, 0, 0), new Date(2024, 1, 2, 0, 0, 0, 0)],
-  });
-
-  const t2 = await actions.createThing({
-    dates: [
-      new Date(2024, 1, 1, 0, 0, 0, 0),
-      new Date(2024, 1, 2, 0, 0, 0, 0),
-      new Date(2024, 1, 3, 0, 0, 0, 0),
-    ],
-  });
-
-  const t3 = await actions.createThing({
-    dates: [new Date(2024, 1, 1, 0, 0, 0, 0), new Date(2024, 1, 2, 0, 0, 0, 0)],
-  });
-
-  const t4 = await actions.createThing({
-    dates: null,
-  });
-
-  const t5 = await actions.createThing({
-    dates: [],
-  });
-
-  const t6 = await actions.createThing({
-    dates: [new Date(2024, 1, 2, 0, 0, 0, 0), new Date(2024, 1, 1, 0, 0, 0, 0)],
-  });
-
-  const things = await actions.listThings({
-    where: {
-      dates: {
-        equals: [
-          new Date(2024, 1, 1, 0, 0, 0, 0),
-          new Date(2024, 1, 2, 0, 0, 0, 0),
         ],
       },
     },
@@ -705,3 +744,5 @@ test("array fields - model api - create", async () => {
   ]);
   expect(thing?.enums).toEqual([MyEnum.One, MyEnum.Two, MyEnum.Three]);
 });
+
+

--- a/node/codegen_test.go
+++ b/node/codegen_test.go
@@ -1095,6 +1095,76 @@ export interface ListBooksInput {
 	})
 }
 
+func TestWriteActionArrayInputTypesListAction(t *testing.T) {
+	schema := `
+enum Sport {
+	Football
+	Tennis
+}
+model Person {
+	fields {
+		favouriteNumbers Number[]
+		favouriteSports Sport[]
+	}
+	actions {
+		list listPeople(favouriteNumbers, favouriteSports)
+	}
+}
+	`
+	expected :=
+		`export interface IntArrayAllQueryInput {
+	equals?: number;
+	notEquals?: number;
+	lessThan?: number;
+	lessThanOrEquals?: number;
+	greaterThan?: number;
+	greaterThanOrEquals?: number;
+}
+export interface IntArrayAnyQueryInput {
+	equals?: number;
+	notEquals?: number;
+	lessThan?: number;
+	lessThanOrEquals?: number;
+	greaterThan?: number;
+	greaterThanOrEquals?: number;
+}
+export interface IntArrayQueryInput {
+	equals?: number[] | null;
+	notEquals?: number[] | null;
+	any?: IntArrayAnyQueryInput;
+	all?: IntArrayAllQueryInput;
+}
+export interface SportArrayAllQueryInput {
+	equals?: Sport;
+	notEquals?: Sport;
+}
+export interface SportArrayAnyQueryInput {
+	equals?: Sport;
+	notEquals?: Sport;
+}
+export interface SportArrayQueryInput {
+	equals?: Sport[] | null;
+	notEquals?: Sport[] | null;
+	any?: SportArrayAnyQueryInput;
+	all?: SportArrayAllQueryInput;
+}
+export interface ListPeopleWhere {
+	favouriteNumbers: IntArrayQueryInput;
+	favouriteSports: SportArrayQueryInput;
+}
+export interface ListPeopleInput {
+	where: ListPeopleWhere;
+	first?: number;
+	after?: string;
+	last?: number;
+	before?: string;
+}`
+
+	runWriterTest(t, schema, expected, func(s *proto.Schema, w *codegen.Writer) {
+		writeMessages(w, s, false)
+	})
+}
+
 func TestWriteActionInputTypesListSortable(t *testing.T) {
 	schema := `
 enum Sport {

--- a/runtime/actions/operator.go
+++ b/runtime/actions/operator.go
@@ -20,28 +20,49 @@ type ActionOperator int
 const (
 	Unknown ActionOperator = iota
 
-	After
-	Before
 	Contains
+	NotContains
 	Equals
+	NotEquals
+	StartsWith
 	EndsWith
 	GreaterThan
 	GreaterThanEquals
 	LessThan
 	LessThanEquals
-	NotContains
-	NotEquals
-	NotOneOf
 	OneOf
+	NotOneOf
+	After
+	Before
 	OnOrAfter
 	OnOrBefore
-	StartsWith
+
+	AllEquals
+	AnyEquals
+	AllNotEquals
+	AnyNotEquals
+	AllGreaterThan
+	AnyGreaterThan
+	AllGreaterThanEquals
+	AnyGreaterThanEquals
+	AllLessThan
+	AnyLessThan
+	AllLessThanEquals
+	AnyLessThanEquals
+	AllAfter
+	AnyAfter
+	AllBefore
+	AnyBefore
+	AllOnOrAfter
+	AnyOnOrAfter
+	AllOnOrBefore
+	AnyOnOrBefore
 )
 
-// graphQlOperatorToActionOperator converts the conditional operators that are used
+// queryOperatorToActionOperator converts the conditional operators that are used
 // in GraphQL request input structures (such as "lessThanOrEquals") to its symbolic constant,
 // machine-readable, ActionOperator value.
-func graphQlOperatorToActionOperator(in string) (out ActionOperator, err error) {
+func queryOperatorToActionOperator(in string) (out ActionOperator, err error) {
 	switch in {
 	case "equals":
 		return Equals, nil
@@ -73,6 +94,60 @@ func graphQlOperatorToActionOperator(in string) (out ActionOperator, err error) 
 		return OnOrAfter, nil
 	default:
 		return out, fmt.Errorf("unrecognized operator: %s", in)
+	}
+}
+
+func anyQueryOperationToActionOperator(in string) (out ActionOperator, err error) {
+	switch in {
+	case "equals":
+		return AnyEquals, nil
+	case "notEquals":
+		return AnyNotEquals, nil
+	case "lessThan":
+		return AnyLessThan, nil
+	case "lessThanOrEquals":
+		return AnyLessThanEquals, nil
+	case "greaterThan":
+		return AnyGreaterThan, nil
+	case "greaterThanOrEquals":
+		return AnyGreaterThanEquals, nil
+	case "before":
+		return AnyBefore, nil
+	case "after":
+		return AnyAfter, nil
+	case "onOrBefore":
+		return AnyOnOrBefore, nil
+	case "onOrAfter":
+		return AnyOnOrAfter, nil
+	default:
+		return out, fmt.Errorf("unrecognized operator for any query: %s", in)
+	}
+}
+
+func allQueryOperatorToActionOperator(in string) (out ActionOperator, err error) {
+	switch in {
+	case "equals":
+		return AllEquals, nil
+	case "notEquals":
+		return AllNotEquals, nil
+	case "lessThan":
+		return AllLessThan, nil
+	case "lessThanOrEquals":
+		return AllLessThanEquals, nil
+	case "greaterThan":
+		return AllGreaterThan, nil
+	case "greaterThanOrEquals":
+		return AllGreaterThanEquals, nil
+	case "before":
+		return AllBefore, nil
+	case "after":
+		return AllAfter, nil
+	case "onOrBefore":
+		return AllOnOrBefore, nil
+	case "onOrAfter":
+		return AllOnOrAfter, nil
+	default:
+		return out, fmt.Errorf("unrecognized operator for all query: %s", in)
 	}
 }
 

--- a/runtime/actions/query.go
+++ b/runtime/actions/query.go
@@ -1331,27 +1331,48 @@ func (query *QueryBuilder) generateConditionTemplate(lhs *QueryOperand, operator
 			template = fmt.Sprintf("%s NOT IN %s", lhsSqlOperand, rhsSqlOperand)
 		} else {
 			if rhs.IsField() {
-				template = fmt.Sprintf("(NOT %[1]s = ANY(%[2]s) OR %[2]s IS NOT DISTINCT FROM NULL)", lhsSqlOperand, rhsSqlOperand)
+				template = fmt.Sprintf("(NOT %s = ANY(%s) OR %s IS NOT DISTINCT FROM NULL)", lhsSqlOperand, rhsSqlOperand, rhsSqlOperand)
 			} else {
 				template = fmt.Sprintf("NOT %s = ANY(%s)", lhsSqlOperand, rhsSqlOperand)
 			}
 		}
-	case LessThan:
+	case LessThan, Before:
 		template = fmt.Sprintf("%s < %s", lhsSqlOperand, rhsSqlOperand)
-	case LessThanEquals:
+	case LessThanEquals, OnOrBefore:
 		template = fmt.Sprintf("%s <= %s", lhsSqlOperand, rhsSqlOperand)
-	case GreaterThan:
+	case GreaterThan, After:
 		template = fmt.Sprintf("%s > %s", lhsSqlOperand, rhsSqlOperand)
-	case GreaterThanEquals:
+	case GreaterThanEquals, OnOrAfter:
 		template = fmt.Sprintf("%s >= %s", lhsSqlOperand, rhsSqlOperand)
-	case Before:
-		template = fmt.Sprintf("%s < %s", lhsSqlOperand, rhsSqlOperand)
-	case After:
-		template = fmt.Sprintf("%s > %s", lhsSqlOperand, rhsSqlOperand)
-	case OnOrBefore:
-		template = fmt.Sprintf("%s <= %s", lhsSqlOperand, rhsSqlOperand)
-	case OnOrAfter:
-		template = fmt.Sprintf("%s >= %s", lhsSqlOperand, rhsSqlOperand)
+
+	/* Any query operators */
+	case AnyEquals:
+		template = fmt.Sprintf("%s = ANY(%s)", rhsSqlOperand, lhsSqlOperand)
+	case AnyNotEquals:
+		template = fmt.Sprintf("(NOT %s = ANY(%s) OR %s IS NOT DISTINCT FROM NULL)", rhsSqlOperand, lhsSqlOperand, lhsSqlOperand)
+	case AnyLessThan, AnyBefore:
+		template = fmt.Sprintf("%s > ANY(%s)", rhsSqlOperand, lhsSqlOperand)
+	case AnyLessThanEquals, AnyOnOrBefore:
+		template = fmt.Sprintf("%s >= ANY(%s)", rhsSqlOperand, lhsSqlOperand)
+	case AnyGreaterThan, AnyAfter:
+		template = fmt.Sprintf("%s < ANY(%s)", rhsSqlOperand, lhsSqlOperand)
+	case AnyGreaterThanEquals, AnyOnOrAfter:
+		template = fmt.Sprintf("%s <= ANY(%s)", rhsSqlOperand, lhsSqlOperand)
+
+	/* All query operators */
+	case AllEquals:
+		template = fmt.Sprintf("(%s = ALL(%s) AND %s IS DISTINCT FROM '{}')", rhsSqlOperand, lhsSqlOperand, lhsSqlOperand)
+	case AllNotEquals:
+		template = fmt.Sprintf("(NOT %s = ALL(%s) OR %s IS NOT DISTINCT FROM '{}' OR %s IS NOT DISTINCT FROM NULL)", rhsSqlOperand, lhsSqlOperand, lhsSqlOperand, lhsSqlOperand)
+	case AllLessThan, AllBefore:
+		template = fmt.Sprintf("%s > ALL(%s)", rhsSqlOperand, lhsSqlOperand)
+	case AllLessThanEquals, AllOnOrBefore:
+		template = fmt.Sprintf("%s >= ALL(%s)", rhsSqlOperand, lhsSqlOperand)
+	case AllGreaterThan, AllAfter:
+		template = fmt.Sprintf("%s < ALL(%s)", rhsSqlOperand, lhsSqlOperand)
+	case AllGreaterThanEquals, AllOnOrAfter:
+		template = fmt.Sprintf("%s <= ALL(%s)", rhsSqlOperand, lhsSqlOperand)
+
 	default:
 		return "", nil, fmt.Errorf("operator: %v is not yet supported", operator)
 	}

--- a/runtime/actions/query_test.go
+++ b/runtime/actions/query_test.go
@@ -2980,6 +2980,126 @@ var testCases = []testCase{
 		expectedArgs: []any{"science", "science", 50},
 	},
 	{
+		name: "list_array_implicit_any_equals",
+		keelSchema: `
+		model Post {
+			fields {
+				tags Text[]
+			}
+			actions {
+				list listPosts(tags)
+			}
+		}`,
+		actionName: "listPosts",
+		input:      map[string]any{"where": map[string]any{"tags": map[string]any{"any": map[string]any{"equals": "science"}}}},
+		expectedTemplate: `
+			SELECT
+				DISTINCT ON("post"."id") "post".*, 
+				CASE WHEN LEAD("post"."id") OVER (ORDER BY "post"."id" ASC) IS NOT NULL THEN true ELSE false END AS hasNext, 
+				(SELECT COUNT(DISTINCT "post"."id") FROM "post" WHERE ? = ANY("post"."tags")) AS totalCount 	
+			FROM "post" 
+			WHERE ? = ANY("post"."tags")
+			ORDER BY "post"."id" ASC 
+			LIMIT ?`,
+		expectedArgs: []any{"science", "science", 50},
+	},
+	{
+		name: "list_array_implicit_all_equals",
+		keelSchema: `
+		model Post {
+			fields {
+				tags Text[]
+			}
+			actions {
+				list listPosts(tags)
+			}
+		}`,
+		actionName: "listPosts",
+		input:      map[string]any{"where": map[string]any{"tags": map[string]any{"all": map[string]any{"equals": "science"}}}},
+		expectedTemplate: `
+			SELECT
+				DISTINCT ON("post"."id") "post".*, 
+				CASE WHEN LEAD("post"."id") OVER (ORDER BY "post"."id" ASC) IS NOT NULL THEN true ELSE false END AS hasNext, 
+				(SELECT COUNT(DISTINCT "post"."id") FROM "post" WHERE (? = ALL("post"."tags") AND "post"."tags" IS DISTINCT FROM '{}')) AS totalCount 	
+			FROM "post" 
+			WHERE (? = ALL("post"."tags") AND "post"."tags" IS DISTINCT FROM '{}')
+			ORDER BY "post"."id" ASC 
+			LIMIT ?`,
+		expectedArgs: []any{"science", "science", 50},
+	},
+	{
+		name: "list_array_implicit_all_less_than",
+		keelSchema: `
+		model Post {
+			fields {
+				votes Number[]
+			}
+			actions {
+				list listPosts(votes)
+			}
+		}`,
+		actionName: "listPosts",
+		input:      map[string]any{"where": map[string]any{"votes": map[string]any{"all": map[string]any{"lessThan": 5}}}},
+		expectedTemplate: `
+			SELECT
+				DISTINCT ON("post"."id") "post".*, 
+				CASE WHEN LEAD("post"."id") OVER (ORDER BY "post"."id" ASC) IS NOT NULL THEN true ELSE false END AS hasNext, 
+				(SELECT COUNT(DISTINCT "post"."id") FROM "post" WHERE ? > ALL("post"."votes")) AS totalCount 	
+			FROM "post" 
+			WHERE ? > ALL("post"."votes")
+			ORDER BY "post"."id" ASC 
+			LIMIT ?`,
+		expectedArgs: []any{5, 5, 50},
+	},
+	{
+		name: "list_array_implicit_any_less_than",
+		keelSchema: `
+		model Post {
+			fields {
+				votes Number[]
+			}
+			actions {
+				list listPosts(votes)
+			}
+		}`,
+		actionName: "listPosts",
+		input:      map[string]any{"where": map[string]any{"votes": map[string]any{"any": map[string]any{"lessThan": 5}}}},
+		expectedTemplate: `
+			SELECT
+				DISTINCT ON("post"."id") "post".*, 
+				CASE WHEN LEAD("post"."id") OVER (ORDER BY "post"."id" ASC) IS NOT NULL THEN true ELSE false END AS hasNext, 
+				(SELECT COUNT(DISTINCT "post"."id") FROM "post" WHERE ? > ANY("post"."votes")) AS totalCount 	
+			FROM "post" 
+			WHERE ? > ANY("post"."votes")
+			ORDER BY "post"."id" ASC 
+			LIMIT ?`,
+		expectedArgs: []any{5, 5, 50},
+	},
+	{
+		name: "list_array_implicit_all_after",
+		keelSchema: `
+		model Post {
+			fields {
+				editedAt Timestamp[]
+			}
+			actions {
+				list listPosts(editedAt)
+			}
+		}`,
+		actionName: "listPosts",
+		input:      map[string]any{"where": map[string]any{"editedAt": map[string]any{"all": map[string]any{"after": "2024-01-01T00:12:00Z"}}}},
+		expectedTemplate: `
+			SELECT
+				DISTINCT ON("post"."id") "post".*, 
+				CASE WHEN LEAD("post"."id") OVER (ORDER BY "post"."id" ASC) IS NOT NULL THEN true ELSE false END AS hasNext, 
+				(SELECT COUNT(DISTINCT "post"."id") FROM "post" WHERE ? < ALL("post"."edited_at")) AS totalCount 	
+			FROM "post" 
+			WHERE ? < ALL("post"."edited_at")
+			ORDER BY "post"."id" ASC 
+			LIMIT ?`,
+		expectedArgs: []any{"2024-01-01T00:12:00Z", "2024-01-01T00:12:00Z", 50},
+	},
+	{
 		name: "list_array_expression_in",
 		keelSchema: `
 			model Post {

--- a/runtime/apis/graphql/testdata/graphql/arrays.graphql
+++ b/runtime/apis/graphql/testdata/graphql/arrays.graphql
@@ -3,22 +3,86 @@ type Query {
   things(input: ThingsInput!): ThingConnection!
 }
 
+input DateArrayAllQueryInput {
+  after: ISO8601
+  before: ISO8601
+  equals: ISO8601
+  notEquals: ISO8601
+  onOrAfter: ISO8601
+  onOrBefore: ISO8601
+}
+
+input DateArrayAnyQueryInput {
+  after: ISO8601
+  before: ISO8601
+  equals: ISO8601
+  notEquals: ISO8601
+  onOrAfter: ISO8601
+  onOrBefore: ISO8601
+}
+
 input DateArrayQueryInput {
+  all: DateArrayAllQueryInput
+  any: DateArrayAnyQueryInput
   equals: [ISO8601]
   notEquals: [ISO8601]
 }
 
+input IntArrayAllQueryInput {
+  equals: Int
+  greaterThan: Int
+  greaterThanOrEquals: Int
+  lessThan: Int
+  lessThanOrEquals: Int
+  notEquals: Int
+}
+
+input IntArrayAnyQueryInput {
+  equals: Int
+  greaterThan: Int
+  greaterThanOrEquals: Int
+  lessThan: Int
+  lessThanOrEquals: Int
+  notEquals: Int
+}
+
 input IntArrayQueryInput {
+  all: IntArrayAllQueryInput
+  any: IntArrayAnyQueryInput
   equals: [Int]
   notEquals: [Int]
 }
 
+input MyEnumArrayAllQueryInput {
+  equals: MyEnum
+  notEquals: MyEnum
+}
+
+input MyEnumArrayAnyQueryInput {
+  equals: MyEnum
+  notEquals: MyEnum
+}
+
 input MyEnumArrayQueryInput {
+  all: MyEnumArrayAllQueryInput
+  any: MyEnumArrayAnyQueryInput
   equals: [MyEnum]
   notEquals: [MyEnum]
 }
 
+input StringArrayAllQueryInput {
+  equals: String
+  notEquals: String
+}
+
+input StringArrayAnyQueryInput {
+  equals: String
+  notEquals: String
+}
+
 input StringArrayQueryInput {
+  all: StringArrayAllQueryInput
+  any: StringArrayAnyQueryInput
   equals: [String]
   notEquals: [String]
 }

--- a/runtime/openapi/testdata/arrays.json
+++ b/runtime/openapi/testdata/arrays.json
@@ -80,9 +80,35 @@
   },
   "components": {
     "schemas": {
+      "DateArrayAllQueryInput": {
+        "type": "object",
+        "properties": {
+          "after": { "type": "string", "format": "date" },
+          "before": { "type": "string", "format": "date" },
+          "equals": { "type": "string", "format": "date" },
+          "notEquals": { "type": "string", "format": "date" },
+          "onOrAfter": { "type": "string", "format": "date" },
+          "onOrBefore": { "type": "string", "format": "date" }
+        },
+        "additionalProperties": false
+      },
+      "DateArrayAnyQueryInput": {
+        "type": "object",
+        "properties": {
+          "after": { "type": "string", "format": "date" },
+          "before": { "type": "string", "format": "date" },
+          "equals": { "type": "string", "format": "date" },
+          "notEquals": { "type": "string", "format": "date" },
+          "onOrAfter": { "type": "string", "format": "date" },
+          "onOrBefore": { "type": "string", "format": "date" }
+        },
+        "additionalProperties": false
+      },
       "DateArrayQueryInput": {
         "type": "object",
         "properties": {
+          "all": { "$ref": "#/components/schemas/DateArrayAllQueryInput" },
+          "any": { "$ref": "#/components/schemas/DateArrayAnyQueryInput" },
           "equals": {
             "type": ["array", "null"],
             "items": { "type": "string", "format": "date" }
@@ -91,12 +117,38 @@
             "type": ["array", "null"],
             "items": { "type": "string", "format": "date" }
           }
+        },
+        "additionalProperties": false
+      },
+      "IntArrayAllQueryInput": {
+        "type": "object",
+        "properties": {
+          "equals": { "type": "number" },
+          "greaterThan": { "type": "number" },
+          "greaterThanOrEquals": { "type": "number" },
+          "lessThan": { "type": "number" },
+          "lessThanOrEquals": { "type": "number" },
+          "notEquals": { "type": "number" }
+        },
+        "additionalProperties": false
+      },
+      "IntArrayAnyQueryInput": {
+        "type": "object",
+        "properties": {
+          "equals": { "type": "number" },
+          "greaterThan": { "type": "number" },
+          "greaterThanOrEquals": { "type": "number" },
+          "lessThan": { "type": "number" },
+          "lessThanOrEquals": { "type": "number" },
+          "notEquals": { "type": "number" }
         },
         "additionalProperties": false
       },
       "IntArrayQueryInput": {
         "type": "object",
         "properties": {
+          "all": { "$ref": "#/components/schemas/IntArrayAllQueryInput" },
+          "any": { "$ref": "#/components/schemas/IntArrayAnyQueryInput" },
           "equals": {
             "type": ["array", "null"],
             "items": { "type": "number" }
@@ -105,12 +157,30 @@
             "type": ["array", "null"],
             "items": { "type": "number" }
           }
+        },
+        "additionalProperties": false
+      },
+      "MyEnumArrayAllQueryInput": {
+        "type": "object",
+        "properties": {
+          "equals": { "enum": ["One", "Two", "Three"] },
+          "notEquals": { "enum": ["One", "Two", "Three"] }
+        },
+        "additionalProperties": false
+      },
+      "MyEnumArrayAnyQueryInput": {
+        "type": "object",
+        "properties": {
+          "equals": { "enum": ["One", "Two", "Three"] },
+          "notEquals": { "enum": ["One", "Two", "Three"] }
         },
         "additionalProperties": false
       },
       "MyEnumArrayQueryInput": {
         "type": "object",
         "properties": {
+          "all": { "$ref": "#/components/schemas/MyEnumArrayAllQueryInput" },
+          "any": { "$ref": "#/components/schemas/MyEnumArrayAnyQueryInput" },
           "equals": {
             "type": ["array", "null"],
             "items": { "enum": ["One", "Two", "Three", null] }
@@ -122,9 +192,27 @@
         },
         "additionalProperties": false
       },
+      "StringArrayAllQueryInput": {
+        "type": "object",
+        "properties": {
+          "equals": { "type": "string" },
+          "notEquals": { "type": "string" }
+        },
+        "additionalProperties": false
+      },
+      "StringArrayAnyQueryInput": {
+        "type": "object",
+        "properties": {
+          "equals": { "type": "string" },
+          "notEquals": { "type": "string" }
+        },
+        "additionalProperties": false
+      },
       "StringArrayQueryInput": {
         "type": "object",
         "properties": {
+          "all": { "$ref": "#/components/schemas/StringArrayAllQueryInput" },
+          "any": { "$ref": "#/components/schemas/StringArrayAnyQueryInput" },
           "equals": {
             "type": ["array", "null"],
             "items": { "type": "string" }

--- a/schema/makeproto.go
+++ b/schema/makeproto.go
@@ -109,7 +109,485 @@ func defaultAPI(scm *proto.Schema) *proto.Api {
 	}
 }
 
-func makeListQueryInputMessage(typeInfo *proto.TypeInfo) (*proto.Message, error) {
+func makeIDQueryInputMessage(name string) *proto.Message {
+	return &proto.Message{Name: name, Fields: []*proto.MessageField{
+		{
+			MessageName: name,
+			Name:        "equals",
+			Optional:    true,
+			Nullable:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_ID,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "oneOf",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type:     proto.Type_TYPE_ID,
+				Repeated: true,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "notEquals",
+			Optional:    true,
+			Nullable:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_ID,
+			},
+		},
+	}}
+}
+
+func makeStringQueryInputMessage(name string) *proto.Message {
+	return &proto.Message{Name: name, Fields: []*proto.MessageField{
+		{
+			MessageName: name,
+			Name:        "equals",
+			Optional:    true,
+			Nullable:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_STRING,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "notEquals",
+			Optional:    true,
+			Nullable:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_STRING,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "startsWith",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_STRING,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "endsWith",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_STRING,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "contains",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_STRING,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "oneOf",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type:     proto.Type_TYPE_STRING,
+				Repeated: true,
+			},
+		},
+	}}
+}
+
+func makeStringArrayQueryInputMessage(name string) *proto.Message {
+	return &proto.Message{Name: name, Fields: []*proto.MessageField{
+		{
+			MessageName: name,
+			Name:        "equals",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_STRING,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "notEquals",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_STRING,
+			},
+		},
+	}}
+}
+
+func makeIntQueryInputMessage(name string) *proto.Message {
+	return &proto.Message{Name: name, Fields: []*proto.MessageField{
+		{
+			MessageName: name,
+			Name:        "equals",
+			Optional:    true,
+			Nullable:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_INT,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "notEquals",
+			Optional:    true,
+			Nullable:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_INT,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "lessThan",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_INT,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "lessThanOrEquals",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_INT,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "greaterThan",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_INT,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "greaterThanOrEquals",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_INT,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "oneOf",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type:     proto.Type_TYPE_INT,
+				Repeated: true,
+			},
+		},
+	}}
+}
+
+func makeIntArrayQueryInputMessage(name string) *proto.Message {
+	return &proto.Message{Name: name, Fields: []*proto.MessageField{
+		{
+			MessageName: name,
+			Name:        "equals",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_INT,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "notEquals",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_INT,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "lessThan",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_INT,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "lessThanOrEquals",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_INT,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "greaterThan",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_INT,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "greaterThanOrEquals",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_INT,
+			},
+		},
+	}}
+}
+
+func makeBooleanQueryInputMessage(name string) *proto.Message {
+	return &proto.Message{Name: name, Fields: []*proto.MessageField{
+		{
+			MessageName: name,
+			Name:        "equals",
+			Optional:    true,
+			Nullable:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_BOOL,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "notEquals",
+			Optional:    true,
+			Nullable:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_BOOL,
+			},
+		},
+	}}
+}
+
+func makeBooleanArrayQueryInputMessage(name string) *proto.Message {
+	return &proto.Message{Name: name, Fields: []*proto.MessageField{
+		{
+			MessageName: name,
+			Name:        "equals",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_BOOL,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "notEquals",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_BOOL,
+			},
+		},
+	}}
+}
+
+func makeDateQueryInputMessage(name string) *proto.Message {
+	return &proto.Message{Name: name, Fields: []*proto.MessageField{
+		{
+			MessageName: name,
+			Name:        "equals",
+			Optional:    true,
+			Nullable:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_DATE,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "notEquals",
+			Optional:    true,
+			Nullable:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_DATE,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "before",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_DATE,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "onOrBefore",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_DATE,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "after",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_DATE,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "onOrAfter",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_DATE,
+			},
+		},
+	}}
+}
+
+func makeDateArrayQueryInputMessage(name string) *proto.Message {
+	return &proto.Message{Name: name, Fields: []*proto.MessageField{
+		{
+			MessageName: name,
+			Name:        "equals",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_DATE,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "notEquals",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_DATE,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "before",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_DATE,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "onOrBefore",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_DATE,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "after",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_DATE,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "onOrAfter",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_DATE,
+			},
+		},
+	}}
+}
+
+func makeTimestampQueryInputMessage(name string) *proto.Message {
+	return &proto.Message{Name: name, Fields: []*proto.MessageField{
+		{
+			MessageName: name,
+			Name:        "before",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_TIMESTAMP,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "after",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_TIMESTAMP,
+			},
+		},
+	}}
+}
+
+func makeTimestampArrayQueryInputMessage(name string) *proto.Message {
+	return &proto.Message{Name: name, Fields: []*proto.MessageField{
+		{
+			MessageName: name,
+			Name:        "before",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_TIMESTAMP,
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "after",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type: proto.Type_TYPE_TIMESTAMP,
+			},
+		},
+	}}
+}
+
+func makeEnumQueryInputMessage(name string, enumName string) *proto.Message {
+	return &proto.Message{Name: name, Fields: []*proto.MessageField{
+		{
+			MessageName: name,
+			Name:        "equals",
+			Nullable:    true,
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type:     proto.Type_TYPE_ENUM,
+				EnumName: wrapperspb.String(enumName),
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "notEquals",
+			Optional:    true,
+			Nullable:    true,
+			Type: &proto.TypeInfo{
+				Type:     proto.Type_TYPE_ENUM,
+				EnumName: wrapperspb.String(enumName),
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "oneOf",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type:     proto.Type_TYPE_ENUM,
+				EnumName: wrapperspb.String(enumName),
+				Repeated: true,
+			},
+		},
+	}}
+}
+
+func makeEnumArrayQueryInputMessage(name string, enumName string) *proto.Message {
+	return &proto.Message{Name: name, Fields: []*proto.MessageField{
+		{
+			MessageName: name,
+			Name:        "equals",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type:     proto.Type_TYPE_ENUM,
+				EnumName: wrapperspb.String(enumName),
+			},
+		},
+		{
+			MessageName: name,
+			Name:        "notEquals",
+			Optional:    true,
+			Type: &proto.TypeInfo{
+				Type:     proto.Type_TYPE_ENUM,
+				EnumName: wrapperspb.String(enumName),
+			},
+		},
+	}}
+}
+
+func (scm *Builder) makeListQueryInputMessage(typeInfo *proto.TypeInfo) (*proto.Message, error) {
 	var prefix string
 	switch typeInfo.Type {
 	case proto.Type_TYPE_ID:
@@ -136,6 +614,40 @@ func makeListQueryInputMessage(typeInfo *proto.TypeInfo) (*proto.Message, error)
 			enumName = typeInfo.EnumName
 		}
 
+		var allQueryMsg *proto.Message
+		var anyQueryMsg *proto.Message
+
+		allQueryMsgName := makeInputMessageName(fmt.Sprintf("%sArrayAllQuery", prefix))
+		anyQueryMsgName := makeInputMessageName(fmt.Sprintf("%sArrayAnyQuery", prefix))
+
+		switch typeInfo.Type {
+		case proto.Type_TYPE_ID:
+
+		case proto.Type_TYPE_STRING:
+			allQueryMsg = makeStringArrayQueryInputMessage(allQueryMsgName)
+			anyQueryMsg = makeStringArrayQueryInputMessage(anyQueryMsgName)
+		case proto.Type_TYPE_INT:
+			allQueryMsg = makeIntArrayQueryInputMessage(allQueryMsgName)
+			anyQueryMsg = makeIntArrayQueryInputMessage(anyQueryMsgName)
+		case proto.Type_TYPE_BOOL:
+			allQueryMsg = makeBooleanArrayQueryInputMessage(allQueryMsgName)
+			anyQueryMsg = makeBooleanArrayQueryInputMessage(anyQueryMsgName)
+		case proto.Type_TYPE_DATE:
+			allQueryMsg = makeDateArrayQueryInputMessage(allQueryMsgName)
+			anyQueryMsg = makeDateArrayQueryInputMessage(anyQueryMsgName)
+		case proto.Type_TYPE_DATETIME, proto.Type_TYPE_TIMESTAMP:
+			allQueryMsg = makeTimestampArrayQueryInputMessage(allQueryMsgName)
+			anyQueryMsg = makeTimestampArrayQueryInputMessage(anyQueryMsgName)
+		case proto.Type_TYPE_ENUM:
+			allQueryMsg = makeEnumArrayQueryInputMessage(allQueryMsgName, typeInfo.EnumName.Value)
+			anyQueryMsg = makeEnumArrayQueryInputMessage(anyQueryMsgName, typeInfo.EnumName.Value)
+		default:
+			return nil, fmt.Errorf("unsupported array query type %s", typeInfo.Type.String())
+		}
+
+		scm.proto.Messages = append(scm.proto.Messages, allQueryMsg)
+		scm.proto.Messages = append(scm.proto.Messages, anyQueryMsg)
+
 		return &proto.Message{Name: msgName, Fields: []*proto.MessageField{
 			{
 				MessageName: msgName,
@@ -157,6 +669,24 @@ func makeListQueryInputMessage(typeInfo *proto.TypeInfo) (*proto.Message, error)
 					Type:     typeInfo.Type,
 					EnumName: enumName,
 					Repeated: true,
+				},
+			},
+			{
+				MessageName: msgName,
+				Name:        "any",
+				Optional:    true,
+				Type: &proto.TypeInfo{
+					Type:        proto.Type_TYPE_MESSAGE,
+					MessageName: wrapperspb.String(anyQueryMsgName),
+				},
+			},
+			{
+				MessageName: msgName,
+				Name:        "all",
+				Optional:    true,
+				Type: &proto.TypeInfo{
+					Type:        proto.Type_TYPE_MESSAGE,
+					MessageName: wrapperspb.String(allQueryMsgName),
 				},
 			},
 		}}, nil
@@ -166,277 +696,19 @@ func makeListQueryInputMessage(typeInfo *proto.TypeInfo) (*proto.Message, error)
 
 	switch typeInfo.Type {
 	case proto.Type_TYPE_ID:
-		return &proto.Message{Name: msgName, Fields: []*proto.MessageField{
-			{
-				MessageName: msgName,
-				Name:        "equals",
-				Optional:    true,
-				Nullable:    true,
-				Type: &proto.TypeInfo{
-					Type: typeInfo.Type,
-				},
-			},
-			{
-				MessageName: msgName,
-				Name:        "oneOf",
-				Optional:    true,
-				Type: &proto.TypeInfo{
-					Type:     typeInfo.Type,
-					Repeated: true,
-				},
-			},
-			{
-				MessageName: msgName,
-				Name:        "notEquals",
-				Optional:    true,
-				Nullable:    true,
-				Type: &proto.TypeInfo{
-					Type: typeInfo.Type,
-				},
-			},
-		}}, nil
+		return makeIDQueryInputMessage(msgName), nil
 	case proto.Type_TYPE_STRING:
-		return &proto.Message{Name: msgName, Fields: []*proto.MessageField{
-			{
-				MessageName: msgName,
-				Name:        "equals",
-				Optional:    true,
-				Nullable:    true,
-				Type: &proto.TypeInfo{
-					Type: typeInfo.Type,
-				},
-			},
-			{
-				MessageName: msgName,
-				Name:        "notEquals",
-				Optional:    true,
-				Nullable:    true,
-				Type: &proto.TypeInfo{
-					Type: typeInfo.Type,
-				},
-			},
-			{
-				MessageName: msgName,
-				Name:        "startsWith",
-				Optional:    true,
-				Type: &proto.TypeInfo{
-					Type: typeInfo.Type,
-				},
-			},
-			{
-				MessageName: msgName,
-				Name:        "endsWith",
-				Optional:    true,
-				Type: &proto.TypeInfo{
-					Type: typeInfo.Type,
-				},
-			},
-			{
-				MessageName: msgName,
-				Name:        "contains",
-				Optional:    true,
-				Type: &proto.TypeInfo{
-					Type: typeInfo.Type,
-				},
-			},
-			{
-				MessageName: msgName,
-				Name:        "oneOf",
-				Optional:    true,
-				Type: &proto.TypeInfo{
-					Type:     typeInfo.Type,
-					Repeated: true,
-				},
-			},
-		}}, nil
+		return makeStringQueryInputMessage(msgName), nil
 	case proto.Type_TYPE_INT:
-		return &proto.Message{Name: msgName, Fields: []*proto.MessageField{
-			{
-				MessageName: msgName,
-				Name:        "equals",
-				Optional:    true,
-				Nullable:    true,
-				Type: &proto.TypeInfo{
-					Type: typeInfo.Type,
-				},
-			},
-			{
-				MessageName: msgName,
-				Name:        "notEquals",
-				Optional:    true,
-				Nullable:    true,
-				Type: &proto.TypeInfo{
-					Type: typeInfo.Type,
-				},
-			},
-			{
-				MessageName: msgName,
-				Name:        "lessThan",
-				Optional:    true,
-				Type: &proto.TypeInfo{
-					Type: typeInfo.Type,
-				},
-			},
-			{
-				MessageName: msgName,
-				Name:        "lessThanOrEquals",
-				Optional:    true,
-				Type: &proto.TypeInfo{
-					Type: typeInfo.Type,
-				},
-			},
-			{
-				MessageName: msgName,
-				Name:        "greaterThan",
-				Optional:    true,
-				Type: &proto.TypeInfo{
-					Type: typeInfo.Type,
-				},
-			},
-			{
-				MessageName: msgName,
-				Name:        "greaterThanOrEquals",
-				Optional:    true,
-				Type: &proto.TypeInfo{
-					Type: typeInfo.Type,
-				},
-			},
-			{
-				MessageName: msgName,
-				Name:        "oneOf",
-				Optional:    true,
-				Type: &proto.TypeInfo{
-					Type:     typeInfo.Type,
-					Repeated: true,
-				},
-			},
-		}}, nil
+		return makeIntQueryInputMessage(msgName), nil
 	case proto.Type_TYPE_BOOL:
-		return &proto.Message{Name: msgName, Fields: []*proto.MessageField{
-			{
-				MessageName: msgName,
-				Name:        "equals",
-				Optional:    true,
-				Nullable:    true,
-				Type: &proto.TypeInfo{
-					Type: typeInfo.Type,
-				},
-			},
-			{
-				MessageName: msgName,
-				Name:        "notEquals",
-				Optional:    true,
-				Nullable:    true,
-				Type: &proto.TypeInfo{
-					Type: typeInfo.Type,
-				},
-			},
-		}}, nil
+		return makeBooleanQueryInputMessage(msgName), nil
 	case proto.Type_TYPE_DATE:
-		return &proto.Message{Name: msgName, Fields: []*proto.MessageField{
-			{
-				MessageName: msgName,
-				Name:        "equals",
-				Optional:    true,
-				Nullable:    true,
-				Type: &proto.TypeInfo{
-					Type: typeInfo.Type,
-				},
-			},
-			{
-				MessageName: msgName,
-				Name:        "notEquals",
-				Optional:    true,
-				Nullable:    true,
-				Type: &proto.TypeInfo{
-					Type: typeInfo.Type,
-				},
-			},
-			{
-				MessageName: msgName,
-				Name:        "before",
-				Optional:    true,
-				Type: &proto.TypeInfo{
-					Type: typeInfo.Type,
-				},
-			},
-			{
-				MessageName: msgName,
-				Name:        "onOrBefore",
-				Optional:    true,
-				Type: &proto.TypeInfo{
-					Type: typeInfo.Type,
-				},
-			},
-			{
-				MessageName: msgName,
-				Name:        "after",
-				Optional:    true,
-				Type: &proto.TypeInfo{
-					Type: typeInfo.Type,
-				},
-			},
-			{
-				MessageName: msgName,
-				Name:        "onOrAfter",
-				Optional:    true,
-				Type: &proto.TypeInfo{
-					Type: typeInfo.Type,
-				},
-			},
-		}}, nil
+		return makeDateQueryInputMessage(msgName), nil
 	case proto.Type_TYPE_DATETIME, proto.Type_TYPE_TIMESTAMP:
-		return &proto.Message{Name: msgName, Fields: []*proto.MessageField{
-			{
-				MessageName: msgName,
-				Name:        "before",
-				Optional:    true,
-				Type: &proto.TypeInfo{
-					Type: typeInfo.Type,
-				},
-			},
-			{
-				MessageName: msgName,
-				Name:        "after",
-				Optional:    true,
-				Type: &proto.TypeInfo{
-					Type: typeInfo.Type,
-				},
-			},
-		}}, nil
+		return makeTimestampQueryInputMessage(msgName), nil
 	case proto.Type_TYPE_ENUM:
-		return &proto.Message{Name: msgName, Fields: []*proto.MessageField{
-			{
-				MessageName: msgName,
-				Name:        "equals",
-				Nullable:    true,
-				Optional:    true,
-				Type: &proto.TypeInfo{
-					Type:     typeInfo.Type,
-					EnumName: typeInfo.EnumName,
-				},
-			},
-			{
-				MessageName: msgName,
-				Name:        "notEquals",
-				Optional:    true,
-				Nullable:    true,
-				Type: &proto.TypeInfo{
-					Type:     typeInfo.Type,
-					EnumName: typeInfo.EnumName,
-				},
-			},
-			{
-				MessageName: msgName,
-				Name:        "oneOf",
-				Optional:    true,
-				Type: &proto.TypeInfo{
-					Type:     typeInfo.Type,
-					EnumName: typeInfo.EnumName,
-					Repeated: true,
-				},
-			},
-		}}, nil
+		return makeEnumQueryInputMessage(msgName, typeInfo.EnumName.Value), nil
 	default:
 		return nil, fmt.Errorf("unsupported query type %s", typeInfo.Type.String())
 	}
@@ -556,7 +828,7 @@ func (scm *Builder) makeMessageHierarchyFromImplicitInput(rootMessage *proto.Mes
 			typeInfo, target, targetsOptionalField := scm.inferParserInputType(model, input)
 
 			if action.Type.Value == parser.ActionTypeList {
-				queryMessage, err := makeListQueryInputMessage(typeInfo)
+				queryMessage, err := scm.makeListQueryInputMessage(typeInfo)
 				if err != nil {
 					panic(err.Error())
 				}

--- a/schema/testdata/proto/array_fields/proto.json
+++ b/schema/testdata/proto/array_fields/proto.json
@@ -103,7 +103,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -140,7 +142,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -284,7 +288,9 @@
             "fieldName": "texts",
             "repeated": true
           },
-          "target": ["texts"]
+          "target": [
+            "texts"
+          ]
         },
         {
           "messageName": "CreateThingInput",
@@ -295,7 +301,9 @@
             "fieldName": "numbers",
             "repeated": true
           },
-          "target": ["numbers"]
+          "target": [
+            "numbers"
+          ]
         },
         {
           "messageName": "CreateThingInput",
@@ -306,7 +314,9 @@
             "fieldName": "booleans",
             "repeated": true
           },
-          "target": ["booleans"]
+          "target": [
+            "booleans"
+          ]
         },
         {
           "messageName": "CreateThingInput",
@@ -317,7 +327,9 @@
             "fieldName": "dates",
             "repeated": true
           },
-          "target": ["dates"]
+          "target": [
+            "dates"
+          ]
         },
         {
           "messageName": "CreateThingInput",
@@ -328,7 +340,55 @@
             "fieldName": "timestamps",
             "repeated": true
           },
-          "target": ["timestamps"]
+          "target": [
+            "timestamps"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "StringArrayAllQueryInput",
+      "fields": [
+        {
+          "messageName": "StringArrayAllQueryInput",
+          "name": "equals",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true,
+          "nullable": true
+        },
+        {
+          "messageName": "StringArrayAllQueryInput",
+          "name": "notEquals",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true,
+          "nullable": true
+        }
+      ]
+    },
+    {
+      "name": "StringArrayAnyQueryInput",
+      "fields": [
+        {
+          "messageName": "StringArrayAnyQueryInput",
+          "name": "equals",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true,
+          "nullable": true
+        },
+        {
+          "messageName": "StringArrayAnyQueryInput",
+          "name": "notEquals",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true,
+          "nullable": true
         }
       ]
     },
@@ -354,6 +414,136 @@
           },
           "optional": true,
           "nullable": true
+        },
+        {
+          "messageName": "StringArrayQueryInput",
+          "name": "any",
+          "type": {
+            "type": "TYPE_MESSAGE",
+            "messageName": "StringArrayAnyQueryInput"
+          },
+          "optional": true,
+          "nullable": true
+        },
+        {
+          "messageName": "StringArrayQueryInput",
+          "name": "all",
+          "type": {
+            "type": "TYPE_MESSAGE",
+            "messageName": "StringArrayAllQueryInput"
+          },
+          "optional": true,
+          "nullable": true
+        }
+      ]
+    },
+    {
+      "name": "IntArrayAllQueryInput",
+      "fields": [
+        {
+          "messageName": "IntArrayAllQueryInput",
+          "name": "equals",
+          "type": {
+            "type": "TYPE_INT"
+          },
+          "optional": true,
+          "nullable": true
+        },
+        {
+          "messageName": "IntArrayAllQueryInput",
+          "name": "notEquals",
+          "type": {
+            "type": "TYPE_INT"
+          },
+          "optional": true,
+          "nullable": true
+        },
+        {
+          "messageName": "IntArrayAllQueryInput",
+          "name": "lessThan",
+          "type": {
+            "type": "TYPE_INT"
+          },
+          "optional": true
+        },
+        {
+          "messageName": "IntArrayAllQueryInput",
+          "name": "lessThanOrEquals",
+          "type": {
+            "type": "TYPE_INT"
+          },
+          "optional": true
+        },
+        {
+          "messageName": "IntArrayAllQueryInput",
+          "name": "greaterThan",
+          "type": {
+            "type": "TYPE_INT"
+          },
+          "optional": true
+        },
+        {
+          "messageName": "IntArrayAllQueryInput",
+          "name": "greaterThanOrEquals",
+          "type": {
+            "type": "TYPE_INT"
+          },
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "IntArrayAnyQueryInput",
+      "fields": [
+        {
+          "messageName": "IntArrayAnyQueryInput",
+          "name": "equals",
+          "type": {
+            "type": "TYPE_INT"
+          },
+          "optional": true,
+          "nullable": true
+        },
+        {
+          "messageName": "IntArrayAnyQueryInput",
+          "name": "notEquals",
+          "type": {
+            "type": "TYPE_INT"
+          },
+          "optional": true,
+          "nullable": true
+        },
+        {
+          "messageName": "IntArrayAnyQueryInput",
+          "name": "lessThan",
+          "type": {
+            "type": "TYPE_INT"
+          },
+          "optional": true
+        },
+        {
+          "messageName": "IntArrayAnyQueryInput",
+          "name": "lessThanOrEquals",
+          "type": {
+            "type": "TYPE_INT"
+          },
+          "optional": true
+        },
+        {
+          "messageName": "IntArrayAnyQueryInput",
+          "name": "greaterThan",
+          "type": {
+            "type": "TYPE_INT"
+          },
+          "optional": true
+        },
+        {
+          "messageName": "IntArrayAnyQueryInput",
+          "name": "greaterThanOrEquals",
+          "type": {
+            "type": "TYPE_INT"
+          },
+          "optional": true
         }
       ]
     },
@@ -376,6 +566,72 @@
           "type": {
             "type": "TYPE_INT",
             "repeated": true
+          },
+          "optional": true,
+          "nullable": true
+        },
+        {
+          "messageName": "IntArrayQueryInput",
+          "name": "any",
+          "type": {
+            "type": "TYPE_MESSAGE",
+            "messageName": "IntArrayAnyQueryInput"
+          },
+          "optional": true,
+          "nullable": true
+        },
+        {
+          "messageName": "IntArrayQueryInput",
+          "name": "all",
+          "type": {
+            "type": "TYPE_MESSAGE",
+            "messageName": "IntArrayAllQueryInput"
+          },
+          "optional": true,
+          "nullable": true
+        }
+      ]
+    },
+    {
+      "name": "BooleanArrayAllQueryInput",
+      "fields": [
+        {
+          "messageName": "BooleanArrayAllQueryInput",
+          "name": "equals",
+          "type": {
+            "type": "TYPE_BOOL"
+          },
+          "optional": true,
+          "nullable": true
+        },
+        {
+          "messageName": "BooleanArrayAllQueryInput",
+          "name": "notEquals",
+          "type": {
+            "type": "TYPE_BOOL"
+          },
+          "optional": true,
+          "nullable": true
+        }
+      ]
+    },
+    {
+      "name": "BooleanArrayAnyQueryInput",
+      "fields": [
+        {
+          "messageName": "BooleanArrayAnyQueryInput",
+          "name": "equals",
+          "type": {
+            "type": "TYPE_BOOL"
+          },
+          "optional": true,
+          "nullable": true
+        },
+        {
+          "messageName": "BooleanArrayAnyQueryInput",
+          "name": "notEquals",
+          "type": {
+            "type": "TYPE_BOOL"
           },
           "optional": true,
           "nullable": true
@@ -404,6 +660,136 @@
           },
           "optional": true,
           "nullable": true
+        },
+        {
+          "messageName": "BooleanArrayQueryInput",
+          "name": "any",
+          "type": {
+            "type": "TYPE_MESSAGE",
+            "messageName": "BooleanArrayAnyQueryInput"
+          },
+          "optional": true,
+          "nullable": true
+        },
+        {
+          "messageName": "BooleanArrayQueryInput",
+          "name": "all",
+          "type": {
+            "type": "TYPE_MESSAGE",
+            "messageName": "BooleanArrayAllQueryInput"
+          },
+          "optional": true,
+          "nullable": true
+        }
+      ]
+    },
+    {
+      "name": "DateArrayAllQueryInput",
+      "fields": [
+        {
+          "messageName": "DateArrayAllQueryInput",
+          "name": "equals",
+          "type": {
+            "type": "TYPE_DATE"
+          },
+          "optional": true,
+          "nullable": true
+        },
+        {
+          "messageName": "DateArrayAllQueryInput",
+          "name": "notEquals",
+          "type": {
+            "type": "TYPE_DATE"
+          },
+          "optional": true,
+          "nullable": true
+        },
+        {
+          "messageName": "DateArrayAllQueryInput",
+          "name": "before",
+          "type": {
+            "type": "TYPE_DATE"
+          },
+          "optional": true
+        },
+        {
+          "messageName": "DateArrayAllQueryInput",
+          "name": "onOrBefore",
+          "type": {
+            "type": "TYPE_DATE"
+          },
+          "optional": true
+        },
+        {
+          "messageName": "DateArrayAllQueryInput",
+          "name": "after",
+          "type": {
+            "type": "TYPE_DATE"
+          },
+          "optional": true
+        },
+        {
+          "messageName": "DateArrayAllQueryInput",
+          "name": "onOrAfter",
+          "type": {
+            "type": "TYPE_DATE"
+          },
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "DateArrayAnyQueryInput",
+      "fields": [
+        {
+          "messageName": "DateArrayAnyQueryInput",
+          "name": "equals",
+          "type": {
+            "type": "TYPE_DATE"
+          },
+          "optional": true,
+          "nullable": true
+        },
+        {
+          "messageName": "DateArrayAnyQueryInput",
+          "name": "notEquals",
+          "type": {
+            "type": "TYPE_DATE"
+          },
+          "optional": true,
+          "nullable": true
+        },
+        {
+          "messageName": "DateArrayAnyQueryInput",
+          "name": "before",
+          "type": {
+            "type": "TYPE_DATE"
+          },
+          "optional": true
+        },
+        {
+          "messageName": "DateArrayAnyQueryInput",
+          "name": "onOrBefore",
+          "type": {
+            "type": "TYPE_DATE"
+          },
+          "optional": true
+        },
+        {
+          "messageName": "DateArrayAnyQueryInput",
+          "name": "after",
+          "type": {
+            "type": "TYPE_DATE"
+          },
+          "optional": true
+        },
+        {
+          "messageName": "DateArrayAnyQueryInput",
+          "name": "onOrAfter",
+          "type": {
+            "type": "TYPE_DATE"
+          },
+          "optional": true
         }
       ]
     },
@@ -429,6 +815,68 @@
           },
           "optional": true,
           "nullable": true
+        },
+        {
+          "messageName": "DateArrayQueryInput",
+          "name": "any",
+          "type": {
+            "type": "TYPE_MESSAGE",
+            "messageName": "DateArrayAnyQueryInput"
+          },
+          "optional": true,
+          "nullable": true
+        },
+        {
+          "messageName": "DateArrayQueryInput",
+          "name": "all",
+          "type": {
+            "type": "TYPE_MESSAGE",
+            "messageName": "DateArrayAllQueryInput"
+          },
+          "optional": true,
+          "nullable": true
+        }
+      ]
+    },
+    {
+      "name": "TimestampArrayAllQueryInput",
+      "fields": [
+        {
+          "messageName": "TimestampArrayAllQueryInput",
+          "name": "before",
+          "type": {
+            "type": "TYPE_TIMESTAMP"
+          },
+          "optional": true
+        },
+        {
+          "messageName": "TimestampArrayAllQueryInput",
+          "name": "after",
+          "type": {
+            "type": "TYPE_TIMESTAMP"
+          },
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "TimestampArrayAnyQueryInput",
+      "fields": [
+        {
+          "messageName": "TimestampArrayAnyQueryInput",
+          "name": "before",
+          "type": {
+            "type": "TYPE_TIMESTAMP"
+          },
+          "optional": true
+        },
+        {
+          "messageName": "TimestampArrayAnyQueryInput",
+          "name": "after",
+          "type": {
+            "type": "TYPE_TIMESTAMP"
+          },
+          "optional": true
         }
       ]
     },
@@ -454,6 +902,26 @@
           },
           "optional": true,
           "nullable": true
+        },
+        {
+          "messageName": "TimestampArrayQueryInput",
+          "name": "any",
+          "type": {
+            "type": "TYPE_MESSAGE",
+            "messageName": "TimestampArrayAnyQueryInput"
+          },
+          "optional": true,
+          "nullable": true
+        },
+        {
+          "messageName": "TimestampArrayQueryInput",
+          "name": "all",
+          "type": {
+            "type": "TYPE_MESSAGE",
+            "messageName": "TimestampArrayAllQueryInput"
+          },
+          "optional": true,
+          "nullable": true
         }
       ]
     },
@@ -467,7 +935,9 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringArrayQueryInput"
           },
-          "target": ["texts"]
+          "target": [
+            "texts"
+          ]
         },
         {
           "messageName": "ListThingsWhere",
@@ -476,7 +946,9 @@
             "type": "TYPE_MESSAGE",
             "messageName": "IntArrayQueryInput"
           },
-          "target": ["numbers"]
+          "target": [
+            "numbers"
+          ]
         },
         {
           "messageName": "ListThingsWhere",
@@ -485,7 +957,9 @@
             "type": "TYPE_MESSAGE",
             "messageName": "BooleanArrayQueryInput"
           },
-          "target": ["booleans"]
+          "target": [
+            "booleans"
+          ]
         },
         {
           "messageName": "ListThingsWhere",
@@ -494,7 +968,9 @@
             "type": "TYPE_MESSAGE",
             "messageName": "DateArrayQueryInput"
           },
-          "target": ["dates"]
+          "target": [
+            "dates"
+          ]
         },
         {
           "messageName": "ListThingsWhere",
@@ -503,7 +979,9 @@
             "type": "TYPE_MESSAGE",
             "messageName": "TimestampArrayQueryInput"
           },
-          "target": ["timestamps"]
+          "target": [
+            "timestamps"
+          ]
         }
       ]
     },

--- a/schema/testdata/proto/array_fields/proto.json
+++ b/schema/testdata/proto/array_fields/proto.json
@@ -355,8 +355,7 @@
           "type": {
             "type": "TYPE_STRING"
           },
-          "optional": true,
-          "nullable": true
+          "optional": true
         },
         {
           "messageName": "StringArrayAllQueryInput",
@@ -364,8 +363,7 @@
           "type": {
             "type": "TYPE_STRING"
           },
-          "optional": true,
-          "nullable": true
+          "optional": true
         }
       ]
     },
@@ -378,8 +376,7 @@
           "type": {
             "type": "TYPE_STRING"
           },
-          "optional": true,
-          "nullable": true
+          "optional": true
         },
         {
           "messageName": "StringArrayAnyQueryInput",
@@ -387,8 +384,7 @@
           "type": {
             "type": "TYPE_STRING"
           },
-          "optional": true,
-          "nullable": true
+          "optional": true
         }
       ]
     },
@@ -422,8 +418,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringArrayAnyQueryInput"
           },
-          "optional": true,
-          "nullable": true
+          "optional": true
         },
         {
           "messageName": "StringArrayQueryInput",
@@ -432,8 +427,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringArrayAllQueryInput"
           },
-          "optional": true,
-          "nullable": true
+          "optional": true
         }
       ]
     },
@@ -446,8 +440,7 @@
           "type": {
             "type": "TYPE_INT"
           },
-          "optional": true,
-          "nullable": true
+          "optional": true
         },
         {
           "messageName": "IntArrayAllQueryInput",
@@ -455,8 +448,7 @@
           "type": {
             "type": "TYPE_INT"
           },
-          "optional": true,
-          "nullable": true
+          "optional": true
         },
         {
           "messageName": "IntArrayAllQueryInput",
@@ -501,8 +493,7 @@
           "type": {
             "type": "TYPE_INT"
           },
-          "optional": true,
-          "nullable": true
+          "optional": true
         },
         {
           "messageName": "IntArrayAnyQueryInput",
@@ -510,8 +501,7 @@
           "type": {
             "type": "TYPE_INT"
           },
-          "optional": true,
-          "nullable": true
+          "optional": true
         },
         {
           "messageName": "IntArrayAnyQueryInput",
@@ -577,8 +567,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "IntArrayAnyQueryInput"
           },
-          "optional": true,
-          "nullable": true
+          "optional": true
         },
         {
           "messageName": "IntArrayQueryInput",
@@ -587,8 +576,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "IntArrayAllQueryInput"
           },
-          "optional": true,
-          "nullable": true
+          "optional": true
         }
       ]
     },
@@ -601,8 +589,7 @@
           "type": {
             "type": "TYPE_BOOL"
           },
-          "optional": true,
-          "nullable": true
+          "optional": true
         },
         {
           "messageName": "BooleanArrayAllQueryInput",
@@ -610,8 +597,7 @@
           "type": {
             "type": "TYPE_BOOL"
           },
-          "optional": true,
-          "nullable": true
+          "optional": true
         }
       ]
     },
@@ -624,8 +610,7 @@
           "type": {
             "type": "TYPE_BOOL"
           },
-          "optional": true,
-          "nullable": true
+          "optional": true
         },
         {
           "messageName": "BooleanArrayAnyQueryInput",
@@ -633,8 +618,7 @@
           "type": {
             "type": "TYPE_BOOL"
           },
-          "optional": true,
-          "nullable": true
+          "optional": true
         }
       ]
     },
@@ -668,8 +652,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "BooleanArrayAnyQueryInput"
           },
-          "optional": true,
-          "nullable": true
+          "optional": true
         },
         {
           "messageName": "BooleanArrayQueryInput",
@@ -678,8 +661,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "BooleanArrayAllQueryInput"
           },
-          "optional": true,
-          "nullable": true
+          "optional": true
         }
       ]
     },
@@ -692,8 +674,7 @@
           "type": {
             "type": "TYPE_DATE"
           },
-          "optional": true,
-          "nullable": true
+          "optional": true
         },
         {
           "messageName": "DateArrayAllQueryInput",
@@ -701,8 +682,7 @@
           "type": {
             "type": "TYPE_DATE"
           },
-          "optional": true,
-          "nullable": true
+          "optional": true
         },
         {
           "messageName": "DateArrayAllQueryInput",
@@ -747,8 +727,7 @@
           "type": {
             "type": "TYPE_DATE"
           },
-          "optional": true,
-          "nullable": true
+          "optional": true
         },
         {
           "messageName": "DateArrayAnyQueryInput",
@@ -756,8 +735,7 @@
           "type": {
             "type": "TYPE_DATE"
           },
-          "optional": true,
-          "nullable": true
+          "optional": true
         },
         {
           "messageName": "DateArrayAnyQueryInput",
@@ -823,8 +801,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "DateArrayAnyQueryInput"
           },
-          "optional": true,
-          "nullable": true
+          "optional": true
         },
         {
           "messageName": "DateArrayQueryInput",
@@ -833,8 +810,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "DateArrayAllQueryInput"
           },
-          "optional": true,
-          "nullable": true
+          "optional": true
         }
       ]
     },
@@ -910,8 +886,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "TimestampArrayAnyQueryInput"
           },
-          "optional": true,
-          "nullable": true
+          "optional": true
         },
         {
           "messageName": "TimestampArrayQueryInput",
@@ -920,8 +895,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "TimestampArrayAllQueryInput"
           },
-          "optional": true,
-          "nullable": true
+          "optional": true
         }
       ]
     },

--- a/schema/testdata/proto/array_fields/proto.json
+++ b/schema/testdata/proto/array_fields/proto.json
@@ -103,9 +103,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -142,9 +140,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -288,9 +284,7 @@
             "fieldName": "texts",
             "repeated": true
           },
-          "target": [
-            "texts"
-          ]
+          "target": ["texts"]
         },
         {
           "messageName": "CreateThingInput",
@@ -301,9 +295,7 @@
             "fieldName": "numbers",
             "repeated": true
           },
-          "target": [
-            "numbers"
-          ]
+          "target": ["numbers"]
         },
         {
           "messageName": "CreateThingInput",
@@ -314,9 +306,7 @@
             "fieldName": "booleans",
             "repeated": true
           },
-          "target": [
-            "booleans"
-          ]
+          "target": ["booleans"]
         },
         {
           "messageName": "CreateThingInput",
@@ -327,9 +317,7 @@
             "fieldName": "dates",
             "repeated": true
           },
-          "target": [
-            "dates"
-          ]
+          "target": ["dates"]
         },
         {
           "messageName": "CreateThingInput",
@@ -340,9 +328,7 @@
             "fieldName": "timestamps",
             "repeated": true
           },
-          "target": [
-            "timestamps"
-          ]
+          "target": ["timestamps"]
         }
       ]
     },
@@ -909,9 +895,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringArrayQueryInput"
           },
-          "target": [
-            "texts"
-          ]
+          "target": ["texts"]
         },
         {
           "messageName": "ListThingsWhere",
@@ -920,9 +904,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "IntArrayQueryInput"
           },
-          "target": [
-            "numbers"
-          ]
+          "target": ["numbers"]
         },
         {
           "messageName": "ListThingsWhere",
@@ -931,9 +913,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "BooleanArrayQueryInput"
           },
-          "target": [
-            "booleans"
-          ]
+          "target": ["booleans"]
         },
         {
           "messageName": "ListThingsWhere",
@@ -942,9 +922,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "DateArrayQueryInput"
           },
-          "target": [
-            "dates"
-          ]
+          "target": ["dates"]
         },
         {
           "messageName": "ListThingsWhere",
@@ -953,9 +931,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "TimestampArrayQueryInput"
           },
-          "target": [
-            "timestamps"
-          ]
+          "target": ["timestamps"]
         }
       ]
     },


### PR DESCRIPTION
# `any` and `all` array queries

With the `list` action, it is now possible to perform queries within array data using the `all` and `any` query operators.  For example, the following query returns all posts **where any tag is equal to "science"**:

```gql
query {
  listPosts(input: {
    where: {
      tags: {
        any: {
          equals: "science"
        }
      }
    }
  }) {
  ...
  }
}
```

All of the scalar query operations are available, with the exception of `contains`, `startsWith` and `endsWith` for Text.

It is also possible to combine queries in just the same way with our existing list querying.  For example:

```gql
query {
  listPosts(input: {
    where: {
      tags: {
        any: {
          equals: "science",
          notEquals: "education"
        },
        all: {
          notEquals: "science"
        }
      }
    }
  }) {
  ...
  }
}
```

This will be generated into a single SQL query.  And, of course, you can combine this with expressions, etc.

Note:  more tests need to be written.