### PR TITLE
fix: audit 'event_processed_at' column cannot be parsed or is empty

### DIFF
--- a/auditing/auditing.go
+++ b/auditing/auditing.go
@@ -124,18 +124,12 @@ func fromRow(row map[string]any) (*AuditLog, error) {
 		return nil, fmt.Errorf("audit '%s' column cannot be parsed or is empty", ColumnCreatedAt)
 	}
 
-	eventProcessedAt, ok := audit.TimeIf(ColumnEventProcessedAt)
-	if !ok {
-		return nil, fmt.Errorf("audit '%s' column cannot be parsed or is empty", ColumnEventProcessedAt)
-	}
-
 	return &AuditLog{
-		Id:               id,
-		TableName:        tableName,
-		Op:               op,
-		Data:             data,
-		CreatedAt:        createdAt,
-		EventProcessedAt: eventProcessedAt,
+		Id:        id,
+		TableName: tableName,
+		Op:        op,
+		Data:      data,
+		CreatedAt: createdAt,
 	}, nil
 }
 

--- a/events/events.go
+++ b/events/events.go
@@ -140,7 +140,7 @@ func SendEvents(ctx context.Context, schema *proto.Schema) error {
 		}
 
 		var previous map[string]any
-		if log.Op != Created {
+		if log.Op != auditing.Insert {
 			p, err := auditing.Previous(ctx, log)
 			if err != nil {
 				return err


### PR DESCRIPTION
It is possible for the event_processed_at column on the `keel_audit` table to not be set when parsing audit logs.  It could be unset due to a legitimate race condition or if an event was not set up for that op type at that time.

We don't need to even parse this column anyway, so I am removing it.