### PR TITLE
feat: enforce maximum identifier length through validation rules

### DIFF
--- a/schema/testdata/errors/fields_names_max_lenght.keel
+++ b/schema/testdata/errors/fields_names_max_lenght.keel
@@ -1,0 +1,7 @@
+model Foo {
+    fields {
+        //expect-error:9:62:E052:Cannot use 'aVeryLongLongLongLongLongFieldNameThatIsTrulyVeryLong' as a field name as it is too long.
+        aVeryLongLongLongLongLongFieldNameThatIsTrulyVeryLong Text
+        aLongLongLongLongLongFieldNameThatIsNotVeryLong Text
+    }
+}

--- a/schema/testdata/errors/model_names_max_lenght.keel
+++ b/schema/testdata/errors/model_names_max_lenght.keel
@@ -1,0 +1,12 @@
+//expect-error:7:51:E053:Cannot use 'ALongLongLongLongLongModelNameThatIsVeryLong' as a model name as it is too long.
+model ALongLongLongLongLongModelNameThatIsVeryLong {
+    fields {
+        foo Text
+    }
+}
+
+model ALongLongLongLongModelNameThatNotVeryLong {
+    fields {
+        foo Text
+    }
+}

--- a/schema/validation/errorhandling/errors.go
+++ b/schema/validation/errorhandling/errors.go
@@ -55,6 +55,8 @@ const (
 	ErrorExpressionMultipleConditions        = "E049"
 	ErrorDefaultExpressionNeeded             = "E050"
 	ErrorDefaultExpressionOperatorPresent    = "E051"
+	ErrorFieldNamesMaxLength                 = "E052"
+	ErrorModelNamesMaxLength                 = "E053"
 	ErrorCreateActionAmbiguousRelationship   = "E059"
 	ErrorExpressionTypeNotNullable           = "E060"
 	ErrorExpressionSingleConditionNotBoolean = "E061"

--- a/schema/validation/errorhandling/errors.yml
+++ b/schema/validation/errorhandling/errors.yml
@@ -135,6 +135,12 @@ en:
   E051:
     message: "default expression doesn't support operators"
     hint: "Try removing '{{ .Op }}'"
+  E052:
+    message: "Cannot use '{{ .Name }}' as a field name as it is too long."
+    hint: "Rename this field to a shorter name"
+  E053:
+    message: "Cannot use '{{ .Name }}' as a model name as it is too long."
+    hint: "Rename this model to a shorter name"
   E059:
     message: "You cannot set values for both {{.IdPath}} and {{.ConflictingPath}} in this create action - because the first one indicates that you want to refer to an existing {{.ModelName}}"
     hint: "Either 1) use the .id form, and none of the {{.ModelName}} fields, or 2) omit the .id form and specify all of the fields of {{.ModelName}} that are needed to create one."

--- a/schema/validation/rules/field/field.go
+++ b/schema/validation/rules/field/field.go
@@ -82,13 +82,13 @@ func ValidFieldTypesRule(asts []*parser.AST) (errs errorhandling.ValidationError
 
 // FieldNamesMaxLengthRule will validate that field names are smaller than the maximum allowed by postgres (63 bytes).
 func FieldNamesMaxLengthRule(asts []*parser.AST) (errs errorhandling.ValidationErrors) {
-	const MAX_BYTES = 63
+	const maxBytes = 63
 
 	for _, model := range query.Models(asts) {
 		for _, field := range query.ModelFields(model) {
 			identifier := casing.ToSnake(field.Name.Value)
 
-			if len(identifier) > MAX_BYTES {
+			if len(identifier) > maxBytes {
 				errs.Append(errorhandling.ErrorFieldNamesMaxLength,
 					map[string]string{
 						"Name": field.Name.Value,

--- a/schema/validation/rules/field/field.go
+++ b/schema/validation/rules/field/field.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/teamkeel/keel/casing"
 	"github.com/teamkeel/keel/formatting"
 	"github.com/teamkeel/keel/schema/parser"
 	"github.com/teamkeel/keel/schema/query"
@@ -73,6 +74,28 @@ func ValidFieldTypesRule(asts []*parser.AST) (errs errorhandling.ValidationError
 				},
 				field.Name,
 			)
+		}
+	}
+
+	return
+}
+
+// FieldNamesMaxLengthRule will validate that field names are smaller than the maximum allowed by postgres (63 bytes).
+func FieldNamesMaxLengthRule(asts []*parser.AST) (errs errorhandling.ValidationErrors) {
+	const MAX_BYTES = 63
+
+	for _, model := range query.Models(asts) {
+		for _, field := range query.ModelFields(model) {
+			identifier := casing.ToSnake(field.Name.Value)
+
+			if len(identifier) > MAX_BYTES {
+				errs.Append(errorhandling.ErrorFieldNamesMaxLength,
+					map[string]string{
+						"Name": field.Name.Value,
+					},
+					field.Name,
+				)
+			}
 		}
 	}
 

--- a/schema/validation/rules/model/model.go
+++ b/schema/validation/rules/model/model.go
@@ -1,0 +1,34 @@
+package model
+
+import (
+	"github.com/teamkeel/keel/casing"
+	"github.com/teamkeel/keel/schema/parser"
+	"github.com/teamkeel/keel/schema/query"
+	"github.com/teamkeel/keel/schema/validation/errorhandling"
+)
+
+// ModelNamesMaxLengthRule will validate that model names are smaller than the maximum allowed by postgres (63 bytes).
+//
+// The maximum field length is given by: 63 - 11 (to accomodate for the longest trigger name suffix: _updated_at) hard limit.
+// This maximum length is applied to the snake cased version of the field name.
+func ModelNamesMaxLengthRule(asts []*parser.AST) (errs errorhandling.ValidationErrors) {
+	const (
+		MAX_BYTES  = 63
+		MAX_SUFFIX = "_updated_at"
+	)
+
+	for _, model := range query.Models(asts) {
+		identifier := casing.ToSnake(model.Name.Value) + MAX_SUFFIX
+
+		if len(identifier) > MAX_BYTES {
+			errs.Append(errorhandling.ErrorModelNamesMaxLength,
+				map[string]string{
+					"Name": model.Name.Value,
+				},
+				model.Name,
+			)
+		}
+	}
+
+	return
+}

--- a/schema/validation/rules/model/model.go
+++ b/schema/validation/rules/model/model.go
@@ -13,14 +13,14 @@ import (
 // This maximum length is applied to the snake cased version of the field name.
 func ModelNamesMaxLengthRule(asts []*parser.AST) (errs errorhandling.ValidationErrors) {
 	const (
-		MAX_BYTES  = 63
-		MAX_SUFFIX = "_updated_at"
+		maxBytes  = 63
+		maxSuffix = "_updated_at"
 	)
 
 	for _, model := range query.Models(asts) {
-		identifier := casing.ToSnake(model.Name.Value) + MAX_SUFFIX
+		identifier := casing.ToSnake(model.Name.Value) + maxSuffix
 
-		if len(identifier) > MAX_BYTES {
+		if len(identifier) > maxBytes {
 			errs.Append(errorhandling.ErrorModelNamesMaxLength,
 				map[string]string{
 					"Name": model.Name.Value,

--- a/schema/validation/validation.go
+++ b/schema/validation/validation.go
@@ -7,6 +7,7 @@ import (
 	"github.com/teamkeel/keel/schema/validation/rules/api"
 	"github.com/teamkeel/keel/schema/validation/rules/attribute"
 	"github.com/teamkeel/keel/schema/validation/rules/field"
+	"github.com/teamkeel/keel/schema/validation/rules/model"
 	"github.com/teamkeel/keel/schema/validation/rules/role"
 )
 
@@ -40,6 +41,9 @@ var validatorFuncs = []validationFunc{
 
 	field.ValidFieldTypesRule,
 	field.UniqueFieldNamesRule,
+	field.FieldNamesMaxLengthRule,
+
+	model.ModelNamesMaxLengthRule,
 
 	attribute.AttributeLocationsRule,
 	attribute.SetWhereAttributeRule,


### PR DESCRIPTION
Postgresql has a maximum identifier length limit of 63 bytes. Anything over 63 bytes will be automatically truncated and this will cause issues with migrations. 

This PR adds validation rules to check that field names and model names will not create identifiers longer than the limit enforced by the DB engine. The limit is applied on the snake cased version of the field/model name, as this is what will be used in order to generate the db identifiers. The limit also takes in account the longest suffix added to generated triggers (e,g, `model_name_updated_at`).