### PR TITLE
feat: capture id token claims in identity

### DIFF
--- a/config/auth.go
+++ b/config/auth.go
@@ -43,9 +43,10 @@ var (
 )
 
 type AuthConfig struct {
-	Tokens      TokensConfig `yaml:"tokens"`
-	RedirectUrl *string      `yaml:"redirectUrl,omitempty"`
-	Providers   []Provider   `yaml:"providers"`
+	Tokens      TokensConfig    `yaml:"tokens"`
+	RedirectUrl *string         `yaml:"redirectUrl,omitempty"`
+	Providers   []Provider      `yaml:"providers"`
+	Claims      []IdentityClaim `yaml:"claims"`
 }
 
 type TokensConfig struct {
@@ -61,6 +62,11 @@ type Provider struct {
 	IssuerUrl        string `yaml:"issuerUrl"`
 	TokenUrl         string `yaml:"tokenUrl"`
 	AuthorizationUrl string `yaml:"authorizationUrl"`
+}
+
+type IdentityClaim struct {
+	Key   string `yaml:"key"`
+	Field string `yaml:"field"`
 }
 
 // AccessTokenExpiry retrieves the configured or default access token expiry

--- a/config/config.go
+++ b/config/config.go
@@ -15,9 +15,6 @@ import (
 
 const Empty = ""
 
-// Config is the configuration for the Keel runtime
-type Config struct{}
-
 // ProjectConfig is the configuration for a keel project
 type ProjectConfig struct {
 	Environment   EnvironmentConfig `yaml:"environment"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -355,3 +355,19 @@ func TestGetCallbackUrl_NoKeelApiUrl(t *testing.T) {
 	assert.ErrorContains(t, err, "empty url")
 	assert.Nil(t, url)
 }
+
+func TestAuthClaims(t *testing.T) {
+	config, err := Load("fixtures/test_auth_identity_claims.yaml")
+	assert.NoError(t, err)
+
+	assert.Equal(t, "https://slack.com/#team_ID", config.Auth.Claims[0].Key)
+	assert.Equal(t, "teamId", config.Auth.Claims[0].Field)
+	assert.Equal(t, "something-else", config.Auth.Claims[1].Key)
+	assert.Equal(t, "somethingElse", config.Auth.Claims[1].Field)
+}
+
+// TODO: field already exists on identity
+
+// TODO: field not correct format/casing
+
+// TODO: field or key already defined in config

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -365,9 +365,3 @@ func TestAuthClaims(t *testing.T) {
 	assert.Equal(t, "something-else", config.Auth.Claims[1].Key)
 	assert.Equal(t, "somethingElse", config.Auth.Claims[1].Field)
 }
-
-// TODO: field already exists on identity
-
-// TODO: field not correct format/casing
-
-// TODO: field or key already defined in config

--- a/config/fixtures/test_auth_identity_claims.yaml
+++ b/config/fixtures/test_auth_identity_claims.yaml
@@ -1,0 +1,11 @@
+auth:
+  providers:
+    - type: google
+      name: google
+      clientId: 1234
+
+  claims:
+    - key: https://slack.com/#team_ID
+      field: teamId
+    - key: something-else
+      field: somethingElse

--- a/config/fixtures/test_auth_invalid_auth_url.yaml
+++ b/config/fixtures/test_auth_invalid_auth_url.yaml
@@ -20,3 +20,9 @@ auth:
       name: missing-endpoint
       clientId: hfjuw983h1hfsdf
       tokenUrl: https://github.com/token
+
+  identityClaims:
+    - field: userId
+      claim: https://slack.com/user-id"
+    - field: teamId
+      claim: https://slack.com/team-id"

--- a/runtime/actions/query.go
+++ b/runtime/actions/query.go
@@ -78,7 +78,7 @@ func Null() *QueryOperand {
 }
 
 func ValueOrNullIfEmpty(value any) *QueryOperand {
-	if reflect.ValueOf(value).IsZero() {
+	if value == nil || reflect.ValueOf(value).IsZero() {
 		return Null()
 	}
 	return Value(value)
@@ -346,7 +346,7 @@ func (query *QueryBuilder) Copy() *QueryBuilder {
 
 // Includes a value to be written during an INSERT or UPDATE.
 func (query *QueryBuilder) AddWriteValue(operand *QueryOperand, value *QueryOperand) {
-
+	query.writeValues.model = query.Model
 	query.writeValues.values[operand.column] = value
 }
 

--- a/runtime/apis/authapi/authorize_endpoint.go
+++ b/runtime/apis/authapi/authorize_endpoint.go
@@ -220,10 +220,20 @@ func CallbackHandler(schema *proto.Schema) common.HandlerFunc {
 			return redirectErrResponse(ctx, redirectUrl, AuthorizationErrAccessDenied, "falied to verify ID token with OIDC provider", err)
 		}
 
-		// Extract claims
-		var claims oauth.IdTokenClaims
-		if err := idToken.Claims(&claims); err != nil {
+		// Extract standardClaims
+		var standardClaims oauth.IdTokenClaims
+		if err := idToken.Claims(&standardClaims); err != nil {
 			return redirectErrResponse(ctx, redirectUrl, AuthorizationErrServerError, "insufficient claims on id_token", err)
+		}
+
+		var claims map[string]any
+		if err := idToken.Claims(&claims); err != nil {
+			return common.InternalServerErrorResponse(ctx, err)
+		}
+
+		customClaims := map[string]any{}
+		for _, c := range config.Claims {
+			customClaims[c.Field] = claims[c.Key]
 		}
 
 		var identity *auth.Identity
@@ -233,12 +243,12 @@ func CallbackHandler(schema *proto.Schema) common.HandlerFunc {
 		}
 
 		if identity == nil {
-			identity, err = actions.CreateIdentityWithIdTokenClaims(ctx, schema, idToken.Subject, idToken.Issuer, claims)
+			identity, err = actions.CreateIdentityWithClaims(ctx, schema, idToken.Subject, idToken.Issuer, &standardClaims, customClaims)
 			if err != nil {
 				return common.InternalServerErrorResponse(ctx, err)
 			}
 		} else {
-			identity, err = actions.UpdateIdentityWithIdTokenClaims(ctx, schema, idToken.Subject, idToken.Issuer, claims)
+			identity, err = actions.UpdateIdentityWithClaims(ctx, schema, idToken.Subject, idToken.Issuer, &standardClaims, customClaims)
 			if err != nil {
 				return common.InternalServerErrorResponse(ctx, err)
 			}

--- a/runtime/apis/authapi/revoke_endpoint_test.go
+++ b/runtime/apis/authapi/revoke_endpoint_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestRevokeTokenForm_Success(t *testing.T) {
-	ctx, database, schema := keeltesting.MakeContext(t, authTestSchema, true)
+	ctx, database, schema := keeltesting.MakeContext(t, context.TODO(), authTestSchema, true)
 	defer database.Close()
 
 	// OIDC test server
@@ -75,7 +75,7 @@ func TestRevokeTokenForm_Success(t *testing.T) {
 }
 
 func TestRevokeTokenJson_Success(t *testing.T) {
-	ctx, database, schema := keeltesting.MakeContext(t, authTestSchema, true)
+	ctx, database, schema := keeltesting.MakeContext(t, context.TODO(), authTestSchema, true)
 	defer database.Close()
 
 	// OIDC test server
@@ -130,7 +130,7 @@ func TestRevokeTokenJson_Success(t *testing.T) {
 }
 
 func TestRevokeEndpoint_HttpGet(t *testing.T) {
-	ctx, database, schema := keeltesting.MakeContext(t, authTestSchema, true)
+	ctx, database, schema := keeltesting.MakeContext(t, context.TODO(), authTestSchema, true)
 	defer database.Close()
 
 	// Make a token exchange grant request
@@ -149,7 +149,7 @@ func TestRevokeEndpoint_HttpGet(t *testing.T) {
 }
 
 func TestRevokeEndpoint_EmptyToken(t *testing.T) {
-	ctx, database, schema := keeltesting.MakeContext(t, authTestSchema, true)
+	ctx, database, schema := keeltesting.MakeContext(t, context.TODO(), authTestSchema, true)
 	defer database.Close()
 
 	// Make a revoke request
@@ -169,7 +169,7 @@ func TestRevokeEndpoint_EmptyToken(t *testing.T) {
 }
 
 func TestRevokeEndpoint_NoToken(t *testing.T) {
-	ctx, database, schema := keeltesting.MakeContext(t, authTestSchema, true)
+	ctx, database, schema := keeltesting.MakeContext(t, context.TODO(), authTestSchema, true)
 	defer database.Close()
 
 	// Make a revoke request
@@ -189,7 +189,7 @@ func TestRevokeEndpoint_NoToken(t *testing.T) {
 }
 
 func TestRevokeEndpoint_UnknownToken(t *testing.T) {
-	ctx, database, schema := keeltesting.MakeContext(t, authTestSchema, true)
+	ctx, database, schema := keeltesting.MakeContext(t, context.TODO(), authTestSchema, true)
 	defer database.Close()
 
 	// Make a revoke request

--- a/runtime/oauth/auth_code_test.go
+++ b/runtime/oauth/auth_code_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestNewAuthCode_NotEmpty(t *testing.T) {
-	ctx, database, _ := keeltesting.MakeContext(t, authTestSchema, true)
+	ctx, database, _ := keeltesting.MakeContext(t, context.TODO(), authTestSchema, true)
 	defer database.Close()
 
 	code, err := oauth.NewAuthCode(ctx, "identity_id")
@@ -26,7 +26,7 @@ func TestNewAuthCode_ErrorOnEmptyIdentityId(t *testing.T) {
 }
 
 func TestConsumeAuthCode_Success(t *testing.T) {
-	ctx, database, _ := keeltesting.MakeContext(t, authTestSchema, true)
+	ctx, database, _ := keeltesting.MakeContext(t, context.TODO(), authTestSchema, true)
 	defer database.Close()
 
 	code, err := oauth.NewAuthCode(ctx, "identity_id")
@@ -39,7 +39,7 @@ func TestConsumeAuthCode_Success(t *testing.T) {
 }
 
 func TestConsumeAuthCode_DoesNotExist(t *testing.T) {
-	ctx, database, _ := keeltesting.MakeContext(t, authTestSchema, true)
+	ctx, database, _ := keeltesting.MakeContext(t, context.TODO(), authTestSchema, true)
 	defer database.Close()
 
 	isValid, identityId, err := oauth.ConsumeAuthCode(ctx, "notexists")
@@ -49,7 +49,7 @@ func TestConsumeAuthCode_DoesNotExist(t *testing.T) {
 }
 
 func TestConsumeAuthCode_AlreadyConsumed(t *testing.T) {
-	ctx, database, _ := keeltesting.MakeContext(t, authTestSchema, true)
+	ctx, database, _ := keeltesting.MakeContext(t, context.TODO(), authTestSchema, true)
 	defer database.Close()
 
 	code, err := oauth.NewAuthCode(ctx, "identity_id")

--- a/runtime/oauth/refresh_token_test.go
+++ b/runtime/oauth/refresh_token_test.go
@@ -15,7 +15,7 @@ import (
 var authTestSchema = `model Post{}`
 
 func TestNewRefreshToken_NotEmpty(t *testing.T) {
-	ctx, database, _ := keeltesting.MakeContext(t, authTestSchema, true)
+	ctx, database, _ := keeltesting.MakeContext(t, context.TODO(), authTestSchema, true)
 	defer database.Close()
 
 	refreshToken, err := oauth.NewRefreshToken(ctx, "identity_id")
@@ -31,7 +31,7 @@ func TestNewRefreshToken_ErrorOnEmptyIdentityId(t *testing.T) {
 }
 
 func TestRotateRefreshToken_Valid(t *testing.T) {
-	ctx, database, _ := keeltesting.MakeContext(t, authTestSchema, true)
+	ctx, database, _ := keeltesting.MakeContext(t, context.TODO(), authTestSchema, true)
 	defer database.Close()
 
 	refreshToken, err := oauth.NewRefreshToken(ctx, "identity_id")
@@ -52,7 +52,7 @@ func TestRotateRefreshToken_Valid(t *testing.T) {
 }
 
 func TestRotateRefreshToken_Expired(t *testing.T) {
-	ctx, database, _ := keeltesting.MakeContext(t, authTestSchema, true)
+	ctx, database, _ := keeltesting.MakeContext(t, context.TODO(), authTestSchema, true)
 	defer database.Close()
 
 	// Set up auth config
@@ -77,7 +77,7 @@ func TestRotateRefreshToken_Expired(t *testing.T) {
 }
 
 func TestRotateRefreshToken_ReuseRefreshTokenNotValid(t *testing.T) {
-	ctx, database, _ := keeltesting.MakeContext(t, authTestSchema, true)
+	ctx, database, _ := keeltesting.MakeContext(t, context.TODO(), authTestSchema, true)
 	defer database.Close()
 
 	refreshToken, err := oauth.NewRefreshToken(ctx, "identity_id")
@@ -97,7 +97,7 @@ func TestRotateRefreshToken_ReuseRefreshTokenNotValid(t *testing.T) {
 }
 
 func TestValidateRefreshToken_Valid(t *testing.T) {
-	ctx, database, _ := keeltesting.MakeContext(t, authTestSchema, true)
+	ctx, database, _ := keeltesting.MakeContext(t, context.TODO(), authTestSchema, true)
 	defer database.Close()
 
 	refreshToken, err := oauth.NewRefreshToken(ctx, "identity_id")
@@ -110,7 +110,7 @@ func TestValidateRefreshToken_Valid(t *testing.T) {
 }
 
 func TestValidateRefreshToken_Expired(t *testing.T) {
-	ctx, database, _ := keeltesting.MakeContext(t, authTestSchema, true)
+	ctx, database, _ := keeltesting.MakeContext(t, context.TODO(), authTestSchema, true)
 	defer database.Close()
 
 	// Set up auth config
@@ -134,7 +134,7 @@ func TestValidateRefreshToken_Expired(t *testing.T) {
 }
 
 func TestRevokeRefreshToken_Unauthorised(t *testing.T) {
-	ctx, database, _ := keeltesting.MakeContext(t, authTestSchema, true)
+	ctx, database, _ := keeltesting.MakeContext(t, context.TODO(), authTestSchema, true)
 	defer database.Close()
 
 	refreshToken, err := oauth.NewRefreshToken(ctx, "identity_id")
@@ -149,7 +149,7 @@ func TestRevokeRefreshToken_Unauthorised(t *testing.T) {
 }
 
 func TestRevokeRefreshToken_MultipleForIdentity(t *testing.T) {
-	ctx, database, _ := keeltesting.MakeContext(t, authTestSchema, true)
+	ctx, database, _ := keeltesting.MakeContext(t, context.TODO(), authTestSchema, true)
 	defer database.Close()
 
 	refreshToken1, err := oauth.NewRefreshToken(ctx, "identity_id")

--- a/runtime/runtime_audit_test.go
+++ b/runtime/runtime_audit_test.go
@@ -50,7 +50,7 @@ func withIdentity(t *testing.T, ctx context.Context, schema *proto.Schema) (cont
 }
 
 func TestAuditCreateAction(t *testing.T) {
-	ctx, database, schema := keeltesting.MakeContext(t, auditSchema, true)
+	ctx, database, schema := keeltesting.MakeContext(t, context.TODO(), auditSchema, true)
 	defer database.Close()
 	db := database.GetDB()
 
@@ -94,7 +94,7 @@ func TestAuditCreateAction(t *testing.T) {
 }
 
 func TestAuditNestedCreateAction(t *testing.T) {
-	ctx, database, schema := keeltesting.MakeContext(t, auditSchema, true)
+	ctx, database, schema := keeltesting.MakeContext(t, context.TODO(), auditSchema, true)
 	defer database.Close()
 	db := database.GetDB()
 
@@ -201,7 +201,7 @@ func TestAuditNestedCreateAction(t *testing.T) {
 }
 
 func TestAuditUpdateAction(t *testing.T) {
-	ctx, database, schema := keeltesting.MakeContext(t, auditSchema, true)
+	ctx, database, schema := keeltesting.MakeContext(t, context.TODO(), auditSchema, true)
 	defer database.Close()
 	db := database.GetDB()
 
@@ -259,7 +259,7 @@ func TestAuditUpdateAction(t *testing.T) {
 }
 
 func TestAuditDeleteAction(t *testing.T) {
-	ctx, database, schema := keeltesting.MakeContext(t, auditSchema, true)
+	ctx, database, schema := keeltesting.MakeContext(t, context.TODO(), auditSchema, true)
 	defer database.Close()
 	db := database.GetDB()
 
@@ -315,7 +315,7 @@ func TestAuditDeleteAction(t *testing.T) {
 }
 
 func TestAuditTablesWithOnlyIdentity(t *testing.T) {
-	ctx, database, schema := keeltesting.MakeContext(t, auditSchema, true)
+	ctx, database, schema := keeltesting.MakeContext(t, context.TODO(), auditSchema, true)
 	defer database.Close()
 	db := database.GetDB()
 
@@ -346,7 +346,7 @@ func TestAuditTablesWithOnlyIdentity(t *testing.T) {
 }
 
 func TestAuditTablesWithOnlyTracing(t *testing.T) {
-	ctx, database, schema := keeltesting.MakeContext(t, auditSchema, true)
+	ctx, database, schema := keeltesting.MakeContext(t, context.TODO(), auditSchema, true)
 	defer database.Close()
 	db := database.GetDB()
 
@@ -372,7 +372,7 @@ func TestAuditTablesWithOnlyTracing(t *testing.T) {
 }
 
 func TestAuditOnStatementExecuteWithoutResult(t *testing.T) {
-	ctx, database, schema := keeltesting.MakeContext(t, auditSchema, true)
+	ctx, database, schema := keeltesting.MakeContext(t, context.TODO(), auditSchema, true)
 	defer database.Close()
 	db := database.GetDB()
 
@@ -413,7 +413,7 @@ func TestAuditOnStatementExecuteWithoutResult(t *testing.T) {
 }
 
 func TestAuditFieldsAreDroppedOnCreate(t *testing.T) {
-	ctx, database, schema := keeltesting.MakeContext(t, auditSchema, true)
+	ctx, database, schema := keeltesting.MakeContext(t, context.TODO(), auditSchema, true)
 	defer database.Close()
 
 	ctx, _ = withIdentity(t, ctx, schema)
@@ -442,7 +442,7 @@ func TestAuditDatabaseMigration(t *testing.T) {
 			@permission(expression: true, actions: [create, update, delete])
 		}`
 
-	ctx, database, pSchema := keeltesting.MakeContext(t, keelSchema, true)
+	ctx, database, pSchema := keeltesting.MakeContext(t, context.TODO(), keelSchema, true)
 
 	create := proto.FindAction(pSchema, "createPerson")
 	_, _, err := actions.Execute(
@@ -464,7 +464,7 @@ func TestAuditDatabaseMigration(t *testing.T) {
 		}`
 
 	database.Close()
-	ctx, database, pSchema = keeltesting.MakeContext(t, updatedSchema, false)
+	ctx, database, pSchema = keeltesting.MakeContext(t, context.TODO(), updatedSchema, false)
 	db := database.GetDB()
 	defer database.Close()
 

--- a/runtime/runtime_events_test.go
+++ b/runtime/runtime_events_test.go
@@ -81,7 +81,7 @@ func (handler *EventHandler) HandleEvent(ctx context.Context, subscriber string,
 }
 
 func TestCreateEvent(t *testing.T) {
-	ctx, database, schema := keeltesting.MakeContext(t, eventsSchema, true)
+	ctx, database, schema := keeltesting.MakeContext(t, context.TODO(), eventsSchema, true)
 	defer database.Close()
 
 	ctx, identity := withIdentity(t, ctx, schema)
@@ -126,7 +126,7 @@ func TestCreateEvent(t *testing.T) {
 }
 
 func TestUpdateEvent(t *testing.T) {
-	ctx, database, schema := keeltesting.MakeContext(t, eventsSchema, true)
+	ctx, database, schema := keeltesting.MakeContext(t, context.TODO(), eventsSchema, true)
 	defer database.Close()
 
 	result, _, err := actions.Execute(
@@ -198,7 +198,7 @@ func TestUpdateEvent(t *testing.T) {
 }
 
 func TestDeleteEvent(t *testing.T) {
-	ctx, database, schema := keeltesting.MakeContext(t, eventsSchema, true)
+	ctx, database, schema := keeltesting.MakeContext(t, context.TODO(), eventsSchema, true)
 	defer database.Close()
 
 	result, _, err := actions.Execute(
@@ -259,7 +259,7 @@ func TestDeleteEvent(t *testing.T) {
 }
 
 func TestNoIdentityEvent(t *testing.T) {
-	ctx, database, schema := keeltesting.MakeContext(t, eventsSchema, true)
+	ctx, database, schema := keeltesting.MakeContext(t, context.TODO(), eventsSchema, true)
 	defer database.Close()
 
 	handler := NewEventHandler(t)
@@ -280,7 +280,7 @@ func TestNoIdentityEvent(t *testing.T) {
 }
 
 func TestNestedCreateEvent(t *testing.T) {
-	ctx, database, schema := keeltesting.MakeContext(t, eventsSchema, true)
+	ctx, database, schema := keeltesting.MakeContext(t, context.TODO(), eventsSchema, true)
 	defer database.Close()
 
 	ctx, _ = withIdentity(t, ctx, schema)
@@ -322,7 +322,7 @@ func TestNestedCreateEvent(t *testing.T) {
 }
 
 func TestMultipleEvents(t *testing.T) {
-	ctx, database, schema := keeltesting.MakeContext(t, eventsSchema, true)
+	ctx, database, schema := keeltesting.MakeContext(t, context.TODO(), eventsSchema, true)
 	defer database.Close()
 
 	ctx, _ = withIdentity(t, ctx, schema)
@@ -371,7 +371,7 @@ func TestMultipleEvents(t *testing.T) {
 }
 
 func TestAuditTableEventCreatedAtUpdated(t *testing.T) {
-	ctx, database, schema := keeltesting.MakeContext(t, eventsSchema, true)
+	ctx, database, schema := keeltesting.MakeContext(t, context.TODO(), eventsSchema, true)
 	defer database.Close()
 
 	handler := NewEventHandler(t)
@@ -410,7 +410,7 @@ func TestAuditTableEventCreatedAtUpdated(t *testing.T) {
 }
 
 func TestFailedEventHandling(t *testing.T) {
-	ctx, database, schema := keeltesting.MakeContext(t, eventsSchema, true)
+	ctx, database, schema := keeltesting.MakeContext(t, context.TODO(), eventsSchema, true)
 	defer database.Close()
 
 	ctx, err := events.WithEventHandler(ctx, func(ctx context.Context, subscriber string, event *events.Event, traceparent string) error {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -539,6 +539,21 @@ func (scm *Builder) insertIdentityModel(declarations *parser.AST, schemaFile *re
 		},
 	}
 
+	if scm.Config != nil {
+		for _, c := range scm.Config.Auth.Claims {
+			identityFields = append(identityFields, &parser.FieldNode{
+				BuiltIn: true,
+				Name: parser.NameNode{
+					Value: c.Field,
+				},
+				Type: parser.NameNode{
+					Value: parser.FieldTypeText,
+				},
+				Optional: true,
+			})
+		}
+	}
+
 	requestPasswordReset := &parser.ActionNode{
 		BuiltIn: true,
 		Type:    parser.NameNode{Value: parser.ActionTypeWrite},

--- a/schema/testdata/proto/action_inputs_in_both_query_and_with/proto.json
+++ b/schema/testdata/proto/action_inputs_in_both_query_and_with/proto.json
@@ -136,9 +136,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -175,9 +173,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -427,9 +423,7 @@
             "modelName": "Account",
             "fieldName": "username"
           },
-          "target": [
-            "username"
-          ]
+          "target": ["username"]
         }
       ]
     },
@@ -444,9 +438,7 @@
             "modelName": "Account",
             "fieldName": "name"
           },
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         },
         {
           "messageName": "UpdateAccountValues",
@@ -456,9 +448,7 @@
             "modelName": "Account",
             "fieldName": "username"
           },
-          "target": [
-            "username"
-          ]
+          "target": ["username"]
         },
         {
           "messageName": "UpdateAccountValues",
@@ -468,9 +458,7 @@
             "modelName": "Account",
             "fieldName": "isActive"
           },
-          "target": [
-            "isActive"
-          ]
+          "target": ["isActive"]
         }
       ]
     },
@@ -506,9 +494,7 @@
             "modelName": "Account",
             "fieldName": "username"
           },
-          "target": [
-            "username"
-          ]
+          "target": ["username"]
         },
         {
           "messageName": "UpdateAccount2Where",
@@ -518,9 +504,7 @@
             "modelName": "Account",
             "fieldName": "isActive"
           },
-          "target": [
-            "isActive"
-          ]
+          "target": ["isActive"]
         }
       ]
     },
@@ -535,9 +519,7 @@
             "modelName": "Account",
             "fieldName": "name"
           },
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         },
         {
           "messageName": "UpdateAccount2Values",
@@ -547,9 +529,7 @@
             "modelName": "Account",
             "fieldName": "username"
           },
-          "target": [
-            "username"
-          ]
+          "target": ["username"]
         },
         {
           "messageName": "UpdateAccount2Values",
@@ -559,9 +539,7 @@
             "modelName": "Account",
             "fieldName": "isActive"
           },
-          "target": [
-            "isActive"
-          ]
+          "target": ["isActive"]
         }
       ]
     },
@@ -597,10 +575,7 @@
             "modelName": "Identity",
             "fieldName": "id"
           },
-          "target": [
-            "identity",
-            "id"
-          ]
+          "target": ["identity", "id"]
         }
       ]
     },
@@ -628,10 +603,7 @@
             "modelName": "Identity",
             "fieldName": "id"
           },
-          "target": [
-            "identity",
-            "id"
-          ]
+          "target": ["identity", "id"]
         }
       ]
     },
@@ -668,10 +640,7 @@
             "fieldName": "email"
           },
           "nullable": true,
-          "target": [
-            "identity",
-            "email"
-          ]
+          "target": ["identity", "email"]
         },
         {
           "messageName": "UpdateAccount4Where",
@@ -682,10 +651,7 @@
             "fieldName": "issuer"
           },
           "nullable": true,
-          "target": [
-            "identity",
-            "issuer"
-          ]
+          "target": ["identity", "issuer"]
         }
       ]
     },
@@ -700,9 +666,7 @@
             "modelName": "Account",
             "fieldName": "email"
           },
-          "target": [
-            "email"
-          ]
+          "target": ["email"]
         }
       ]
     },
@@ -739,10 +703,7 @@
             "fieldName": "email"
           },
           "nullable": true,
-          "target": [
-            "identity",
-            "email"
-          ]
+          "target": ["identity", "email"]
         },
         {
           "messageName": "UpdateAccount5Where",
@@ -753,10 +714,7 @@
             "fieldName": "issuer"
           },
           "nullable": true,
-          "target": [
-            "identity",
-            "issuer"
-          ]
+          "target": ["identity", "issuer"]
         }
       ]
     },
@@ -785,10 +743,7 @@
             "fieldName": "email"
           },
           "nullable": true,
-          "target": [
-            "identity",
-            "email"
-          ]
+          "target": ["identity", "email"]
         }
       ]
     },

--- a/schema/testdata/proto/action_inputs_long_form/proto.json
+++ b/schema/testdata/proto/action_inputs_long_form/proto.json
@@ -92,9 +92,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -131,9 +129,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/action_inputs_with_empty/proto.json
+++ b/schema/testdata/proto/action_inputs_with_empty/proto.json
@@ -88,9 +88,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -127,9 +125,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -363,9 +359,7 @@
             "modelName": "Account",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },

--- a/schema/testdata/proto/action_inputs_with_omitted/proto.json
+++ b/schema/testdata/proto/action_inputs_with_omitted/proto.json
@@ -88,9 +88,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -127,9 +125,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -363,9 +359,7 @@
             "modelName": "Account",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },

--- a/schema/testdata/proto/apis_default_api_false/proto.json
+++ b/schema/testdata/proto/apis_default_api_false/proto.json
@@ -47,9 +47,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -86,9 +84,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/apis_default_api_model_with_no_actions/proto.json
+++ b/schema/testdata/proto/apis_default_api_model_with_no_actions/proto.json
@@ -47,9 +47,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -86,9 +84,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/apis_none_defined_and_default_api_false/proto.json
+++ b/schema/testdata/proto/apis_none_defined_and_default_api_false/proto.json
@@ -63,9 +63,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -102,9 +100,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -306,9 +302,7 @@
             "modelName": "Author",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -323,9 +317,7 @@
             "modelName": "Author",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     }

--- a/schema/testdata/proto/apis_none_defined_and_default_api_true/proto.json
+++ b/schema/testdata/proto/apis_none_defined_and_default_api_true/proto.json
@@ -63,9 +63,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -102,9 +100,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -335,9 +331,7 @@
             "modelName": "Author",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -352,9 +346,7 @@
             "modelName": "Author",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     }

--- a/schema/testdata/proto/apis_override_default_api_actions/proto.json
+++ b/schema/testdata/proto/apis_override_default_api_actions/proto.json
@@ -109,9 +109,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -148,9 +146,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -386,9 +382,7 @@
             "modelName": "Author",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -403,9 +397,7 @@
             "modelName": "Author",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -420,9 +412,7 @@
             "modelName": "Book",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     }

--- a/schema/testdata/proto/apis_override_default_api_models/proto.json
+++ b/schema/testdata/proto/apis_override_default_api_models/proto.json
@@ -109,9 +109,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -148,9 +146,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -370,9 +366,7 @@
             "modelName": "Author",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -387,9 +381,7 @@
             "modelName": "Author",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -404,9 +396,7 @@
             "modelName": "Book",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     }

--- a/schema/testdata/proto/apis_with_actions_specified/proto.json
+++ b/schema/testdata/proto/apis_with_actions_specified/proto.json
@@ -124,9 +124,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -163,9 +161,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -409,9 +405,7 @@
             "modelName": "Author",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -426,9 +420,7 @@
             "modelName": "Author",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -492,9 +484,7 @@
             "modelName": "Book",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     }

--- a/schema/testdata/proto/apis_without_actions_specified/proto.json
+++ b/schema/testdata/proto/apis_without_actions_specified/proto.json
@@ -102,9 +102,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -141,9 +139,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -413,9 +409,7 @@
             "modelName": "Foo",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -430,9 +424,7 @@
             "modelName": "Bar",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     }

--- a/schema/testdata/proto/arbitrary_function/proto.json
+++ b/schema/testdata/proto/arbitrary_function/proto.json
@@ -57,9 +57,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -96,9 +94,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/arbitrary_function_any_type/proto.json
+++ b/schema/testdata/proto/arbitrary_function_any_type/proto.json
@@ -57,9 +57,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -96,9 +94,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -338,9 +334,7 @@
             "modelName": "Person",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     }

--- a/schema/testdata/proto/arbitrary_function_inline_inputs/proto.json
+++ b/schema/testdata/proto/arbitrary_function_inline_inputs/proto.json
@@ -64,9 +64,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -103,9 +101,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -345,9 +341,7 @@
             "modelName": "Post",
             "fieldName": "name"
           },
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         },
         {
           "messageName": "GetPostInput",

--- a/schema/testdata/proto/arbitrary_function_no_inputs/proto.json
+++ b/schema/testdata/proto/arbitrary_function_no_inputs/proto.json
@@ -81,9 +81,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -120,9 +118,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/arbitrary_functions_any/proto.json
+++ b/schema/testdata/proto/arbitrary_functions_any/proto.json
@@ -65,9 +65,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -104,9 +102,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/array_fields/proto.json
+++ b/schema/testdata/proto/array_fields/proto.json
@@ -103,9 +103,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -142,9 +140,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -376,9 +372,7 @@
             "fieldName": "texts",
             "repeated": true
           },
-          "target": [
-            "texts"
-          ]
+          "target": ["texts"]
         },
         {
           "messageName": "CreateThingInput",
@@ -389,9 +383,7 @@
             "fieldName": "numbers",
             "repeated": true
           },
-          "target": [
-            "numbers"
-          ]
+          "target": ["numbers"]
         },
         {
           "messageName": "CreateThingInput",
@@ -402,9 +394,7 @@
             "fieldName": "booleans",
             "repeated": true
           },
-          "target": [
-            "booleans"
-          ]
+          "target": ["booleans"]
         },
         {
           "messageName": "CreateThingInput",
@@ -415,9 +405,7 @@
             "fieldName": "dates",
             "repeated": true
           },
-          "target": [
-            "dates"
-          ]
+          "target": ["dates"]
         },
         {
           "messageName": "CreateThingInput",
@@ -428,9 +416,7 @@
             "fieldName": "timestamps",
             "repeated": true
           },
-          "target": [
-            "timestamps"
-          ]
+          "target": ["timestamps"]
         }
       ]
     },
@@ -997,9 +983,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringArrayQueryInput"
           },
-          "target": [
-            "texts"
-          ]
+          "target": ["texts"]
         },
         {
           "messageName": "ListThingsWhere",
@@ -1008,9 +992,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "IntArrayQueryInput"
           },
-          "target": [
-            "numbers"
-          ]
+          "target": ["numbers"]
         },
         {
           "messageName": "ListThingsWhere",
@@ -1019,9 +1001,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "BooleanArrayQueryInput"
           },
-          "target": [
-            "booleans"
-          ]
+          "target": ["booleans"]
         },
         {
           "messageName": "ListThingsWhere",
@@ -1030,9 +1010,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "DateArrayQueryInput"
           },
-          "target": [
-            "dates"
-          ]
+          "target": ["dates"]
         },
         {
           "messageName": "ListThingsWhere",
@@ -1041,9 +1019,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "TimestampArrayQueryInput"
           },
-          "target": [
-            "timestamps"
-          ]
+          "target": ["timestamps"]
         }
       ]
     },

--- a/schema/testdata/proto/array_fields_default/proto.json
+++ b/schema/testdata/proto/array_fields_default/proto.json
@@ -136,9 +136,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -175,9 +173,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/array_fields_optional/proto.json
+++ b/schema/testdata/proto/array_fields_optional/proto.json
@@ -101,9 +101,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -140,9 +138,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -373,9 +369,7 @@
           },
           "optional": true,
           "nullable": true,
-          "target": [
-            "texts"
-          ]
+          "target": ["texts"]
         },
         {
           "messageName": "CreateThingInput",
@@ -388,9 +382,7 @@
           },
           "optional": true,
           "nullable": true,
-          "target": [
-            "numbers"
-          ]
+          "target": ["numbers"]
         },
         {
           "messageName": "CreateThingInput",
@@ -403,9 +395,7 @@
           },
           "optional": true,
           "nullable": true,
-          "target": [
-            "booleans"
-          ]
+          "target": ["booleans"]
         },
         {
           "messageName": "CreateThingInput",
@@ -418,9 +408,7 @@
           },
           "optional": true,
           "nullable": true,
-          "target": [
-            "dates"
-          ]
+          "target": ["dates"]
         },
         {
           "messageName": "CreateThingInput",
@@ -433,9 +421,7 @@
           },
           "optional": true,
           "nullable": true,
-          "target": [
-            "timestamps"
-          ]
+          "target": ["timestamps"]
         }
       ]
     }

--- a/schema/testdata/proto/array_fields_set/proto.json
+++ b/schema/testdata/proto/array_fields_set/proto.json
@@ -131,9 +131,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -170,9 +168,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/attribute_on/proto.json
+++ b/schema/testdata/proto/attribute_on/proto.json
@@ -112,9 +112,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -151,9 +149,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -372,9 +368,7 @@
       "name": "SendWelcomeMailEvent",
       "type": {
         "type": "TYPE_UNION",
-        "unionNames": [
-          "SendWelcomeMailMemberCreatedEvent"
-        ]
+        "unionNames": ["SendWelcomeMailMemberCreatedEvent"]
       }
     },
     {
@@ -724,9 +718,7 @@
       "name": "SendGoodbyeMailEvent",
       "type": {
         "type": "TYPE_UNION",
-        "unionNames": [
-          "SendGoodbyeMailMemberDeletedEvent"
-        ]
+        "unionNames": ["SendGoodbyeMailMemberDeletedEvent"]
       }
     },
     {
@@ -805,9 +797,7 @@
     {
       "name": "sendWelcomeMail",
       "inputMessageName": "SendWelcomeMailEvent",
-      "eventNames": [
-        "member.created"
-      ]
+      "eventNames": ["member.created"]
     },
     {
       "name": "verifyEmail",
@@ -822,9 +812,7 @@
     {
       "name": "sendGoodbyeMail",
       "inputMessageName": "SendGoodbyeMailEvent",
-      "eventNames": [
-        "member.deleted"
-      ]
+      "eventNames": ["member.deleted"]
     }
   ],
   "events": [

--- a/schema/testdata/proto/attribute_orderby/proto.json
+++ b/schema/testdata/proto/attribute_orderby/proto.json
@@ -80,9 +80,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -119,9 +117,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/attribute_sortable/proto.json
+++ b/schema/testdata/proto/attribute_sortable/proto.json
@@ -70,9 +70,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -109,9 +107,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/basics/proto.json
+++ b/schema/testdata/proto/basics/proto.json
@@ -54,9 +54,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -93,9 +91,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/create_inputs_missing_reln_valid/proto.json
+++ b/schema/testdata/proto/create_inputs_missing_reln_valid/proto.json
@@ -139,9 +139,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -178,9 +176,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -414,9 +410,7 @@
             "modelName": "Post",
             "fieldName": "content"
           },
-          "target": [
-            "content"
-          ]
+          "target": ["content"]
         },
         {
           "messageName": "CreatePostBInput",
@@ -439,10 +433,7 @@
             "modelName": "Author",
             "fieldName": "id"
           },
-          "target": [
-            "author",
-            "id"
-          ]
+          "target": ["author", "id"]
         }
       ]
     },
@@ -457,9 +448,7 @@
             "modelName": "Post",
             "fieldName": "content"
           },
-          "target": [
-            "content"
-          ]
+          "target": ["content"]
         },
         {
           "messageName": "CreatePostCInput",

--- a/schema/testdata/proto/default_zero/proto.json
+++ b/schema/testdata/proto/default_zero/proto.json
@@ -57,9 +57,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -96,9 +94,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/delete_action/proto.json
+++ b/schema/testdata/proto/delete_action/proto.json
@@ -56,9 +56,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -95,9 +93,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -325,9 +321,7 @@
             "modelName": "Person",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     }

--- a/schema/testdata/proto/delete_operation_unique_lookup_in_inputs/proto.json
+++ b/schema/testdata/proto/delete_operation_unique_lookup_in_inputs/proto.json
@@ -68,9 +68,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -107,9 +105,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -337,9 +333,7 @@
             "modelName": "MyModel",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     }

--- a/schema/testdata/proto/delete_operation_unique_lookup_in_wheres/proto.json
+++ b/schema/testdata/proto/delete_operation_unique_lookup_in_wheres/proto.json
@@ -79,9 +79,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -118,9 +116,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/empty_fields/proto.json
+++ b/schema/testdata/proto/empty_fields/proto.json
@@ -47,9 +47,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -86,9 +84,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/enum_default/proto.json
+++ b/schema/testdata/proto/enum_default/proto.json
@@ -60,9 +60,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -99,9 +97,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/enums/proto.json
+++ b/schema/testdata/proto/enums/proto.json
@@ -10,9 +10,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -49,9 +47,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/environment_variables/proto.json
+++ b/schema/testdata/proto/environment_variables/proto.json
@@ -42,9 +42,7 @@
           "expression": {
             "source": "ctx.env.FOO == \"d\""
           },
-          "actionTypes": [
-            "ACTION_TYPE_GET"
-          ]
+          "actionTypes": ["ACTION_TYPE_GET"]
         }
       ]
     },
@@ -58,9 +56,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -97,9 +93,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/expression_enum_field_comparison/proto.json
+++ b/schema/testdata/proto/expression_enum_field_comparison/proto.json
@@ -81,9 +81,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -120,9 +118,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -363,9 +359,7 @@
             "modelName": "Post",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     }

--- a/schema/testdata/proto/expression_enum_set/proto.json
+++ b/schema/testdata/proto/expression_enum_set/proto.json
@@ -69,9 +69,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -108,9 +106,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -351,9 +347,7 @@
             "modelName": "Post",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },

--- a/schema/testdata/proto/expression_identity_field_comparison/proto.json
+++ b/schema/testdata/proto/expression_identity_field_comparison/proto.json
@@ -230,9 +230,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -269,9 +267,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -505,9 +501,7 @@
             "modelName": "Post",
             "fieldName": "title"
           },
-          "target": [
-            "title"
-          ]
+          "target": ["title"]
         },
         {
           "messageName": "CreatePostInput",
@@ -540,10 +534,7 @@
             "modelName": "Publisher",
             "fieldName": "id"
           },
-          "target": [
-            "publisher",
-            "id"
-          ]
+          "target": ["publisher", "id"]
         }
       ]
     },
@@ -558,10 +549,7 @@
             "modelName": "Author",
             "fieldName": "id"
           },
-          "target": [
-            "owner",
-            "id"
-          ]
+          "target": ["owner", "id"]
         }
       ]
     }

--- a/schema/testdata/proto/expression_named_inputs/proto.json
+++ b/schema/testdata/proto/expression_named_inputs/proto.json
@@ -99,9 +99,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -138,9 +136,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -374,9 +370,7 @@
             "modelName": "Person",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         },
         {
           "messageName": "GetBobInput",
@@ -398,9 +392,7 @@
             "modelName": "Person",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         },
         {
           "messageName": "GetPersonInput",

--- a/schema/testdata/proto/expression_nullish_optional_comparison/proto.json
+++ b/schema/testdata/proto/expression_nullish_optional_comparison/proto.json
@@ -92,9 +92,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -131,9 +129,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/expressions/proto.json
+++ b/schema/testdata/proto/expressions/proto.json
@@ -139,9 +139,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -178,9 +176,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -469,9 +465,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         }
       ]
     },
@@ -531,9 +525,7 @@
             "modelName": "Person",
             "fieldName": "name"
           },
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         }
       ]
     },
@@ -548,9 +540,7 @@
             "modelName": "Person",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },

--- a/schema/testdata/proto/expressions_compare_model_operand/proto.json
+++ b/schema/testdata/proto/expressions_compare_model_operand/proto.json
@@ -148,9 +148,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -187,9 +185,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -440,9 +436,7 @@
             "modelName": "BankAccount",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     }

--- a/schema/testdata/proto/expressions_null_values/proto.json
+++ b/schema/testdata/proto/expressions_null_values/proto.json
@@ -81,9 +81,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -120,9 +118,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -353,9 +349,7 @@
             "modelName": "Post",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },

--- a/schema/testdata/proto/field_array_of_same_message_type/proto.json
+++ b/schema/testdata/proto/field_array_of_same_message_type/proto.json
@@ -57,9 +57,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -96,9 +94,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -354,9 +350,7 @@
             "modelName": "Person",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     }

--- a/schema/testdata/proto/field_optional_of_same_message_type/proto.json
+++ b/schema/testdata/proto/field_optional_of_same_message_type/proto.json
@@ -57,9 +57,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -96,9 +94,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -354,9 +350,7 @@
             "modelName": "Person",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     }

--- a/schema/testdata/proto/field_optional_of_same_model_type/proto.json
+++ b/schema/testdata/proto/field_optional_of_same_model_type/proto.json
@@ -89,9 +89,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -128,9 +126,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/fields_attributes/proto.json
+++ b/schema/testdata/proto/fields_attributes/proto.json
@@ -95,9 +95,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -134,9 +132,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/fields_names/proto.json
+++ b/schema/testdata/proto/fields_names/proto.json
@@ -61,9 +61,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -100,9 +98,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/fields_optional/proto.json
+++ b/schema/testdata/proto/fields_optional/proto.json
@@ -55,9 +55,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -94,9 +92,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/fields_types/proto.json
+++ b/schema/testdata/proto/fields_types/proto.json
@@ -117,9 +117,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -156,9 +154,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/functions_inputs/proto.json
+++ b/schema/testdata/proto/functions_inputs/proto.json
@@ -84,9 +84,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -123,9 +121,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -411,9 +407,7 @@
             "modelName": "Foo",
             "fieldName": "bar"
           },
-          "target": [
-            "bar"
-          ]
+          "target": ["bar"]
         }
       ]
     },
@@ -428,9 +422,7 @@
             "modelName": "Foo",
             "fieldName": "bar"
           },
-          "target": [
-            "bar"
-          ]
+          "target": ["bar"]
         },
         {
           "messageName": "OperationCInput",

--- a/schema/testdata/proto/get_operation_unique_lookup_in_inputs/proto.json
+++ b/schema/testdata/proto/get_operation_unique_lookup_in_inputs/proto.json
@@ -68,9 +68,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -107,9 +105,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -337,9 +333,7 @@
             "modelName": "MyModel",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     }

--- a/schema/testdata/proto/get_operation_unique_lookup_in_wheres/proto.json
+++ b/schema/testdata/proto/get_operation_unique_lookup_in_wheres/proto.json
@@ -79,9 +79,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -118,9 +116,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/identity_backlinks/proto.json
+++ b/schema/testdata/proto/identity_backlinks/proto.json
@@ -70,9 +70,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -109,9 +107,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/identity_backlinks_relation_attribute/proto.json
+++ b/schema/testdata/proto/identity_backlinks_relation_attribute/proto.json
@@ -93,9 +93,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -132,9 +130,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/identity_claims/keelconfig.yaml
+++ b/schema/testdata/proto/identity_claims/keelconfig.yaml
@@ -1,0 +1,6 @@
+auth:
+  claims: 
+    - key: myClaim
+      field: myCustomClaim
+    - key: https://slack.com/claims/#teamId
+      field: teamId1

--- a/schema/testdata/proto/identity_claims/proto.json
+++ b/schema/testdata/proto/identity_claims/proto.json
@@ -1,10 +1,10 @@
 {
   "models": [
     {
-      "name": "Foo",
+      "name": "Author",
       "fields": [
         {
-          "modelName": "Foo",
+          "modelName": "Author",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -16,7 +16,7 @@
           }
         },
         {
-          "modelName": "Foo",
+          "modelName": "Author",
           "name": "createdAt",
           "type": {
             "type": "TYPE_DATETIME"
@@ -26,7 +26,7 @@
           }
         },
         {
-          "modelName": "Foo",
+          "modelName": "Author",
           "name": "updatedAt",
           "type": {
             "type": "TYPE_DATETIME"
@@ -34,15 +34,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        }
-      ],
-      "actions": [
-        {
-          "modelName": "Foo",
-          "name": "operationA",
-          "type": "ACTION_TYPE_LIST",
-          "implementation": "ACTION_IMPLEMENTATION_AUTO",
-          "inputMessageName": "OperationAInput"
         }
       ]
     },
@@ -185,6 +176,22 @@
         },
         {
           "modelName": "Identity",
+          "name": "myCustomClaim",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Identity",
+          "name": "teamId1",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Identity",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -238,15 +245,18 @@
   ],
   "apis": [
     {
+      "name": "Admin",
+      "apiModels": [
+        {
+          "modelName": "Author"
+        }
+      ]
+    },
+    {
       "name": "Api",
       "apiModels": [
         {
-          "modelName": "Foo",
-          "modelActions": [
-            {
-              "actionName": "operationA"
-            }
-          ]
+          "modelName": "Author"
         },
         {
           "modelName": "Identity",
@@ -309,55 +319,6 @@
     },
     {
       "name": "ResetPasswordResponse"
-    },
-    {
-      "name": "OperationAWhere"
-    },
-    {
-      "name": "OperationAInput",
-      "fields": [
-        {
-          "messageName": "OperationAInput",
-          "name": "where",
-          "type": {
-            "type": "TYPE_MESSAGE",
-            "messageName": "OperationAWhere"
-          },
-          "optional": true
-        },
-        {
-          "messageName": "OperationAInput",
-          "name": "first",
-          "type": {
-            "type": "TYPE_INT"
-          },
-          "optional": true
-        },
-        {
-          "messageName": "OperationAInput",
-          "name": "after",
-          "type": {
-            "type": "TYPE_STRING"
-          },
-          "optional": true
-        },
-        {
-          "messageName": "OperationAInput",
-          "name": "last",
-          "type": {
-            "type": "TYPE_INT"
-          },
-          "optional": true
-        },
-        {
-          "messageName": "OperationAInput",
-          "name": "before",
-          "type": {
-            "type": "TYPE_STRING"
-          },
-          "optional": true
-        }
-      ]
     }
   ]
 }

--- a/schema/testdata/proto/identity_claims/schema.keel
+++ b/schema/testdata/proto/identity_claims/schema.keel
@@ -1,0 +1,7 @@
+model Author { }
+
+api Admin {
+	models {
+		Author
+	}
+}

--- a/schema/testdata/proto/job_adhoc/proto.json
+++ b/schema/testdata/proto/job_adhoc/proto.json
@@ -10,9 +10,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -49,9 +47,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -284,9 +280,7 @@
       "inputMessageName": "MyJobMessage",
       "permissions": [
         {
-          "roleNames": [
-            "Admin"
-          ]
+          "roleNames": ["Admin"]
         }
       ]
     }

--- a/schema/testdata/proto/job_fields/proto.json
+++ b/schema/testdata/proto/job_fields/proto.json
@@ -10,9 +10,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -49,9 +47,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -333,9 +329,7 @@
       "inputMessageName": "MyJobMessage",
       "permissions": [
         {
-          "roleNames": [
-            "Admin"
-          ]
+          "roleNames": ["Admin"]
         }
       ]
     }

--- a/schema/testdata/proto/job_permissions_expressions/proto.json
+++ b/schema/testdata/proto/job_permissions_expressions/proto.json
@@ -10,9 +10,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -49,9 +47,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -301,9 +297,7 @@
           }
         },
         {
-          "roleNames": [
-            "Admin"
-          ]
+          "roleNames": ["Admin"]
         }
       ]
     },
@@ -311,9 +305,7 @@
       "name": "MyJob4",
       "permissions": [
         {
-          "roleNames": [
-            "Admin"
-          ],
+          "roleNames": ["Admin"],
           "expression": {
             "source": "ctx.env.FOO == \"bar\""
           }

--- a/schema/testdata/proto/job_permissions_roles/proto.json
+++ b/schema/testdata/proto/job_permissions_roles/proto.json
@@ -10,9 +10,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -49,9 +47,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -197,9 +193,7 @@
   "roles": [
     {
       "name": "Admin",
-      "domains": [
-        "keel.so"
-      ]
+      "domains": ["keel.so"]
     },
     {
       "name": "Developer"
@@ -289,10 +283,7 @@
       "name": "MyManualJob",
       "permissions": [
         {
-          "roleNames": [
-            "Admin",
-            "Developer"
-          ]
+          "roleNames": ["Admin", "Developer"]
         }
       ]
     },
@@ -301,9 +292,7 @@
       "inputMessageName": "MyManualJobWithInputsMessage",
       "permissions": [
         {
-          "roleNames": [
-            "Admin"
-          ]
+          "roleNames": ["Admin"]
         }
       ]
     }

--- a/schema/testdata/proto/job_scheduled/proto.json
+++ b/schema/testdata/proto/job_scheduled/proto.json
@@ -10,9 +10,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -49,9 +47,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/message_enum_field/proto.json
+++ b/schema/testdata/proto/message_enum_field/proto.json
@@ -64,9 +64,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -103,9 +101,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/message_type/proto.json
+++ b/schema/testdata/proto/message_type/proto.json
@@ -64,9 +64,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -103,9 +101,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/message_type_nested_model/proto.json
+++ b/schema/testdata/proto/message_type_nested_model/proto.json
@@ -64,9 +64,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -103,9 +101,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/models_multiple/proto.json
+++ b/schema/testdata/proto/models_multiple/proto.json
@@ -84,9 +84,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -123,9 +121,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/models_permissions/proto.json
+++ b/schema/testdata/proto/models_permissions/proto.json
@@ -46,25 +46,16 @@
       "permissions": [
         {
           "modelName": "Foo",
-          "roleNames": [
-            "Admin"
-          ],
+          "roleNames": ["Admin"],
           "expression": {
             "source": "foo.f1 == true"
           },
-          "actionTypes": [
-            "ACTION_TYPE_LIST",
-            "ACTION_TYPE_GET"
-          ]
+          "actionTypes": ["ACTION_TYPE_LIST", "ACTION_TYPE_GET"]
         },
         {
           "modelName": "Foo",
-          "roleNames": [
-            "Restricted"
-          ],
-          "actionTypes": [
-            "ACTION_TYPE_UPDATE"
-          ]
+          "roleNames": ["Restricted"],
+          "actionTypes": ["ACTION_TYPE_UPDATE"]
         }
       ]
     },
@@ -78,9 +69,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -117,9 +106,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -265,15 +252,11 @@
   "roles": [
     {
       "name": "Admin",
-      "domains": [
-        "bar.com"
-      ]
+      "domains": ["bar.com"]
     },
     {
       "name": "Restricted",
-      "emails": [
-        "superuser@myorg.com"
-      ]
+      "emails": ["superuser@myorg.com"]
     }
   ],
   "apis": [

--- a/schema/testdata/proto/models_unique/proto.json
+++ b/schema/testdata/proto/models_unique/proto.json
@@ -9,9 +9,7 @@
           "type": {
             "type": "TYPE_STRING"
           },
-          "uniqueWith": [
-            "lastName"
-          ]
+          "uniqueWith": ["lastName"]
         },
         {
           "modelName": "Person",
@@ -19,9 +17,7 @@
           "type": {
             "type": "TYPE_STRING"
           },
-          "uniqueWith": [
-            "firstName"
-          ]
+          "uniqueWith": ["firstName"]
         },
         {
           "modelName": "Person",
@@ -67,9 +63,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -106,9 +100,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/operations_attr_set/proto.json
+++ b/schema/testdata/proto/operations_attr_set/proto.json
@@ -75,9 +75,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -114,9 +112,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -344,9 +340,7 @@
             "modelName": "Foo",
             "fieldName": "f2"
           },
-          "target": [
-            "f2"
-          ]
+          "target": ["f2"]
         }
       ]
     }

--- a/schema/testdata/proto/operations_attr_set_null/proto.json
+++ b/schema/testdata/proto/operations_attr_set_null/proto.json
@@ -80,9 +80,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -119,9 +117,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/operations_attr_validate/proto.json
+++ b/schema/testdata/proto/operations_attr_validate/proto.json
@@ -68,9 +68,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -107,9 +105,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -337,9 +333,7 @@
             "modelName": "Person",
             "fieldName": "name"
           },
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         }
       ]
     }

--- a/schema/testdata/proto/operations_attr_where/proto.json
+++ b/schema/testdata/proto/operations_attr_where/proto.json
@@ -69,9 +69,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -108,9 +106,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/operations_create_all_required_inputs/proto.json
+++ b/schema/testdata/proto/operations_create_all_required_inputs/proto.json
@@ -71,9 +71,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -110,9 +108,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -340,9 +336,7 @@
             "modelName": "Person",
             "fieldName": "name"
           },
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         }
       ]
     }

--- a/schema/testdata/proto/operations_create_mutate_id/proto.json
+++ b/schema/testdata/proto/operations_create_mutate_id/proto.json
@@ -75,9 +75,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -114,9 +112,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -347,9 +343,7 @@
             "modelName": "Person",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         },
         {
           "messageName": "CreatePersonInput",
@@ -359,9 +353,7 @@
             "modelName": "Person",
             "fieldName": "name"
           },
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         }
       ]
     },
@@ -383,9 +375,7 @@
             "modelName": "Person",
             "fieldName": "name"
           },
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         }
       ]
     }

--- a/schema/testdata/proto/operations_create_relationships/proto.json
+++ b/schema/testdata/proto/operations_create_relationships/proto.json
@@ -225,9 +225,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -264,9 +262,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -511,9 +507,7 @@
             "modelName": "Sale",
             "fieldName": "date"
           },
-          "target": [
-            "date"
-          ]
+          "target": ["date"]
         },
         {
           "messageName": "CreateSaleAndItemsInput",
@@ -545,10 +539,7 @@
             "modelName": "SaleItem",
             "fieldName": "quantity"
           },
-          "target": [
-            "items",
-            "quantity"
-          ]
+          "target": ["items", "quantity"]
         }
       ]
     },
@@ -563,11 +554,7 @@
             "modelName": "Product",
             "fieldName": "id"
           },
-          "target": [
-            "items",
-            "product",
-            "id"
-          ]
+          "target": ["items", "product", "id"]
         }
       ]
     },
@@ -582,9 +569,7 @@
             "modelName": "Sale",
             "fieldName": "date"
           },
-          "target": [
-            "date"
-          ]
+          "target": ["date"]
         },
         {
           "messageName": "CreateSaleAndProductInput",
@@ -616,10 +601,7 @@
             "modelName": "SaleItem",
             "fieldName": "quantity"
           },
-          "target": [
-            "items",
-            "quantity"
-          ]
+          "target": ["items", "quantity"]
         }
       ]
     },
@@ -634,11 +616,7 @@
             "modelName": "Product",
             "fieldName": "name"
           },
-          "target": [
-            "items",
-            "product",
-            "name"
-          ]
+          "target": ["items", "product", "name"]
         }
       ]
     },
@@ -669,9 +647,7 @@
             "modelName": "SaleItem",
             "fieldName": "quantity"
           },
-          "target": [
-            "quantity"
-          ]
+          "target": ["quantity"]
         }
       ]
     },
@@ -686,10 +662,7 @@
             "modelName": "Sale",
             "fieldName": "id"
           },
-          "target": [
-            "sale",
-            "id"
-          ]
+          "target": ["sale", "id"]
         }
       ]
     },
@@ -704,10 +677,7 @@
             "modelName": "Product",
             "fieldName": "id"
           },
-          "target": [
-            "product",
-            "id"
-          ]
+          "target": ["product", "id"]
         }
       ]
     },
@@ -738,9 +708,7 @@
             "modelName": "SaleItem",
             "fieldName": "quantity"
           },
-          "target": [
-            "quantity"
-          ]
+          "target": ["quantity"]
         }
       ]
     },
@@ -755,10 +723,7 @@
             "modelName": "Sale",
             "fieldName": "id"
           },
-          "target": [
-            "sale",
-            "id"
-          ]
+          "target": ["sale", "id"]
         }
       ]
     },
@@ -773,10 +738,7 @@
             "modelName": "Product",
             "fieldName": "name"
           },
-          "target": [
-            "product",
-            "name"
-          ]
+          "target": ["product", "name"]
         }
       ]
     }

--- a/schema/testdata/proto/operations_get_unique_input/proto.json
+++ b/schema/testdata/proto/operations_get_unique_input/proto.json
@@ -56,9 +56,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -95,9 +93,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -325,9 +321,7 @@
             "modelName": "MyModel",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     }

--- a/schema/testdata/proto/operations_get_unique_where/proto.json
+++ b/schema/testdata/proto/operations_get_unique_where/proto.json
@@ -69,9 +69,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -108,9 +106,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/operations_inputs/proto.json
+++ b/schema/testdata/proto/operations_inputs/proto.json
@@ -91,9 +91,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -130,9 +128,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -369,9 +365,7 @@
             "modelName": "Foo",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -505,9 +499,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": [
-            "f1"
-          ]
+          "target": ["f1"]
         },
         {
           "messageName": "OpBWhere",
@@ -516,9 +508,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "IntQueryInput"
           },
-          "target": [
-            "f2"
-          ]
+          "target": ["f2"]
         }
       ]
     },
@@ -578,9 +568,7 @@
             "modelName": "Foo",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -595,9 +583,7 @@
             "modelName": "Foo",
             "fieldName": "f1"
           },
-          "target": [
-            "f1"
-          ]
+          "target": ["f1"]
         }
       ]
     },
@@ -633,9 +619,7 @@
             "modelName": "Foo",
             "fieldName": "f1"
           },
-          "target": [
-            "f1"
-          ]
+          "target": ["f1"]
         },
         {
           "messageName": "OpDInput",
@@ -645,9 +629,7 @@
             "modelName": "Foo",
             "fieldName": "f2"
           },
-          "target": [
-            "f2"
-          ]
+          "target": ["f2"]
         }
       ]
     }

--- a/schema/testdata/proto/operations_list_nested_input_optional_model/proto.json
+++ b/schema/testdata/proto/operations_list_nested_input_optional_model/proto.json
@@ -201,9 +201,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -240,9 +238,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -488,11 +484,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": [
-            "author",
-            "publisher",
-            "name"
-          ]
+          "target": ["author", "publisher", "name"]
         }
       ]
     },

--- a/schema/testdata/proto/operations_multiple/proto.json
+++ b/schema/testdata/proto/operations_multiple/proto.json
@@ -63,9 +63,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -102,9 +100,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/operations_nested_model_input/proto.json
+++ b/schema/testdata/proto/operations_nested_model_input/proto.json
@@ -283,9 +283,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -322,9 +320,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -591,12 +587,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": [
-            "theFi",
-            "theFo",
-            "theFum",
-            "theName"
-          ]
+          "target": ["theFi", "theFo", "theFum", "theName"]
         }
       ]
     },
@@ -750,12 +741,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": [
-            "theFos",
-            "theFis",
-            "theFees",
-            "theName"
-          ]
+          "target": ["theFos", "theFis", "theFees", "theName"]
         }
       ]
     },

--- a/schema/testdata/proto/operations_permissions/proto.json
+++ b/schema/testdata/proto/operations_permissions/proto.json
@@ -53,9 +53,7 @@
             {
               "modelName": "Foo",
               "actionName": "opA",
-              "roleNames": [
-                "Admin"
-              ],
+              "roleNames": ["Admin"],
               "expression": {
                 "source": "foo.f1 == true"
               }
@@ -63,9 +61,7 @@
             {
               "modelName": "Foo",
               "actionName": "opA",
-              "roleNames": [
-                "Restricted"
-              ]
+              "roleNames": ["Restricted"]
             }
           ],
           "inputMessageName": "OpAInput"
@@ -82,9 +78,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -121,9 +115,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -269,15 +261,11 @@
   "roles": [
     {
       "name": "Admin",
-      "domains": [
-        "myorg.com"
-      ]
+      "domains": ["myorg.com"]
     },
     {
       "name": "Restricted",
-      "emails": [
-        "superuser@myorg.com"
-      ]
+      "emails": ["superuser@myorg.com"]
     }
   ],
   "apis": [

--- a/schema/testdata/proto/operations_types/proto.json
+++ b/schema/testdata/proto/operations_types/proto.json
@@ -85,9 +85,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -124,9 +122,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -366,9 +362,7 @@
             "modelName": "Foo",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -384,9 +378,7 @@
             "fieldName": "name"
           },
           "nullable": true,
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         }
       ]
     },
@@ -422,9 +414,7 @@
             "modelName": "Foo",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },

--- a/schema/testdata/proto/operations_update_mutate_id/proto.json
+++ b/schema/testdata/proto/operations_update_mutate_id/proto.json
@@ -169,9 +169,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -208,9 +206,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -450,9 +446,7 @@
             "modelName": "Person",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -467,9 +461,7 @@
             "modelName": "Person",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         },
         {
           "messageName": "UpdatePersonValues",
@@ -479,9 +471,7 @@
             "modelName": "Person",
             "fieldName": "name"
           },
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         }
       ]
     },
@@ -517,9 +507,7 @@
             "modelName": "Person",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -567,9 +555,7 @@
             "modelName": "Person",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -597,10 +583,7 @@
             "modelName": "Company",
             "fieldName": "id"
           },
-          "target": [
-            "employer",
-            "id"
-          ]
+          "target": ["employer", "id"]
         }
       ]
     },
@@ -636,9 +619,7 @@
             "modelName": "Person",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },

--- a/schema/testdata/proto/optional_inputs/proto.json
+++ b/schema/testdata/proto/optional_inputs/proto.json
@@ -85,9 +85,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -124,9 +122,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -360,9 +356,7 @@
             "modelName": "Person",
             "fieldName": "name"
           },
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         },
         {
           "messageName": "CreatePersonInput",
@@ -373,9 +367,7 @@
             "fieldName": "preferredName"
           },
           "nullable": true,
-          "target": [
-            "preferredName"
-          ]
+          "target": ["preferredName"]
         }
       ]
     },
@@ -390,9 +382,7 @@
             "modelName": "Person",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -407,9 +397,7 @@
             "modelName": "Person",
             "fieldName": "name"
           },
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         },
         {
           "messageName": "UpdatePersonValues",
@@ -420,9 +408,7 @@
             "fieldName": "preferredName"
           },
           "nullable": true,
-          "target": [
-            "preferredName"
-          ]
+          "target": ["preferredName"]
         }
       ]
     },
@@ -513,9 +499,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         },
         {
           "messageName": "ListPersonWhere",
@@ -524,9 +508,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": [
-            "preferredName"
-          ]
+          "target": ["preferredName"]
         }
       ]
     },

--- a/schema/testdata/proto/optional_nested_input/proto.json
+++ b/schema/testdata/proto/optional_nested_input/proto.json
@@ -171,9 +171,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -210,9 +208,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -448,10 +444,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": [
-            "company",
-            "name"
-          ]
+          "target": ["company", "name"]
         },
         {
           "messageName": "ListByCompanyCompanyInput",
@@ -460,10 +453,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": [
-            "company",
-            "tradingAs"
-          ]
+          "target": ["company", "tradingAs"]
         }
       ]
     },
@@ -591,10 +581,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": [
-            "previousCompany",
-            "name"
-          ]
+          "target": ["previousCompany", "name"]
         },
         {
           "messageName": "ListByPreviousCompanyPreviousCompanyInput",
@@ -603,10 +590,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": [
-            "previousCompany",
-            "tradingAs"
-          ]
+          "target": ["previousCompany", "tradingAs"]
         }
       ]
     },
@@ -679,10 +663,7 @@
             "messageName": "StringQueryInput"
           },
           "optional": true,
-          "target": [
-            "company",
-            "name"
-          ]
+          "target": ["company", "name"]
         },
         {
           "messageName": "ListByCompanyOptionalInputsCompanyInput",
@@ -692,10 +673,7 @@
             "messageName": "StringQueryInput"
           },
           "optional": true,
-          "target": [
-            "company",
-            "tradingAs"
-          ]
+          "target": ["company", "tradingAs"]
         }
       ]
     },

--- a/schema/testdata/proto/permission_expression_with_identity/proto.json
+++ b/schema/testdata/proto/permission_expression_with_identity/proto.json
@@ -81,9 +81,7 @@
           "expression": {
             "source": "account.identity == ctx.identity"
           },
-          "actionTypes": [
-            "ACTION_TYPE_CREATE"
-          ]
+          "actionTypes": ["ACTION_TYPE_CREATE"]
         }
       ]
     },
@@ -97,9 +95,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -136,9 +132,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relations_both_sides/proto.json
+++ b/schema/testdata/proto/relations_both_sides/proto.json
@@ -115,9 +115,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -154,9 +152,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relations_multi_uses_reln_attribute/proto.json
+++ b/schema/testdata/proto/relations_multi_uses_reln_attribute/proto.json
@@ -177,9 +177,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -216,9 +214,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relations_single/proto.json
+++ b/schema/testdata/proto/relations_single/proto.json
@@ -104,9 +104,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -143,9 +141,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_create_with_explicit_input/proto.json
+++ b/schema/testdata/proto/relationships_create_with_explicit_input/proto.json
@@ -184,9 +184,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -223,9 +221,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -462,9 +458,7 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": [
-            "isActive"
-          ]
+          "target": ["isActive"]
         },
         {
           "messageName": "CreateChild1Input",
@@ -486,9 +480,7 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": [
-            "isActive"
-          ]
+          "target": ["isActive"]
         },
         {
           "messageName": "CreateChild2Input",
@@ -510,9 +502,7 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": [
-            "isActive"
-          ]
+          "target": ["isActive"]
         },
         {
           "messageName": "CreateChild3Input",

--- a/schema/testdata/proto/relationships_create_with_implicit_input/proto.json
+++ b/schema/testdata/proto/relationships_create_with_implicit_input/proto.json
@@ -156,9 +156,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -195,9 +193,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -431,9 +427,7 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": [
-            "isActive"
-          ]
+          "target": ["isActive"]
         },
         {
           "messageName": "CreateChild1Input",
@@ -456,10 +450,7 @@
             "modelName": "ParentModel",
             "fieldName": "id"
           },
-          "target": [
-            "parent",
-            "id"
-          ]
+          "target": ["parent", "id"]
         }
       ]
     },
@@ -474,9 +465,7 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": [
-            "isActive"
-          ]
+          "target": ["isActive"]
         },
         {
           "messageName": "CreateChild2Input",
@@ -508,10 +497,7 @@
             "modelName": "ParentModel",
             "fieldName": "id"
           },
-          "target": [
-            "parent",
-            "id"
-          ]
+          "target": ["parent", "id"]
         }
       ]
     },
@@ -526,10 +512,7 @@
             "modelName": "ParentModel",
             "fieldName": "id"
           },
-          "target": [
-            "parentOptional",
-            "id"
-          ]
+          "target": ["parentOptional", "id"]
         }
       ]
     }

--- a/schema/testdata/proto/relationships_mixed/proto.json
+++ b/schema/testdata/proto/relationships_mixed/proto.json
@@ -168,9 +168,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -207,9 +205,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_mixed_one_to_many_single_sided/proto.json
+++ b/schema/testdata/proto/relationships_mixed_one_to_many_single_sided/proto.json
@@ -167,9 +167,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -206,9 +204,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_mixed_one_to_one_single_sided/proto.json
+++ b/schema/testdata/proto/relationships_mixed_one_to_one_single_sided/proto.json
@@ -168,9 +168,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -207,9 +205,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_mixed_one_to_one_single_sided_2/proto.json
+++ b/schema/testdata/proto/relationships_mixed_one_to_one_single_sided_2/proto.json
@@ -168,9 +168,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -207,9 +205,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_mixed_with_self_relationship/proto.json
+++ b/schema/testdata/proto/relationships_mixed_with_self_relationship/proto.json
@@ -182,9 +182,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -221,9 +219,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_many_multi_one_sided/proto.json
+++ b/schema/testdata/proto/relationships_one_to_many_multi_one_sided/proto.json
@@ -124,9 +124,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -163,9 +161,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_many_multi_one_sided_same_side/proto.json
+++ b/schema/testdata/proto/relationships_one_to_many_multi_one_sided_same_side/proto.json
@@ -124,9 +124,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -163,9 +161,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_many_single_sided_multiple/proto.json
+++ b/schema/testdata/proto/relationships_one_to_many_single_sided_multiple/proto.json
@@ -164,9 +164,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -203,9 +201,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_one/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one/proto.json
@@ -122,9 +122,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -161,9 +159,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -407,10 +403,7 @@
             "modelName": "CompanyProfile",
             "fieldName": "employeeCount"
           },
-          "target": [
-            "profile",
-            "employeeCount"
-          ]
+          "target": ["profile", "employeeCount"]
         }
       ]
     }

--- a/schema/testdata/proto/relationships_one_to_one_both_directions/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one_both_directions/proto.json
@@ -148,9 +148,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -187,9 +185,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_one_both_directions_missing_relation_attribute/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one_both_directions_missing_relation_attribute/proto.json
@@ -148,9 +148,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -187,9 +185,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_one_both_directions_no_relation_attribute/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one_both_directions_no_relation_attribute/proto.json
@@ -148,9 +148,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -187,9 +185,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_one_both_sides/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one_both_sides/proto.json
@@ -132,9 +132,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -171,9 +169,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -417,10 +413,7 @@
             "modelName": "CompanyProfile",
             "fieldName": "employeeCount"
           },
-          "target": [
-            "profile",
-            "employeeCount"
-          ]
+          "target": ["profile", "employeeCount"]
         }
       ]
     }

--- a/schema/testdata/proto/relationships_one_to_one_missing_reln/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one_missing_reln/proto.json
@@ -148,9 +148,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -187,9 +185,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_one_multi_layered/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one_multi_layered/proto.json
@@ -235,9 +235,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -274,9 +272,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -520,9 +516,7 @@
             "modelName": "Company",
             "fieldName": "name"
           },
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         },
         {
           "messageName": "CreateCompanyInput",
@@ -545,10 +539,7 @@
             "modelName": "CompanyProfile",
             "fieldName": "employeeCount"
           },
-          "target": [
-            "companyProfile",
-            "employeeCount"
-          ]
+          "target": ["companyProfile", "employeeCount"]
         },
         {
           "messageName": "CreateCompanyCompanyProfileInput",
@@ -572,11 +563,7 @@
             "modelName": "TaxProfile",
             "fieldName": "taxNumber"
           },
-          "target": [
-            "companyProfile",
-            "taxProfile",
-            "taxNumber"
-          ]
+          "target": ["companyProfile", "taxProfile", "taxNumber"]
         }
       ]
     },
@@ -590,10 +577,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "IdQueryInput"
           },
-          "target": [
-            "company",
-            "id"
-          ]
+          "target": ["company", "id"]
         }
       ]
     },
@@ -710,11 +694,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "IdQueryInput"
           },
-          "target": [
-            "companyProfile",
-            "company",
-            "id"
-          ]
+          "target": ["companyProfile", "company", "id"]
         }
       ]
     },

--- a/schema/testdata/proto/relationships_one_to_one_unique_both_sides/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one_unique_both_sides/proto.json
@@ -128,9 +128,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -167,9 +165,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_one_with_unique/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one_with_unique/proto.json
@@ -140,9 +140,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -179,9 +177,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_self_referencing_multiple/proto.json
+++ b/schema/testdata/proto/relationships_self_referencing_multiple/proto.json
@@ -113,9 +113,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -152,9 +150,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_self_referencing_no_reln_attribute/proto.json
+++ b/schema/testdata/proto/relationships_self_referencing_no_reln_attribute/proto.json
@@ -150,9 +150,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -189,9 +187,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_self_referencing_uses_reln_attribute/proto.json
+++ b/schema/testdata/proto/relationships_self_referencing_uses_reln_attribute/proto.json
@@ -150,9 +150,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -189,9 +187,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_update_with_explicit_input/proto.json
+++ b/schema/testdata/proto/relationships_update_with_explicit_input/proto.json
@@ -184,9 +184,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -223,9 +221,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -462,9 +458,7 @@
             "modelName": "ChildModel",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -479,9 +473,7 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": [
-            "isActive"
-          ]
+          "target": ["isActive"]
         },
         {
           "messageName": "UpdateChild1Values",
@@ -524,9 +516,7 @@
             "modelName": "ChildModel",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -541,9 +531,7 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": [
-            "isActive"
-          ]
+          "target": ["isActive"]
         },
         {
           "messageName": "UpdateChild2Values",
@@ -586,9 +574,7 @@
             "modelName": "ChildModel",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -603,9 +589,7 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": [
-            "isActive"
-          ]
+          "target": ["isActive"]
         },
         {
           "messageName": "UpdateChild3Values",

--- a/schema/testdata/proto/relationships_update_with_implicit_input/proto.json
+++ b/schema/testdata/proto/relationships_update_with_implicit_input/proto.json
@@ -170,9 +170,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -209,9 +207,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -451,9 +447,7 @@
             "modelName": "ChildModel",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -468,9 +462,7 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": [
-            "isActive"
-          ]
+          "target": ["isActive"]
         },
         {
           "messageName": "UpdateChild1Values",
@@ -493,10 +485,7 @@
             "modelName": "ParentModel",
             "fieldName": "id"
           },
-          "target": [
-            "parent",
-            "id"
-          ]
+          "target": ["parent", "id"]
         }
       ]
     },
@@ -532,9 +521,7 @@
             "modelName": "ChildModel",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -549,9 +536,7 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": [
-            "isActive"
-          ]
+          "target": ["isActive"]
         },
         {
           "messageName": "UpdateChild2Values",
@@ -561,9 +546,7 @@
             "modelName": "ChildModel",
             "fieldName": "parentId"
           },
-          "target": [
-            "parentId"
-          ]
+          "target": ["parentId"]
         }
       ]
     },
@@ -599,9 +582,7 @@
             "modelName": "ChildModel",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -616,9 +597,7 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": [
-            "isActive"
-          ]
+          "target": ["isActive"]
         },
         {
           "messageName": "UpdateChild3Values",
@@ -650,10 +629,7 @@
             "modelName": "ParentModel",
             "fieldName": "id"
           },
-          "target": [
-            "parent",
-            "id"
-          ]
+          "target": ["parent", "id"]
         }
       ]
     },
@@ -668,10 +644,7 @@
             "modelName": "ParentModel",
             "fieldName": "id"
           },
-          "target": [
-            "parentOptional",
-            "id"
-          ]
+          "target": ["parentOptional", "id"]
         }
       ]
     },
@@ -707,9 +680,7 @@
             "modelName": "ChildModel",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -724,9 +695,7 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": [
-            "isActive"
-          ]
+          "target": ["isActive"]
         },
         {
           "messageName": "UpdateChild4Values",
@@ -736,9 +705,7 @@
             "modelName": "ChildModel",
             "fieldName": "parentId"
           },
-          "target": [
-            "parentId"
-          ]
+          "target": ["parentId"]
         },
         {
           "messageName": "UpdateChild4Values",
@@ -749,9 +716,7 @@
             "fieldName": "parentOptionalId"
           },
           "nullable": true,
-          "target": [
-            "parentOptionalId"
-          ]
+          "target": ["parentOptionalId"]
         }
       ]
     },

--- a/schema/testdata/proto/request_headers_expression/proto.json
+++ b/schema/testdata/proto/request_headers_expression/proto.json
@@ -68,9 +68,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -107,9 +105,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/roles/proto.json
+++ b/schema/testdata/proto/roles/proto.json
@@ -10,9 +10,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -49,9 +47,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -197,14 +193,8 @@
   "roles": [
     {
       "name": "Admin",
-      "domains": [
-        "domain1.com",
-        "domain2.zyz"
-      ],
-      "emails": [
-        "person1@bbc.com",
-        "person2@keel.xyz"
-      ]
+      "domains": ["domain1.com", "domain2.zyz"],
+      "emails": ["person1@bbc.com", "person2@keel.xyz"]
     },
     {
       "name": "Other"

--- a/schema/testdata/proto/secrets/proto.json
+++ b/schema/testdata/proto/secrets/proto.json
@@ -42,9 +42,7 @@
           "expression": {
             "source": "ctx.secrets.TEST_SECRET == \"d\""
           },
-          "actionTypes": [
-            "ACTION_TYPE_GET"
-          ]
+          "actionTypes": ["ACTION_TYPE_GET"]
         }
       ]
     },
@@ -58,9 +56,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -97,9 +93,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/set_attribute_backlink_repeated_rhs_fields/proto.json
+++ b/schema/testdata/proto/set_attribute_backlink_repeated_rhs_fields/proto.json
@@ -163,10 +163,7 @@
           "expression": {
             "source": "true"
           },
-          "actionTypes": [
-            "ACTION_TYPE_CREATE",
-            "ACTION_TYPE_UPDATE"
-          ]
+          "actionTypes": ["ACTION_TYPE_CREATE", "ACTION_TYPE_UPDATE"]
         }
       ]
     },
@@ -332,9 +329,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -371,9 +366,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -617,9 +610,7 @@
             "modelName": "Record",
             "fieldName": "name"
           },
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         },
         {
           "messageName": "CreateRecordWithChildrenInput",
@@ -643,10 +634,7 @@
             "modelName": "Record",
             "fieldName": "name"
           },
-          "target": [
-            "children",
-            "name"
-          ]
+          "target": ["children", "name"]
         }
       ]
     }

--- a/schema/testdata/proto/set_attribute_backlinks/proto.json
+++ b/schema/testdata/proto/set_attribute_backlinks/proto.json
@@ -329,9 +329,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -368,9 +366,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -617,9 +613,7 @@
             "modelName": "Record",
             "fieldName": "name"
           },
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         }
       ]
     },
@@ -634,9 +628,7 @@
             "modelName": "Record",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },

--- a/schema/testdata/proto/set_attribute_ctx_identity_fields/proto.json
+++ b/schema/testdata/proto/set_attribute_ctx_identity_fields/proto.json
@@ -150,9 +150,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -189,9 +187,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -425,9 +421,7 @@
             "modelName": "UserExtension",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },

--- a/schema/testdata/proto/set_attribute_lhs_within_write_scope/proto.json
+++ b/schema/testdata/proto/set_attribute_lhs_within_write_scope/proto.json
@@ -560,9 +560,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -599,9 +597,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -924,11 +920,7 @@
             "modelName": "Country",
             "fieldName": "id"
           },
-          "target": [
-            "publisher",
-            "country",
-            "id"
-          ]
+          "target": ["publisher", "country", "id"]
         }
       ]
     },
@@ -943,11 +935,7 @@
             "modelName": "Department",
             "fieldName": "name"
           },
-          "target": [
-            "publisher",
-            "departments",
-            "name"
-          ]
+          "target": ["publisher", "departments", "name"]
         },
         {
           "messageName": "NestedData1PublisherDepartmentsInput",
@@ -957,11 +945,7 @@
             "modelName": "Department",
             "fieldName": "number"
           },
-          "target": [
-            "publisher",
-            "departments",
-            "number"
-          ]
+          "target": ["publisher", "departments", "number"]
         }
       ]
     },
@@ -977,9 +961,7 @@
             "fieldName": "name"
           },
           "nullable": true,
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         }
       ]
     },
@@ -1030,11 +1012,7 @@
             "modelName": "Country",
             "fieldName": "id"
           },
-          "target": [
-            "publisher",
-            "country",
-            "id"
-          ]
+          "target": ["publisher", "country", "id"]
         }
       ]
     },
@@ -1049,11 +1027,7 @@
             "modelName": "Department",
             "fieldName": "name"
           },
-          "target": [
-            "publisher",
-            "departments",
-            "name"
-          ]
+          "target": ["publisher", "departments", "name"]
         },
         {
           "messageName": "NestedData3PublisherDepartmentsInput",
@@ -1063,11 +1037,7 @@
             "modelName": "Department",
             "fieldName": "number"
           },
-          "target": [
-            "publisher",
-            "departments",
-            "number"
-          ]
+          "target": ["publisher", "departments", "number"]
         }
       ]
     },
@@ -1118,11 +1088,7 @@
             "modelName": "Country",
             "fieldName": "id"
           },
-          "target": [
-            "publisher",
-            "country",
-            "id"
-          ]
+          "target": ["publisher", "country", "id"]
         }
       ]
     },
@@ -1137,11 +1103,7 @@
             "modelName": "Department",
             "fieldName": "name"
           },
-          "target": [
-            "publisher",
-            "departments",
-            "name"
-          ]
+          "target": ["publisher", "departments", "name"]
         },
         {
           "messageName": "NestedData4PublisherDepartmentsInput",
@@ -1151,11 +1113,7 @@
             "modelName": "Department",
             "fieldName": "number"
           },
-          "target": [
-            "publisher",
-            "departments",
-            "number"
-          ]
+          "target": ["publisher", "departments", "number"]
         }
       ]
     },
@@ -1171,9 +1129,7 @@
             "fieldName": "name"
           },
           "nullable": true,
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         }
       ]
     },
@@ -1215,11 +1171,7 @@
             "modelName": "Country",
             "fieldName": "id"
           },
-          "target": [
-            "publisher",
-            "country",
-            "id"
-          ]
+          "target": ["publisher", "country", "id"]
         }
       ]
     },
@@ -1271,11 +1223,7 @@
             "fieldName": "name"
           },
           "nullable": true,
-          "target": [
-            "publisher",
-            "country",
-            "name"
-          ]
+          "target": ["publisher", "country", "name"]
         }
       ]
     },
@@ -1290,11 +1238,7 @@
             "modelName": "Department",
             "fieldName": "name"
           },
-          "target": [
-            "publisher",
-            "departments",
-            "name"
-          ]
+          "target": ["publisher", "departments", "name"]
         },
         {
           "messageName": "NestedData7PublisherDepartmentsInput",
@@ -1304,11 +1248,7 @@
             "modelName": "Department",
             "fieldName": "number"
           },
-          "target": [
-            "publisher",
-            "departments",
-            "number"
-          ]
+          "target": ["publisher", "departments", "number"]
         }
       ]
     },
@@ -1359,11 +1299,7 @@
             "modelName": "Country",
             "fieldName": "id"
           },
-          "target": [
-            "publisher",
-            "country",
-            "id"
-          ]
+          "target": ["publisher", "country", "id"]
         }
       ]
     },
@@ -1378,11 +1314,7 @@
             "modelName": "Department",
             "fieldName": "name"
           },
-          "target": [
-            "publisher",
-            "departments",
-            "name"
-          ]
+          "target": ["publisher", "departments", "name"]
         },
         {
           "messageName": "NestedData8PublisherDepartmentsInput",
@@ -1392,11 +1324,7 @@
             "modelName": "Department",
             "fieldName": "number"
           },
-          "target": [
-            "publisher",
-            "departments",
-            "number"
-          ]
+          "target": ["publisher", "departments", "number"]
         }
       ]
     },

--- a/schema/testdata/proto/unique_attribute/proto.json
+++ b/schema/testdata/proto/unique_attribute/proto.json
@@ -9,9 +9,7 @@
           "type": {
             "type": "TYPE_STRING"
           },
-          "uniqueWith": [
-            "publisher"
-          ]
+          "uniqueWith": ["publisher"]
         },
         {
           "modelName": "Product",
@@ -20,9 +18,7 @@
             "type": "TYPE_MODEL",
             "modelName": "Publisher"
           },
-          "uniqueWith": [
-            "name"
-          ],
+          "uniqueWith": ["name"],
           "foreignKeyFieldName": "publisherId"
         },
         {
@@ -117,9 +113,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -156,9 +150,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/unique_composite_lookup/proto.json
+++ b/schema/testdata/proto/unique_composite_lookup/proto.json
@@ -116,9 +116,7 @@
             "type": "TYPE_MODEL",
             "modelName": "Supplier"
           },
-          "uniqueWith": [
-            "supplierSku"
-          ],
+          "uniqueWith": ["supplierSku"],
           "foreignKeyFieldName": "supplierId",
           "inverseFieldName": "products"
         },
@@ -128,9 +126,7 @@
           "type": {
             "type": "TYPE_STRING"
           },
-          "uniqueWith": [
-            "supplier"
-          ]
+          "uniqueWith": ["supplier"]
         },
         {
           "modelName": "Product",
@@ -453,9 +449,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -492,9 +486,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -778,9 +770,7 @@
             "modelName": "Product",
             "fieldName": "supplierSku"
           },
-          "target": [
-            "supplierSku"
-          ]
+          "target": ["supplierSku"]
         },
         {
           "messageName": "GetBySupplierSkuInputAndIdInputInput",
@@ -790,10 +780,7 @@
             "modelName": "Supplier",
             "fieldName": "id"
           },
-          "target": [
-            "supplier",
-            "id"
-          ]
+          "target": ["supplier", "id"]
         }
       ]
     },
@@ -808,9 +795,7 @@
             "modelName": "Product",
             "fieldName": "supplierSku"
           },
-          "target": [
-            "supplierSku"
-          ]
+          "target": ["supplierSku"]
         },
         {
           "messageName": "GetBySupplierSkuInputAndCodeInputInput",
@@ -820,10 +805,7 @@
             "modelName": "Supplier",
             "fieldName": "supplierCode"
           },
-          "target": [
-            "supplier",
-            "supplierCode"
-          ]
+          "target": ["supplier", "supplierCode"]
         }
       ]
     },
@@ -895,9 +877,7 @@
             "modelName": "Product",
             "fieldName": "supplierSku"
           },
-          "target": [
-            "supplierSku"
-          ]
+          "target": ["supplierSku"]
         }
       ]
     },
@@ -915,10 +895,7 @@
             "modelName": "Product",
             "fieldName": "supplierSku"
           },
-          "target": [
-            "product",
-            "supplierSku"
-          ]
+          "target": ["product", "supplierSku"]
         },
         {
           "messageName": "GetBySupplierSkuAndCodeInput",
@@ -928,11 +905,7 @@
             "modelName": "Supplier",
             "fieldName": "supplierCode"
           },
-          "target": [
-            "product",
-            "supplier",
-            "supplierCode"
-          ]
+          "target": ["product", "supplier", "supplierCode"]
         }
       ]
     },
@@ -947,10 +920,7 @@
             "modelName": "Product",
             "fieldName": "sku"
           },
-          "target": [
-            "product",
-            "sku"
-          ]
+          "target": ["product", "sku"]
         }
       ]
     },
@@ -968,9 +938,7 @@
             "modelName": "Supplier",
             "fieldName": "supplierCode"
           },
-          "target": [
-            "supplierCode"
-          ]
+          "target": ["supplierCode"]
         }
       ]
     },
@@ -985,10 +953,7 @@
             "modelName": "Product",
             "fieldName": "sku"
           },
-          "target": [
-            "products",
-            "sku"
-          ]
+          "target": ["products", "sku"]
         }
       ]
     }

--- a/schema/testdata/proto/unique_lookup/proto.json
+++ b/schema/testdata/proto/unique_lookup/proto.json
@@ -259,9 +259,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -298,9 +296,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -568,9 +564,7 @@
             "modelName": "Product",
             "fieldName": "sku"
           },
-          "target": [
-            "sku"
-          ]
+          "target": ["sku"]
         }
       ]
     },
@@ -597,9 +591,7 @@
             "modelName": "Product",
             "fieldName": "name"
           },
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         }
       ]
     },
@@ -617,9 +609,7 @@
             "modelName": "Product",
             "fieldName": "sku"
           },
-          "target": [
-            "sku"
-          ]
+          "target": ["sku"]
         }
       ]
     },

--- a/schema/testdata/proto/unique_lookup_model/proto.json
+++ b/schema/testdata/proto/unique_lookup_model/proto.json
@@ -84,9 +84,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -123,9 +121,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/unique_lookup_nested/proto.json
+++ b/schema/testdata/proto/unique_lookup_nested/proto.json
@@ -233,9 +233,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -272,9 +270,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -528,10 +524,7 @@
             "modelName": "ProductStock",
             "fieldName": "id"
           },
-          "target": [
-            "stock",
-            "id"
-          ]
+          "target": ["stock", "id"]
         }
       ]
     },
@@ -546,10 +539,7 @@
             "modelName": "ProductStock",
             "fieldName": "barcode"
           },
-          "target": [
-            "stock",
-            "barcode"
-          ]
+          "target": ["stock", "barcode"]
         }
       ]
     },
@@ -576,10 +566,7 @@
             "modelName": "ProductStock",
             "fieldName": "barcode"
           },
-          "target": [
-            "stock",
-            "barcode"
-          ]
+          "target": ["stock", "barcode"]
         }
       ]
     },
@@ -618,9 +605,7 @@
             "modelName": "Product",
             "fieldName": "sku"
           },
-          "target": [
-            "sku"
-          ]
+          "target": ["sku"]
         }
       ]
     },
@@ -635,10 +620,7 @@
             "modelName": "Product",
             "fieldName": "sku"
           },
-          "target": [
-            "product",
-            "sku"
-          ]
+          "target": ["product", "sku"]
         }
       ]
     }

--- a/schema/testdata/proto/update_operation_unique_lookup_in_inputs/proto.json
+++ b/schema/testdata/proto/update_operation_unique_lookup_in_inputs/proto.json
@@ -68,9 +68,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -107,9 +105,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -337,9 +333,7 @@
             "modelName": "MyModel",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     }

--- a/schema/testdata/proto/update_operation_unique_lookup_in_wheres/proto.json
+++ b/schema/testdata/proto/update_operation_unique_lookup_in_wheres/proto.json
@@ -79,9 +79,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -118,9 +116,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/where_expression_allowed_operators_builtin_types/proto.json
+++ b/schema/testdata/proto/where_expression_allowed_operators_builtin_types/proto.json
@@ -310,9 +310,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -349,9 +347,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",


### PR DESCRIPTION
# Capture ID Token claims in `Identity`

It is possible to configure claims from your OIDC provider to be persisted as new fields on the `Identity` model.  For each reauthentication using ID Token or SSO flow, these claims will be updated in the database.

For example, the following `keel.config` will map the claim `https://slack.com/#team_ID` to a new field `Identity.teamId`

```yaml
auth:
  providers:
    - type: slack
      name: slack
      clientId: 1234

  claims:
    - key: https://slack.com/#team_ID
      field: teamId
```