### PR TITLE
fix: check for crypto before importing module

### DIFF
--- a/packages/wasm/lib/wasm_exec_node.js
+++ b/packages/wasm/lib/wasm_exec_node.js
@@ -13,11 +13,12 @@ if (!globalThis.performance) {
   };
 }
 
-const crypto = require("crypto");
-globalThis.crypto = {
-  getRandomValues(b) {
-    crypto.randomFillSync(b);
-  },
-};
-
+if (!globalThis.crypto) {
+  const crypto = require("crypto");
+  globalThis.crypto = {
+    getRandomValues(b) {
+      crypto.randomFillSync(b);
+    },
+  };
+}
 require("./wasm_exec");


### PR DESCRIPTION
Check if `crypto` is set before attempting to set the property. 

This issue came up when using newer versions of node. It seems that starting with node@19, crypto was no longer experimental and therefore included as a built-in module, `globalThis.crypto`, thus attempting to set it on `globalThis` as a polyfill would end up with an error:

```
TypeError: Cannot set property crypto of #<Object> which has only a getter
```