### PR TITLE
fix: rename runtime logging env var

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -286,7 +286,7 @@ func withRequestResponseLogging(handler common.HandlerFunc) common.HandlerFunc {
 }
 
 func logLevel() log.Level {
-	switch os.Getenv("LOG_LEVEL") {
+	switch os.Getenv("KEEL_LOG_LEVEL") {
 	case "trace":
 		return log.TraceLevel
 	case "debug":


### PR DESCRIPTION
Runtime logging level should be controlled via a dedicated `KEEL_` prefixed env var to avoid collisions with other env vars that may be used in custom code.