### PR TITLE
fix: database connect timeout too short

### DIFF
--- a/cmd/database/database.go
+++ b/cmd/database/database.go
@@ -435,13 +435,13 @@ func connectAndWaitForDbServer(serverConnectionInfo *db.ConnectionInfo) (server 
 		return nil, err
 	}
 
-	// ping() the database for 5 seconds until it is available.
+	// ping() the database until it is available.
 	var pingError error
 	for i := 0; i < 20; i++ {
 		if pingError = server.Ping(); pingError == nil {
 			break
 		}
-		time.Sleep(250 * time.Millisecond)
+		time.Sleep(500 * time.Millisecond)
 	}
 	return server, pingError
 }


### PR DESCRIPTION
I've found that I am regularly getting the following error when running `keel` locally:

```
Error: failed to connect to `host=0.0.0.0 user=postgres database=`: server error (FATAL: the database system is starting up (SQLSTATE 57P03))
Usage:
  keel test [flags]

Flags:
  -h, --help                      help for test
  -p, --pattern string            pattern to isolate test (default "(.*)")
      --private-key-path string   path to the private key .pem file

Global Flags:
  -d, --dir string   directory containing a Keel project (default "/Users/davenewza/code/keel/integration/testdata/client_password_grant")
  -v, --version      Print the Keel CLI version

Error: failed to connect to `host=0.0.0.0 user=postgres database=`: server error (FATAL: the database system is starting up (SQLSTATE 57P03))
```

Adjusting the ping frequency fixes this issue.