### PR TITLE
fix: numbers in secret names

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -486,7 +486,7 @@ func validateFormat(config *ProjectConfig, formatType string) (bool, map[string]
 				continue
 			}
 
-			ssName := casing.ToScreamingSnake(secret.Name)
+			ssName := strings.ToUpper(secret.Name)
 
 			if secret.Name != ssName {
 				incorrectNamesMap[secret.Name] = true

--- a/config/fixtures/test_basic_config.yaml
+++ b/config/fixtures/test_basic_config.yaml
@@ -17,3 +17,7 @@ secrets:
   - name: API_KEY
     required:
       - "production"
+  - name: S3_BUCKET
+    required:
+      - "production"
+


### PR DESCRIPTION
## Fix for numbers validated against in secret names

The following validation error was occurring, which is incorrect:

![image](https://github.com/teamkeel/keel/assets/6212830/bfe804d0-a5ac-4bc9-a331-0afe7a669011)
