### PR TITLE
Format optional repeated fields 

### DIFF
--- a/schema/format/format.go
+++ b/schema/format/format.go
@@ -1,7 +1,6 @@
 package format
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 	"text/scanner"
@@ -17,123 +16,6 @@ const (
 	indentSize    = 4
 	maxLineLength = 80
 )
-
-type Writer struct {
-	b          strings.Builder
-	currIndent int
-
-	// We keep a stack of comments as when ending a block
-	// we will print any trailing comments inside the closing
-	// paren
-	commentStack [][]lexer.Token
-
-	// We keep a cache of which comments we've already printed
-	// as the same comment tokens can appear on different nodes
-	commentCache map[string]bool
-}
-
-func (w *Writer) WriteLine(s string, args ...any) {
-	if w.isStartOfLine() && s != "" {
-		w.b.WriteString(strings.Repeat(" ", w.currIndent))
-	}
-	w.b.WriteString(fmt.Sprintf(s+"\n", args...))
-}
-
-func (w *Writer) Write(s string, args ...any) {
-	if w.isStartOfLine() && s != "" {
-		w.b.WriteString(strings.Repeat(" ", w.currIndent))
-	}
-	w.b.WriteString(fmt.Sprintf(s, args...))
-}
-
-func (w *Writer) Indent() {
-	w.currIndent += indentSize
-}
-
-func (w *Writer) Dedent() {
-	w.currIndent -= indentSize
-	if w.currIndent < 0 {
-		w.currIndent = 0
-	}
-}
-
-func (w *Writer) Block(fn func()) {
-	w.WriteLine(" {")
-	w.Indent()
-	fn()
-	if len(w.commentStack) > 0 {
-		tokens := w.commentStack[len(w.commentStack)-1]
-		w.trailingComments(tokens)
-	}
-	w.Dedent()
-	w.WriteLine("}")
-}
-
-func (w *Writer) LineLength() int {
-	s := w.b.String()
-	lines := strings.Split(s, "\n")
-	curr := lines[len(lines)-1]
-	return len(curr)
-}
-
-func (w *Writer) Comments(node node.ParserNode, fn func()) {
-	tokens := node.GetTokens()
-	w.commentStack = append(w.commentStack, tokens)
-
-	w.leadingComments(tokens)
-	fn()
-	w.trailingComments(tokens)
-
-	w.commentStack = w.commentStack[0 : len(w.commentStack)-1]
-}
-
-func (w *Writer) leadingComments(tokens []lexer.Token) {
-	for _, t := range tokens {
-		if t.Type != scanner.Comment {
-			return
-		}
-		if !w.seenToken(t) {
-			w.WriteLine(t.Value)
-		}
-	}
-}
-
-func (w *Writer) trailingComments(tokens []lexer.Token) {
-	comments := []lexer.Token{}
-	for i := len(tokens) - 1; i >= 0; i-- {
-		t := tokens[i]
-		if t.Type == '}' {
-			continue
-		}
-		if t.Type != scanner.Comment {
-			break
-		}
-		comments = append(comments, t)
-	}
-	for _, t := range lo.Reverse(comments) {
-		if !w.seenToken(t) {
-			w.WriteLine(t.Value)
-		}
-	}
-}
-
-func (w *Writer) seenToken(t lexer.Token) bool {
-	key := fmt.Sprintf("%d:%d", t.Pos.Line, t.Pos.Column)
-	_, seen := w.commentCache[key]
-	if !seen {
-		w.commentCache[key] = true
-	}
-	return seen
-}
-
-func (w *Writer) String() string {
-	return w.b.String()
-}
-
-func (w *Writer) isStartOfLine() bool {
-	s := w.b.String()
-	return len(s) > 0 && s[len(s)-1] == '\n'
-}
 
 func HasComments(nodes []node.ParserNode) bool {
 	for _, n := range nodes {
@@ -154,9 +36,9 @@ func Format(ast *parser.AST) string {
 
 	for i, decl := range ast.Declarations {
 		if i > 0 {
-			writer.WriteLine("")
+			writer.writeLine("")
 		}
-		writer.Comments(decl, func() {
+		writer.comments(decl, func() {
 			switch {
 			case decl.Model != nil:
 				printModel(writer, decl.Model)
@@ -174,31 +56,31 @@ func Format(ast *parser.AST) string {
 		})
 	}
 
-	return writer.String()
+	return writer.string()
 }
 
 func printMessage(writer *Writer, message *parser.MessageNode) {
-	writer.Comments(message, func() {
-		writer.Write("message %s", camel(message.Name.Value))
-		writer.Block(func() {
+	writer.comments(message, func() {
+		writer.write("message %s", camel(message.Name.Value))
+		writer.block(func() {
 
 			for _, field := range message.Fields {
-				writer.Comments(field, func() {
-					writer.Write(
+				writer.comments(field, func() {
+					writer.write(
 						"%s %s",
 						lowerCamel(field.Name.Value),
 						field.Type.Value,
 					)
 
 					if field.Optional {
-						writer.Write("?")
+						writer.write("?")
 					}
 
 					if field.Repeated {
-						writer.Write("[]")
+						writer.write("[]")
 					}
 
-					writer.WriteLine("")
+					writer.writeLine("")
 				})
 			}
 		})
@@ -207,32 +89,32 @@ func printMessage(writer *Writer, message *parser.MessageNode) {
 }
 
 func printJob(writer *Writer, job *parser.JobNode) {
-	writer.Comments(job, func() {
-		writer.Write("job %s", camel(job.Name.Value))
-		writer.Block(func() {
+	writer.comments(job, func() {
+		writer.write("job %s", camel(job.Name.Value))
+		writer.block(func() {
 			for _, section := range job.Sections {
-				writer.Comments(section, func() {
+				writer.comments(section, func() {
 					switch {
 					case len(section.Inputs) > 0:
-						writer.Write("inputs")
-						writer.Block(func() {
+						writer.write("inputs")
+						writer.block(func() {
 							for _, input := range section.Inputs {
-								writer.Comments(input, func() {
-									writer.Write(
+								writer.comments(input, func() {
+									writer.write(
 										"%s %s",
 										lowerCamel(input.Name.Value),
 										camel(input.Type.Value),
 									)
 									if input.Optional {
-										writer.Write("?")
+										writer.write("?")
 									}
-									writer.WriteLine("")
+									writer.writeLine("")
 								})
 							}
 						},
 						)
 						if len(section.Inputs) > 0 {
-							writer.WriteLine("")
+							writer.writeLine("")
 						}
 					case section.Attribute != nil:
 						printAttributes(writer, []*parser.AttributeNode{section.Attribute})
@@ -244,9 +126,9 @@ func printJob(writer *Writer, job *parser.JobNode) {
 }
 
 func printModel(writer *Writer, model *parser.ModelNode) {
-	writer.Comments(model, func() {
-		writer.Write("model %s", camel(model.Name.Value))
-		writer.Block(func() {
+	writer.comments(model, func() {
+		writer.write("model %s", camel(model.Name.Value))
+		writer.block(func() {
 
 			fieldSections := []*parser.ModelSectionNode{}
 			actionSections := []*parser.ModelSectionNode{}
@@ -268,9 +150,9 @@ func printModel(writer *Writer, model *parser.ModelNode) {
 
 			for _, section := range fieldSections {
 				fields := section.Fields
-				writer.Comments(section, func() {
-					writer.Write("fields")
-					writer.Block(func() {
+				writer.comments(section, func() {
+					writer.write("fields")
+					writer.block(func() {
 						for _, field := range fields {
 							if field.BuiltIn {
 								continue
@@ -285,15 +167,15 @@ func printModel(writer *Writer, model *parser.ModelNode) {
 								fieldType = camel(field.Type.Value)
 							}
 
-							if field.Optional {
-								fieldType += "?"
-							}
 							if field.Repeated {
 								fieldType += "[]"
 							}
+							if field.Optional {
+								fieldType += "?"
+							}
 
-							writer.Comments(field, func() {
-								writer.Write(
+							writer.comments(field, func() {
+								writer.write(
 									"%s %s",
 									lowerCamel(field.Name.Value),
 									fieldType,
@@ -311,7 +193,7 @@ func printModel(writer *Writer, model *parser.ModelNode) {
 								// attribute and no comments, otherwise the attributes
 								// get wrapper in a block
 								if len(field.Attributes) == 1 && !hasComments {
-									writer.Write(" ")
+									writer.write(" ")
 									printAttributes(writer, field.Attributes)
 								} else {
 									printAttributesBlock(writer, field.Attributes)
@@ -325,7 +207,7 @@ func printModel(writer *Writer, model *parser.ModelNode) {
 
 			for _, section := range actionSections {
 				if sections > 0 {
-					writer.WriteLine("")
+					writer.writeLine("")
 				}
 				printActionsBlock(writer, section)
 				sections++
@@ -333,9 +215,9 @@ func printModel(writer *Writer, model *parser.ModelNode) {
 
 			for _, section := range attributeSections {
 				if sections > 0 {
-					writer.WriteLine("")
+					writer.writeLine("")
 				}
-				writer.Comments(section, func() {
+				writer.comments(section, func() {
 					printAttributes(writer, []*parser.AttributeNode{section.Attribute})
 				})
 				sections++
@@ -345,18 +227,18 @@ func printModel(writer *Writer, model *parser.ModelNode) {
 }
 
 func printActionsBlock(writer *Writer, section *parser.ModelSectionNode) {
-	writer.Comments(section, func() {
+	writer.comments(section, func() {
 		actions := []*parser.ActionNode{}
 		if section.Actions != nil {
 			actions = section.Actions
-			writer.Write(parser.KeywordActions)
+			writer.write(parser.KeywordActions)
 		}
 
-		writer.Block(func() {
+		writer.block(func() {
 			for _, op := range actions {
 
-				writer.Comments(op, func() {
-					writer.Write(
+				writer.comments(op, func() {
+					writer.write(
 						"%s %s",
 						lowerCamel(op.Type.Value),
 						lowerCamel(op.Name.Value),
@@ -365,12 +247,12 @@ func printActionsBlock(writer *Writer, section *parser.ModelSectionNode) {
 					printActionInputs(writer, op.Inputs, op.IsArbitraryFunction())
 
 					if len(op.With) > 0 {
-						writer.Write(" with ")
+						writer.write(" with ")
 						printActionInputs(writer, op.With, op.IsArbitraryFunction())
 					}
 
 					if len(op.Returns) > 0 {
-						writer.Write(" returns ")
+						writer.write(" returns ")
 						printActionInputs(writer, op.Returns, op.IsArbitraryFunction())
 					}
 
@@ -382,8 +264,8 @@ func printActionsBlock(writer *Writer, section *parser.ModelSectionNode) {
 }
 
 func printActionInputs(writer *Writer, inputs []*parser.ActionInputNode, isArbitraryFunction bool) {
-	writer.Write("(")
-	writer.Indent()
+	writer.write("(")
+	writer.indent()
 
 	// If there any any comments in the action inputs then we need to print
 	// each input on it's own line, to allow space for the comments
@@ -393,7 +275,7 @@ func printActionInputs(writer *Writer, inputs []*parser.ActionInputNode, isArbit
 
 	// TODO: find a more generic way to do line-wrapping
 	if !isMultiline {
-		length := writer.LineLength()
+		length := writer.lineLength()
 		for _, arg := range inputs {
 			if arg.Label != nil {
 				length += len(arg.Label.Value)
@@ -418,69 +300,69 @@ func printActionInputs(writer *Writer, inputs []*parser.ActionInputNode, isArbit
 
 	for i, arg := range inputs {
 		if isMultiline {
-			writer.WriteLine("")
+			writer.writeLine("")
 		}
 
-		writer.Comments(arg, func() {
+		writer.comments(arg, func() {
 			if arg.Label != nil {
 				// explicit input
-				writer.Write("%s: %s", arg.Label.Value, arg.Type.Fragments[0].Fragment)
+				writer.write("%s: %s", arg.Label.Value, arg.Type.Fragments[0].Fragment)
 			} else {
 
 				// Note: not using arg.Type.ToString() here as we want to try
 				// and fix any casing issues
 				for i, fragment := range arg.Type.Fragments {
 					if i > 0 {
-						writer.Write(".")
+						writer.write(".")
 					}
 
 					// if its an arbitrary function, then we dont want to automatically lowercase the input names
 					if isArbitraryFunction {
-						writer.Write(fragment.Fragment)
+						writer.write(fragment.Fragment)
 					} else {
-						writer.Write(lowerCamel(fragment.Fragment))
+						writer.write(lowerCamel(fragment.Fragment))
 					}
 				}
 			}
 
 			if arg.Optional {
-				writer.Write("?")
+				writer.write("?")
 			}
 		})
 
 		if len(inputs) > 1 {
 			if isMultiline {
-				writer.Write(",")
+				writer.write(",")
 			} else if i < len(inputs)-1 {
-				writer.Write(", ")
+				writer.write(", ")
 			}
 		}
 	}
 
 	if isMultiline {
-		writer.WriteLine("")
+		writer.writeLine("")
 	}
 
-	writer.Dedent()
-	writer.Write(")")
+	writer.dedent()
+	writer.write(")")
 }
 
 func printRole(writer *Writer, role *parser.RoleNode) {
-	writer.Comments(role, func() {
+	writer.comments(role, func() {
 
-		writer.Write("role %s", camel(role.Name.Value))
-		writer.Block(func() {
+		writer.write("role %s", camel(role.Name.Value))
+		writer.block(func() {
 			sections := 0
 			// domains
 			for _, section := range role.Sections {
 				if len(section.Domains) > 0 {
 					sections++
-					writer.Comments(section, func() {
-						writer.Write("domains")
-						writer.Block((func() {
+					writer.comments(section, func() {
+						writer.write("domains")
+						writer.block((func() {
 							for _, domain := range section.Domains {
-								writer.Comments(domain, func() {
-									writer.WriteLine(domain.Domain)
+								writer.comments(domain, func() {
+									writer.writeLine(domain.Domain)
 								})
 							}
 						}))
@@ -492,14 +374,14 @@ func printRole(writer *Writer, role *parser.RoleNode) {
 			for _, section := range role.Sections {
 				if len(section.Emails) > 0 {
 					if sections > 0 {
-						writer.WriteLine("")
+						writer.writeLine("")
 					}
-					writer.Comments(section, func() {
-						writer.Write("emails")
-						writer.Block(func() {
+					writer.comments(section, func() {
+						writer.write("emails")
+						writer.block(func() {
 							for _, email := range section.Emails {
-								writer.Comments(email, func() {
-									writer.WriteLine(email.Email)
+								writer.comments(email, func() {
+									writer.writeLine(email.Email)
 								})
 							}
 						})
@@ -511,21 +393,21 @@ func printRole(writer *Writer, role *parser.RoleNode) {
 }
 
 func printApi(writer *Writer, api *parser.APINode) {
-	writer.Comments(api, func() {
-		writer.Write("api %s", camel(api.Name.Value))
-		writer.Block(func() {
+	writer.comments(api, func() {
+		writer.write("api %s", camel(api.Name.Value))
+		writer.block(func() {
 			for i, section := range api.Sections {
 				if i > 0 {
-					writer.WriteLine("")
+					writer.writeLine("")
 				}
-				writer.Comments(section, func() {
+				writer.comments(section, func() {
 					switch {
 					case len(section.Models) > 0:
-						writer.Write("models")
-						writer.Block(func() {
+						writer.write("models")
+						writer.block(func() {
 							for _, model := range section.Models {
-								writer.Comments(model, func() {
-									writer.WriteLine(camel(model.Name.Value))
+								writer.comments(model, func() {
+									writer.writeLine(camel(model.Name.Value))
 								})
 							}
 						})
@@ -540,62 +422,62 @@ func printApi(writer *Writer, api *parser.APINode) {
 
 func printAttributesBlock(writer *Writer, attributes []*parser.AttributeNode) {
 	if len(attributes) == 0 {
-		writer.WriteLine("")
+		writer.writeLine("")
 		return
 	}
 
 	if len(attributes) == 1 && attributes[0].Name.Value == parser.AttributeFunction {
-		writer.Write(" ")
+		writer.write(" ")
 		printAttributes(writer, attributes)
 
 		return
 	}
 
-	writer.Block(func() {
+	writer.block(func() {
 		printAttributes(writer, attributes)
 	})
 }
 
 func printAttributes(writer *Writer, attributes []*parser.AttributeNode) {
 	for _, attr := range attributes {
-		writer.Comments(attr, func() {
-			writer.Write("@%s", lowerCamel(attr.Name.Value))
+		writer.comments(attr, func() {
+			writer.write("@%s", lowerCamel(attr.Name.Value))
 
 			if len(attr.Arguments) > 0 {
-				writer.Write("(")
+				writer.write("(")
 
 				isMultiline := len(attr.Arguments) > 1
 				if isMultiline {
-					writer.WriteLine("")
-					writer.Indent()
+					writer.writeLine("")
+					writer.indent()
 				}
 
 				for i, arg := range attr.Arguments {
 					if i > 0 {
 						if isMultiline {
-							writer.WriteLine(",")
+							writer.writeLine(",")
 						} else {
-							writer.Write(", ")
+							writer.write(", ")
 						}
 					}
-					writer.Comments(arg, func() {
+					writer.comments(arg, func() {
 						if arg.Label != nil {
-							writer.Write("%s: ", lowerCamel(arg.Label.Value))
+							writer.write("%s: ", lowerCamel(arg.Label.Value))
 						}
 						expr, _ := arg.Expression.ToString()
-						writer.Write(expr)
+						writer.write(expr)
 					})
 				}
 
 				if isMultiline {
-					writer.WriteLine("")
-					writer.Dedent()
+					writer.writeLine("")
+					writer.dedent()
 				}
 
-				writer.Write(")")
+				writer.write(")")
 			}
 
-			writer.WriteLine("")
+			writer.writeLine("")
 		})
 	}
 }
@@ -623,12 +505,12 @@ func lowerCamel(s string) string {
 }
 
 func printEnum(writer *Writer, enum *parser.EnumNode) {
-	writer.Comments(enum, func() {
-		writer.Write("enum %s", camel(enum.Name.Value))
-		writer.Block(func() {
+	writer.comments(enum, func() {
+		writer.write("enum %s", camel(enum.Name.Value))
+		writer.block(func() {
 			for _, v := range enum.Values {
-				writer.Comments(v, func() {
-					writer.WriteLine(camel(v.Name.Value))
+				writer.comments(v, func() {
+					writer.writeLine(camel(v.Name.Value))
 				})
 			}
 		})

--- a/schema/format/testdata/repeated_field.txt
+++ b/schema/format/testdata/repeated_field.txt
@@ -1,6 +1,7 @@
 model Person {
     fields {
         faveColours Text[]
+    optionalColours Text[]?
     }
 }
 
@@ -9,5 +10,6 @@ model Person {
 model Person {
     fields {
         faveColours Text[]
+        optionalColours Text[]?
     }
 }

--- a/schema/format/writer.go
+++ b/schema/format/writer.go
@@ -1,0 +1,128 @@
+package format
+
+import (
+	"fmt"
+	"strings"
+	"text/scanner"
+
+	"github.com/alecthomas/participle/v2/lexer"
+	"github.com/samber/lo"
+	"github.com/teamkeel/keel/schema/node"
+)
+
+type Writer struct {
+	b          strings.Builder
+	currIndent int
+
+	// We keep a stack of comments as when ending a block
+	// we will print any trailing comments inside the closing
+	// paren
+	commentStack [][]lexer.Token
+
+	// We keep a cache of which comments we've already printed
+	// as the same comment tokens can appear on different nodes
+	commentCache map[string]bool
+}
+
+func (w *Writer) writeLine(s string) {
+	if w.isStartOfLine() && s != "" {
+		w.b.WriteString(strings.Repeat(" ", w.currIndent))
+	}
+	w.b.WriteString(fmt.Sprintf(s + "\n"))
+}
+
+func (w *Writer) write(s string, args ...any) {
+	if w.isStartOfLine() && s != "" {
+		w.b.WriteString(strings.Repeat(" ", w.currIndent))
+	}
+	w.b.WriteString(fmt.Sprintf(s, args...))
+}
+
+func (w *Writer) indent() {
+	w.currIndent += indentSize
+}
+
+func (w *Writer) dedent() {
+	w.currIndent -= indentSize
+	if w.currIndent < 0 {
+		w.currIndent = 0
+	}
+}
+
+func (w *Writer) block(fn func()) {
+	w.writeLine(" {")
+	w.indent()
+	fn()
+	if len(w.commentStack) > 0 {
+		tokens := w.commentStack[len(w.commentStack)-1]
+		w.trailingComments(tokens)
+	}
+	w.dedent()
+	w.writeLine("}")
+}
+
+func (w *Writer) lineLength() int {
+	s := w.b.String()
+	lines := strings.Split(s, "\n")
+	curr := lines[len(lines)-1]
+	return len(curr)
+}
+
+func (w *Writer) comments(node node.ParserNode, fn func()) {
+	tokens := node.GetTokens()
+	w.commentStack = append(w.commentStack, tokens)
+
+	w.leadingComments(tokens)
+	fn()
+	w.trailingComments(tokens)
+
+	w.commentStack = w.commentStack[0 : len(w.commentStack)-1]
+}
+
+func (w *Writer) leadingComments(tokens []lexer.Token) {
+	for _, t := range tokens {
+		if t.Type != scanner.Comment {
+			return
+		}
+		if !w.seenToken(t) {
+			w.writeLine(t.Value)
+		}
+	}
+}
+
+func (w *Writer) trailingComments(tokens []lexer.Token) {
+	comments := []lexer.Token{}
+	for i := len(tokens) - 1; i >= 0; i-- {
+		t := tokens[i]
+		if t.Type == '}' {
+			continue
+		}
+		if t.Type != scanner.Comment {
+			break
+		}
+		comments = append(comments, t)
+	}
+	for _, t := range lo.Reverse(comments) {
+		if !w.seenToken(t) {
+			w.writeLine(t.Value)
+		}
+	}
+}
+
+func (w *Writer) seenToken(t lexer.Token) bool {
+	key := fmt.Sprintf("%d:%d", t.Pos.Line, t.Pos.Column)
+	_, seen := w.commentCache[key]
+	if !seen {
+		w.commentCache[key] = true
+	}
+	return seen
+}
+
+func (w *Writer) string() string {
+	return w.b.String()
+}
+
+func (w *Writer) isStartOfLine() bool {
+	s := w.b.String()
+	return len(s) > 0 && s[len(s)-1] == '\n'
+}


### PR DESCRIPTION
Optional repeated fields, defined as `Type[]?` are automatically formatted to `Type?[]` which is not a valid definition. This PR addresses this issue by moving the optional `?` char after the array notation `[]`.

Also, this PR moves the writer structure in a new file and un-exports its methods as they are not used outside of the `format` package