### PR TITLE
Fix: backwards pagination

### DIFF
--- a/integration/testdata/orderby_list_operation/tests.test.ts
+++ b/integration/testdata/orderby_list_operation/tests.test.ts
@@ -137,6 +137,7 @@ test("orderby - before cursor - better than John", async () => {
   const cursor = winners.results[3].id;
   const betterThanJohn = await actions.listRankings({
     before: cursor,
+    last: 3,
   });
 
   expect(betterThanJohn.pageInfo.count).toEqual(3);

--- a/runtime/actions/pagination.go
+++ b/runtime/actions/pagination.go
@@ -87,3 +87,19 @@ func ParsePage(args map[string]any) (Page, error) {
 
 	return page, nil
 }
+
+// IsBackwards tells us if the page is backwards paginated (e.g. we're requesting elements before a cursor)
+func (p *Page) IsBackwards() bool {
+	return p.Before != "" && p.Last > 0
+}
+
+// Cursor returns the cursor used in the pagination based on the direction of pagination:
+// - if backwards, it's `before`
+// - if forward pagination, it's `after`
+func (p *Page) Cursor() string {
+	if p.IsBackwards() {
+		return p.Before
+	}
+
+	return p.After
+}

--- a/runtime/actions/query_test.go
+++ b/runtime/actions/query_test.go
@@ -1792,7 +1792,7 @@ var testCases = []testCase{
 			WHERE
 				"thing"."id" < (SELECT "thing"."id" FROM "thing" WHERE "thing"."id" IS NOT DISTINCT FROM ? )
 			ORDER BY
-				"thing"."id" ASC LIMIT ?`,
+				"thing"."id" DESC LIMIT ?`,
 		expectedArgs: []any{"123", 2},
 	},
 	{


### PR DESCRIPTION
When paginating results, using cursor backwards pagination we will be retrieving items `before` the cursor, with a limit of `last` items. To achieve this we have to flip the order direction and then reverse the returned items back again. More information about [cursor pagination](https://relay.dev/graphql/connections.htm)