### PR TITLE
fix: snake case fields when creating via ModelAPI

### DIFF
--- a/integration/testdata/client_basic/main.test.ts
+++ b/integration/testdata/client_basic/main.test.ts
@@ -12,7 +12,10 @@ beforeEach(() => {
 beforeEach(resetDatabase);
 
 test("client - create action", async () => {
-  const post = await client.api.mutations.createPost({ title: "My Post", field1: "test" });
+  const post = await client.api.mutations.createPost({
+    title: "My Post",
+    field1: "test",
+  });
 
   expect(post.data).not.toBeNull();
   expect(post.data?.title).toEqual("My Post");
@@ -38,7 +41,10 @@ test("client - get action", async () => {
 });
 
 test("client - update action", async () => {
-  const post = await client.api.mutations.createPost({ title: "My Post", field1: "test" });
+  const post = await client.api.mutations.createPost({
+    title: "My Post",
+    field1: "test",
+  });
 
   const updated = await client.api.mutations.updatePost({
     where: { id: post.data!.id },

--- a/integration/testdata/client_basic/main.test.ts
+++ b/integration/testdata/client_basic/main.test.ts
@@ -12,12 +12,13 @@ beforeEach(() => {
 beforeEach(resetDatabase);
 
 test("client - create action", async () => {
-  const post = await client.api.mutations.createPost({ title: "My Post" });
+  const post = await client.api.mutations.createPost({ title: "My Post", field1: "test" });
 
   expect(post.data).not.toBeNull();
   expect(post.data?.title).toEqual("My Post");
   expect(post.data?.views).toEqual(0);
   expect(post.data?.category).toBeNull();
+  expect(post.data?.field1).toEqual("test");
 
   const retrieved = await models.post.findOne({ id: post.data!.id });
   expect(retrieved).not.toBeNull();
@@ -37,7 +38,7 @@ test("client - get action", async () => {
 });
 
 test("client - update action", async () => {
-  const post = await client.api.mutations.createPost({ title: "My Post" });
+  const post = await client.api.mutations.createPost({ title: "My Post", field1: "test" });
 
   const updated = await client.api.mutations.updatePost({
     where: { id: post.data!.id },
@@ -45,11 +46,13 @@ test("client - update action", async () => {
       title: "Updated Post",
       views: 10,
       category: Category.Lifestyle,
+      field1: "test again",
     },
   });
 
   expect(updated.data).not.toBeNull();
   expect(updated.data?.title).toEqual("Updated Post");
+  expect(updated.data?.field1).toEqual("test again");
   expect(updated.data?.views).toEqual(10);
   expect(updated.data?.category).toEqual(Category.Lifestyle);
 

--- a/integration/testdata/client_basic/schema.keel
+++ b/integration/testdata/client_basic/schema.keel
@@ -3,12 +3,13 @@ model Post {
         title Text
         views Number @default(0)
         category Category?
+        field1 Text?
     }
 
     actions {
-        create createPost() with (title, category?, views?)
+        create createPost() with (title, category?, views?, field1?)
         get getPost(id)
-        update updatePost(id) with (title, category?, views?)
+        update updatePost(id) with (title, category?, views?, field1?)
         delete deletePost(id)
         list listPosts(title, category?, views?) 
     }

--- a/packages/functions-runtime/src/ModelAPI.js
+++ b/packages/functions-runtime/src/ModelAPI.js
@@ -54,7 +54,12 @@ class ModelAPI {
 
     return tracing.withSpan(name, () => {
       const db = useDatabase();
-      return create(db, this._tableName, this._tableConfigMap, values);
+      return create(
+        db,
+        this._tableName,
+        this._tableConfigMap,
+        snakeCaseObject(values)
+      );
     });
   }
 


### PR DESCRIPTION
When creating models via ModelAPI, all fields need to be passed through the snake case object helper func. This will transform fields such as `address1` into the expected db column `address_1`.