### PR TITLE
Feat: validation improvements & WASM update

### DIFF
--- a/colors/colors.go
+++ b/colors/colors.go
@@ -9,6 +9,8 @@ var (
 	StatusYellowBright     = lipgloss.AdaptiveColor{Light: "#B3B300", Dark: "#FFFF00"}
 	StatusRed              = lipgloss.AdaptiveColor{Light: "#990000", Dark: "#CC0000"}
 	StatusRedBright        = lipgloss.AdaptiveColor{Light: "#FF0000", Dark: "#FF0000"}
+	StatusOrange           = lipgloss.AdaptiveColor{Light: "#CC7700", Dark: "#FFAA00"}
+	StatusOrangeBright     = lipgloss.AdaptiveColor{Light: "#FFAA00", Dark: "#FFAA00"}
 	StatusBlue             = lipgloss.AdaptiveColor{Light: "#000099", Dark: "#000099"}
 	StatusBlueBright       = lipgloss.AdaptiveColor{Light: "#0000FF", Dark: "#6699ff"}
 	HighlightBlack         = lipgloss.AdaptiveColor{Light: "#000000", Dark: "#FFFFFF"}
@@ -90,6 +92,14 @@ func Yellow(text string) *Colors {
 		BaseColor:      StatusYellow,
 		HighlightColor: StatusYellowBright,
 		text:           setText(text, StatusYellow),
+	}
+}
+
+func Orange(text string) *Colors {
+	return &Colors{
+		BaseColor:      StatusOrange,
+		HighlightColor: StatusOrangeBright,
+		text:           setText(text, StatusOrange),
 	}
 }
 

--- a/packages/wasm/index.d.ts
+++ b/packages/wasm/index.d.ts
@@ -33,6 +33,7 @@ export interface GetDefinitionRequest {
 export interface ValidateRequest {
   schemaFiles: SchemaFile[];
   config?: string;
+  includeWarnings?: bool;
 }
 
 export interface SchemaFile {
@@ -67,4 +68,5 @@ export interface ValidationError {
 
 export interface ValidationResult {
   errors: ValidationError[];
+  warnings?: ValidationError[];
 }

--- a/packages/wasm/index.test.ts
+++ b/packages/wasm/index.test.ts
@@ -148,6 +148,44 @@ test("validate - multi file", async () => {
   expect(errors.length).toEqual(0);
 });
 
+test("validate - warnings", async () => {
+  const schema = `model Person {
+    fields { 
+        name Text
+    }
+
+    @on([create], createPersonSubscriber
+    )
+}`;
+  const { errors, warnings } = await validate({
+    schemaFiles: [{ filename: "schema.keel", contents: schema }],
+    config: configFile,
+    includeWarnings: true,
+  });
+
+  expect(errors.length).toEqual(0);
+  expect(warnings?.length).toEqual(1);
+});
+
+test("validate - ignore warnings", async () => {
+  const schema = `model Person {
+    fields { 
+        name Text
+    }
+
+    @on([create], createPersonSubscriber
+    )
+}`;
+  const { errors, warnings } = await validate({
+    schemaFiles: [{ filename: "schema.keel", contents: schema }],
+    config: configFile,
+    includeWarnings: false,
+  });
+
+  expect(errors.length).toEqual(0);
+  expect(warnings).toBeUndefined();
+});
+
 test("validate - invalid schema", async () => {
   const schema = `model Person {
     fields {`;

--- a/packages/wasm/lib/main.go
+++ b/packages/wasm/lib/main.go
@@ -199,7 +199,8 @@ func formatSchema(this js.Value, args []js.Value) any {
 //				contents: "",
 //			},
 //		],
-//		config: "<YAML config file>"
+//		config: "<YAML config file>",
+//		includeWarnings: true
 //	}
 //
 // The config file source is optional.
@@ -228,9 +229,9 @@ func validate(this js.Value, args []js.Value) any {
 			}
 		}
 
-		_, err := builder.MakeFromInputs(&reader.Inputs{
+		err := builder.ValidateFromInputs(&reader.Inputs{
 			SchemaFiles: schemaFiles,
-		})
+		}, args[0].Get("includeWarnings").Truthy())
 
 		if err != nil {
 			errs, ok := err.(*errorhandling.ValidationErrors)

--- a/packages/wasm/lib/wasm_exec_node.js
+++ b/packages/wasm/lib/wasm_exec_node.js
@@ -13,11 +13,13 @@ if (!globalThis.performance) {
   };
 }
 
-const crypto = require("crypto");
-globalThis.crypto = {
-  getRandomValues(b) {
-    crypto.randomFillSync(b);
-  },
-};
+if (!globalThis.crypto) {
+  const crypto = require("crypto");
+  globalThis.crypto = {
+    getRandomValues(b) {
+      crypto.randomFillSync(b);
+    },
+  };
+}
 
 require("./wasm_exec");

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -167,7 +167,7 @@ func (scm *Builder) makeFromInputs(allInputFiles *reader.Inputs) (*proto.Schema,
 	}
 
 	v := validation.NewValidator(asts)
-	validationErrors := v.RunAllValidators()
+	validationErrors := v.RunAllValidators(false)
 	if validationErrors != nil {
 		return nil, validationErrors
 	}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -178,6 +178,34 @@ func (scm *Builder) makeFromInputs(allInputFiles *reader.Inputs) (*proto.Schema,
 	return protoModels, nil
 }
 
+// ValidateFromInputs will tyake the given inputs and build the ASTs and run all validators, including/excluding warnings
+// based on the given param. Similar with MakeFromInputs, this function avoide building the protoModels for increased
+// performance when only validation is required
+func (scm *Builder) ValidateFromInputs(inputs *reader.Inputs, includeWarnings bool) error {
+	scm.schemaFiles = inputs.SchemaFiles
+
+	asts, parseErrors, err := scm.PrepareAst(inputs)
+	if err != nil {
+		return err
+	}
+
+	// insert the foreign key fields (for relationships)
+	errDetails := scm.insertForeignKeyFields(asts)
+	if errDetails != nil {
+		parseErrors.Errors = append(parseErrors.Errors, &errorhandling.ValidationError{
+			ErrorDetails: errDetails,
+		})
+	}
+
+	// if we have errors in parsing then no point running validation rules
+	if len(parseErrors.Errors) > 0 {
+		return &parseErrors
+	}
+
+	v := validation.NewValidator(asts)
+	return v.RunAllValidators(includeWarnings)
+}
+
 // insertBuiltInFields injects new fields into the parser schema, to represent
 // our implicit (or built-in) fields. For example every Model has an <id> field.
 func (scm *Builder) insertBuiltInFields(declarations *parser.AST) {

--- a/schema/validation/errorhandling/format.go
+++ b/schema/validation/errorhandling/format.go
@@ -9,130 +9,179 @@ import (
 	"github.com/teamkeel/keel/schema/reader"
 )
 
-// ToAnnotatedSchema formats the validation errors by pointing to the relevant line
+const (
+	// Number of lines of the source code to render before and after the line with the error
+	bufferLines = 3
+	// How much to indent the entire result e.g. every line is indented this much
+	indent = 2
+)
+
+// ToAnnotatedSchema formats both the validation errors and warnings by pointing to the relevant line
 // in the source file that produced the error
 //
 // The output is formatted using ANSI colours (if supported by the environment).
 func (verrs *ValidationErrors) ToAnnotatedSchema(sources []*reader.SchemaFile) string {
-
-	// Number of lines of the source code to render before and after the line with the error
-	bufferLines := 3
-
-	// How much to indent the entire result e.g. every line is indented this much
-	indent := 2
-
 	result := strings.Repeat(" ", indent)
+
+	for _, err := range verrs.Errors {
+		result += renderError(sources, err, false)
+	}
+	for _, err := range verrs.Warnings {
+		result += renderError(sources, err, true)
+	}
+
+	return result
+}
+
+// ErrorsToAnnotatedSchema formats the validation errors by pointing to the relevant line
+// in the source file that produced the error
+//
+// The output is formatted using ANSI colours (if supported by the environment).
+func (verrs *ValidationErrors) ErrorsToAnnotatedSchema(sources []*reader.SchemaFile) string {
+	result := strings.Repeat(" ", indent)
+
+	for _, err := range verrs.Errors {
+		result += renderError(sources, err, false)
+	}
+
+	return result
+}
+
+// WarningsToAnnotatedSchema formats the validation warnings by pointing to the relevant line
+// in the source file that produced the error
+//
+// The output is formatted using ANSI colours (if supported by the environment).
+func (verrs *ValidationErrors) WarningsToAnnotatedSchema(sources []*reader.SchemaFile) string {
+	result := strings.Repeat(" ", indent)
+
+	for _, err := range verrs.Warnings {
+		result += renderError(sources, err, true)
+	}
+
+	return result
+}
+
+func renderError(sources []*reader.SchemaFile, err *ValidationError, warning bool) string {
+	if err == nil {
+		return ""
+	}
+
+	result := ""
 	newLine := func() {
 		result += "\n" + strings.Repeat(" ", indent)
 	}
+	// Assumption here is that the error is on one line
+	errorLine := err.Pos.Line
 
-	for _, err := range verrs.Errors {
-		// Assumption here is that the error is on one line
-		errorLine := err.Pos.Line
+	startSourceLine := errorLine - bufferLines
+	endSourceLine := errorLine + bufferLines
 
-		startSourceLine := errorLine - bufferLines
-		endSourceLine := errorLine + bufferLines
+	// This produces a format string like "%3s| " which we use to render the gutter
+	// The number after the "%" is the width, which is documented as:
+	//   > For most values, width is the minimum number of runes to output,
+	//   > padding the formatted form with spaces if necessary.
+	gutterFmt := "%" + fmt.Sprintf("%d", len(fmt.Sprintf("%d", endSourceLine))) + "s| "
 
-		// This produces a format string like "%3s| " which we use to render the gutter
-		// The number after the "%" is the width, which is documented as:
-		//   > For most values, width is the minimum number of runes to output,
-		//   > padding the formatted form with spaces if necessary.
-		gutterFmt := "%" + fmt.Sprintf("%d", len(fmt.Sprintf("%d", endSourceLine))) + "s| "
+	var source string
+	for _, s := range sources {
+		if s.FileName == err.Pos.Filename {
+			source = s.Contents
+			break
+		}
+	}
 
-		var source string
-		for _, s := range sources {
-			if s.FileName == err.Pos.Filename {
-				source = s.Contents
-				break
-			}
+	result += colors.Gray(fmt.Sprintf(gutterFmt, " ")).String()
+	result += colors.Green(fmt.Sprint(err.Pos.Filename)).String()
+	newLine()
+
+	// not sure this can happen, but just in case we'll handle it
+	if source == "" {
+		result += err.Message
+		newLine()
+		return result
+	}
+	lines := strings.Split(source, "\n")
+
+	for lineIndex, line := range lines {
+		// If this line is outside of the buffer we can drop it
+		if (lineIndex+1) < (startSourceLine) || (lineIndex+1) > (endSourceLine) {
+			continue
 		}
 
-		result += colors.Gray(fmt.Sprintf(gutterFmt, " ")).String()
-		result += colors.Green(fmt.Sprint(err.Pos.Filename)).String()
-		newLine()
+		// Render line numbers in gutter
+		result += colors.Gray(fmt.Sprintf(gutterFmt, fmt.Sprintf("%d", lineIndex+1))).String()
 
-		// not sure this can happen, but just in case we'll handle it
-		if source == "" {
-			result += err.Message
+		// If the error line doesn't match the currently enumerated line
+		// then we can render the whole line without any colorization
+		if (lineIndex + 1) != errorLine {
+			result += colors.Gray(line).String()
 			newLine()
 			continue
 		}
 
-		lines := strings.Split(source, "\n")
+		chars := strings.Split(line, "")
 
-		for lineIndex, line := range lines {
+		// Enumerate over the characters in the line
+		for charIdx, char := range chars {
 
-			// If this line is outside of the buffer we can drop it
-			if (lineIndex+1) < (startSourceLine) || (lineIndex+1) > (endSourceLine) {
+			// Check if the character index is less than or greater than the corresponding start and end column
+			// If so, then render the char without any colorization
+			if (charIdx+1) < err.Pos.Column || (charIdx+1) > err.EndPos.Column-1 {
+				result += char
 				continue
 			}
 
-			// Render line numbers in gutter
-			result += colors.Gray(fmt.Sprintf(gutterFmt, fmt.Sprintf("%d", lineIndex+1))).String()
-
-			// If the error line doesn't match the currently enumerated line
-			// then we can render the whole line without any colorization
-			if (lineIndex + 1) != errorLine {
-				result += colors.Gray(line).String()
-				newLine()
-				continue
-			}
-
-			chars := strings.Split(line, "")
-
-			// Enumerate over the characters in the line
-			for charIdx, char := range chars {
-
-				// Check if the character index is less than or greater than the corresponding start and end column
-				// If so, then render the char without any colorization
-				if (charIdx+1) < err.Pos.Column || (charIdx+1) > err.EndPos.Column-1 {
-					result += char
-					continue
-				}
-
+			if warning {
+				result += colors.Orange(fmt.Sprint(char)).String()
+			} else {
 				result += colors.Red(fmt.Sprint(char)).String()
-			}
 
-			newLine()
-
-			// Underline the token that caused the error
-			result += colors.Gray(fmt.Sprintf(gutterFmt, "")).String()
-			result += strings.Repeat(" ", err.Pos.Column-1)
-			tokenLength := err.EndPos.Column - err.Pos.Column
-			for i := 0; i < tokenLength; i++ {
-				if i == tokenLength/2 {
-					result += colors.Yellow("\u252C").Highlight().String()
-				} else {
-					result += colors.Yellow("\u2500").Highlight().String()
-				}
-			}
-			newLine()
-
-			msgIndent := (err.Pos.Column - 1) + int(math.Max(float64((err.EndPos.Column-err.Pos.Column)/2), 0))
-
-			// Render the down arrow
-			result += colors.Gray(fmt.Sprintf(gutterFmt, "")).String()
-			result += strings.Repeat(" ", msgIndent)
-			result += colors.Yellow("\u2570").Highlight().String()
-			result += colors.Yellow("\u2500").Highlight().String()
-
-			// Render the message
-			result += fmt.Sprintf(" %s %s", colors.Yellow(fmt.Sprint(err.ErrorDetails.Message)).Highlight().String(), colors.Red(fmt.Sprintf("(%s)", err.Code)).String())
-			newLine()
-
-			// Render the hint
-			if err.ErrorDetails.Hint != "" {
-				result += colors.Gray(fmt.Sprintf(gutterFmt, "")).String()
-				result += strings.Repeat(" ", msgIndent)
-				// Line up hint with the error message above (taking into account unicode arrows)
-				result += strings.Repeat(" ", 3)
-				result += colors.Cyan(fmt.Sprint(err.ErrorDetails.Hint)).String()
-				newLine()
 			}
 		}
 
 		newLine()
+
+		// Underline the token that caused the error
+		result += colors.Gray(fmt.Sprintf(gutterFmt, "")).String()
+		result += strings.Repeat(" ", err.Pos.Column-1)
+		tokenLength := err.EndPos.Column - err.Pos.Column
+		for i := 0; i < tokenLength; i++ {
+			if i == tokenLength/2 {
+				result += colors.Yellow("\u252C").Highlight().String()
+			} else {
+				result += colors.Yellow("\u2500").Highlight().String()
+			}
+		}
+		newLine()
+
+		msgIndent := (err.Pos.Column - 1) + int(math.Max(float64((err.EndPos.Column-err.Pos.Column)/2), 0))
+
+		// Render the down arrow
+		result += colors.Gray(fmt.Sprintf(gutterFmt, "")).String()
+		result += strings.Repeat(" ", msgIndent)
+		result += colors.Yellow("\u2570").Highlight().String()
+		result += colors.Yellow("\u2500").Highlight().String()
+
+		// Render the message
+		result += fmt.Sprintf(" %s ", colors.Yellow(fmt.Sprint(err.ErrorDetails.Message)).Highlight().String())
+		if warning {
+			result += colors.Orange(fmt.Sprintf("(%s)", err.Code)).String()
+		} else {
+			result += colors.Red(fmt.Sprintf("(%s)", err.Code)).String()
+		}
+		newLine()
+
+		// Render the hint
+		if err.ErrorDetails.Hint != "" {
+			result += colors.Gray(fmt.Sprintf(gutterFmt, "")).String()
+			result += strings.Repeat(" ", msgIndent)
+			// Line up hint with the error message above (taking into account unicode arrows)
+			result += strings.Repeat(" ", 3)
+			result += colors.Cyan(fmt.Sprint(err.ErrorDetails.Hint)).String()
+			newLine()
+		}
 	}
 
+	newLine()
 	return result
 }

--- a/schema/validation/studio_features.go
+++ b/schema/validation/studio_features.go
@@ -1,0 +1,50 @@
+package validation
+
+import (
+	"fmt"
+
+	"github.com/teamkeel/keel/schema/parser"
+	"github.com/teamkeel/keel/schema/validation/errorhandling"
+)
+
+func StudioFeatures(asts []*parser.AST, errs *errorhandling.ValidationErrors) Visitor {
+	return Visitor{
+		EnterJob: func(n *parser.JobNode) {
+			errs.AppendWarning(
+				errorhandling.NewValidationErrorWithDetails(
+					errorhandling.UnsupportedFeatureError,
+					errorhandling.ErrorDetails{
+						Message: fmt.Sprintf("Job definitions are not supported in Keel Studio: '%s'", n.Name.Value),
+					},
+					n.Name,
+				),
+			)
+		},
+		EnterAction: func(n *parser.ActionNode) {
+			if n.IsFunction() && !n.BuiltIn {
+				errs.AppendWarning(
+					errorhandling.NewValidationErrorWithDetails(
+						errorhandling.UnsupportedFeatureError,
+						errorhandling.ErrorDetails{
+							Message: fmt.Sprintf("Custom functions are not supported in Keel Studio: '%s'", n.Name.Value),
+						},
+						n.Name,
+					),
+				)
+			}
+		},
+		EnterAttribute: func(n *parser.AttributeNode) {
+			if n.Name.Value == parser.AttributeOn {
+				errs.AppendWarning(
+					errorhandling.NewValidationErrorWithDetails(
+						errorhandling.UnsupportedFeatureError,
+						errorhandling.ErrorDetails{
+							Message: fmt.Sprintf("Event subscribers are not supported in Keel Studio"),
+						},
+						n.Name,
+					),
+				)
+			}
+		},
+	}
+}

--- a/schema/validation/studio_features.go
+++ b/schema/validation/studio_features.go
@@ -39,7 +39,7 @@ func StudioFeatures(asts []*parser.AST, errs *errorhandling.ValidationErrors) Vi
 					errorhandling.NewValidationErrorWithDetails(
 						errorhandling.UnsupportedFeatureError,
 						errorhandling.ErrorDetails{
-							Message: fmt.Sprintf("Event subscribers are not supported in Keel Studio"),
+							Message: "Event subscribers are not supported in Keel Studio",
 						},
 						n.Name,
 					),

--- a/schema/validation/validation.go
+++ b/schema/validation/validation.go
@@ -85,9 +85,12 @@ var visitorFuncs = []VisitorFunc{
 	OnAttributeRule,
 	RelationshipsRules,
 	ApiModelActions,
+	StudioFeatures,
 }
 
-func (v *Validator) RunAllValidators() (errs *errorhandling.ValidationErrors) {
+// RunAllValidators will run all the validators available. If withWarnings is true, it will return the errors even if
+// they contain just warnings
+func (v *Validator) RunAllValidators(withWarnings bool) (errs *errorhandling.ValidationErrors) {
 	errs = &errorhandling.ValidationErrors{}
 
 	for _, vf := range validatorFuncs {
@@ -100,6 +103,11 @@ func (v *Validator) RunAllValidators() (errs *errorhandling.ValidationErrors) {
 	}
 
 	runVisitors(v.asts, visitors)
+
+	// if we've got any warnings and they should be included, just return, no need to check for actual errors
+	if withWarnings && len(errs.Warnings) > 0 {
+		return errs
+	}
 
 	if len(errs.Errors) == 0 {
 		return nil


### PR DESCRIPTION
Validation errors will now include warnings. These are suppressed by default when using the CLI but in the wasm package an option is available which will include warnings in its output. The WASM validation will now also just validate rather than build the proto schema. This will inevitably improve performance, but it is unknown by how much at this point in time.