### PR TITLE
feat: custom hostname for `keel run`

### DIFF
--- a/cmd/program/commands.go
+++ b/cmd/program/commands.go
@@ -449,9 +449,13 @@ type RuntimeRequestMsg struct {
 	done chan bool
 }
 
-func StartRuntimeServer(port string, ch chan tea.Msg) tea.Cmd {
+func StartRuntimeServer(port string, customHostname string, ch chan tea.Msg) tea.Cmd {
 	return func() tea.Msg {
-		os.Setenv("KEEL_API_URL", fmt.Sprintf("http://localhost:%s", port))
+		if customHostname != "" {
+			os.Setenv("KEEL_API_URL", customHostname)
+		} else {
+			os.Setenv("KEEL_API_URL", fmt.Sprintf("http://localhost:%s", port))
+		}
 
 		runtimeServer := http.Server{
 			Addr: fmt.Sprintf(":%s", port),

--- a/cmd/program/model.go
+++ b/cmd/program/model.go
@@ -160,6 +160,9 @@ type Model struct {
 	// This will then show all system events in the local console.
 	VerboseTracing bool
 
+	// A custom configured hostname, which may be necessary to change for SSO callback.
+	CustomHostname string
+
 	// Model state - used in View()
 	Status            int
 	Err               error
@@ -300,7 +303,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.Status = StatusLoadSchema
 
 		cmds := []tea.Cmd{
-			StartRuntimeServer(m.Port, m.runtimeRequestsCh),
+			StartRuntimeServer(m.Port, m.CustomHostname, m.runtimeRequestsCh),
 			StartRpcServer(m.RpcPort, m.rpcRequestsCh),
 			NextMsgCommand(m.runtimeRequestsCh),
 			NextMsgCommand(m.rpcRequestsCh),

--- a/cmd/program/views.go
+++ b/cmd/program/views.go
@@ -136,7 +136,11 @@ func renderRun(m *Model) string {
 			for _, values := range endpoints {
 				b.WriteString("\n")
 				b.WriteString(" - ")
-				b.WriteString(colors.Blue(fmt.Sprintf("http://localhost:%s/%s/%s", m.Port, strings.ToLower(api.Name), values[0])).Highlight().String())
+				if m.CustomHostname == "" {
+					b.WriteString(colors.Blue(fmt.Sprintf("http://localhost:%s/%s/%s", m.Port, strings.ToLower(api.Name), values[0])).Highlight().String())
+				} else {
+					b.WriteString(colors.Blue(fmt.Sprintf("%s/%s/%s", m.CustomHostname, strings.ToLower(api.Name), values[0])).Highlight().String())
+				}
 				b.WriteString(colors.White(fmt.Sprintf(" (%s)", values[1])).String())
 			}
 			b.WriteString("\n")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,7 @@ var (
 	flagVersion          bool
 	flagVerboseTracing   bool
 	flagEnvironment      string
+	flagHostname         string
 )
 
 var rootCmd = &cobra.Command{

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -24,6 +24,7 @@ var runCmd = &cobra.Command{
 			ProjectDir:       flagProjectDir,
 			ResetDatabase:    flagReset,
 			Port:             flagPort,
+			CustomHostname:   flagHostname,
 			CustomTracing:    flagTracing,
 			NodePackagesPath: flagNodePackagesPath,
 			PackageManager:   packageManager,
@@ -36,7 +37,8 @@ func init() {
 	rootCmd.AddCommand(runCmd)
 
 	runCmd.Flags().BoolVar(&flagReset, "reset", false, "if set the database will be reset")
-	runCmd.Flags().StringVar(&flagPort, "port", "8000", "the port to run the Keel application on")
+	runCmd.Flags().StringVar(&flagHostname, "hostname", "", "custom hostname to handle HTTP requests")
+	runCmd.Flags().StringVar(&flagPort, "port", "8000", "the local port to handle Keel HTTP requests")
 	runCmd.Flags().StringVar(&flagPrivateKeyPath, "private-key-path", "", "path to the private key .pem file")
 
 	if enabledDebugFlags == "true" {


### PR DESCRIPTION
# Custom hostname for `keel run`

It may be necessary to make the local Keel application available on some custom domain, such as with using ngrok.

It will then be necessary to configure Keel accordingly, especially because SSO requires redirects back to the Keel app, which will now need to be aware of this custom hostname.

Use `--hostname` to configure this:

```
keel run --hostname https://mycustomdomain
```

The CLI will then expose URLs and redirects using this hostname.

<img width="1001" alt="image" src="https://github.com/teamkeel/keel/assets/6212830/24d1b8b8-3367-443a-b6ee-ba1c74017437">
