### PR TITLE
fix: using new volume for pg16

### DIFF
--- a/cmd/database/database.go
+++ b/cmd/database/database.go
@@ -484,5 +484,5 @@ func findVolume(dockerClient *client.Client) (volume *dockerVolume.Volume, err e
 const postgresImageName string = "pgvector/pgvector"
 const postgresTag string = "pg16"
 const keelPostgresContainerName string = "keel-run-postgres"
-const keelPGVolumeName string = "keel-pg-volume"
+const keelPGVolumeName string = "keel-pg-volume-v16"
 const keelVolumeMountPath = `/var/lib/postgresql/data`


### PR DESCRIPTION
Pointing to a new Docker volume for the upgrade to PostgeSQL 16.  This will maintain customer's existing data on the old volume, and it will mean they can revert back to a previous version of Keel to access it.  They can also migrate if need be.