### PR TITLE
fix: request/response logging

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -267,18 +267,19 @@ func withRequestResponseLogging(handler common.HandlerFunc) common.HandlerFunc {
 			"headers": request.Header,
 			"method":  request.Method,
 			"host":    request.Host,
-		})
+		}).Info("Runtime request")
 
 		response := handler(request)
 
 		entry := log.WithFields(log.Fields{
 			"headers": response.Headers,
 			"status":  response.Status,
+			"url":     request.URL,
 		})
 		if response.Status >= 300 {
 			entry.WithField("body", string(response.Body))
 		}
-		entry.Info("response")
+		entry.Info("Runtime response")
 
 		return response
 	}


### PR DESCRIPTION
Request and response logging was added previously (see https://github.com/teamkeel/keel/pull/785) but the request data was never really logged, only the response. This PR fixes this issue and will create two log entries, one for the request and one for the response. The response log will also contain the request url.