### PR TITLE
feat: custom unique fields on identity claims

### DIFF
--- a/config/auth.go
+++ b/config/auth.go
@@ -65,8 +65,9 @@ type Provider struct {
 }
 
 type IdentityClaim struct {
-	Key   string `yaml:"key"`
-	Field string `yaml:"field"`
+	Key    string `yaml:"key"`
+	Field  string `yaml:"field"`
+	Unique bool   `yaml:"unique"`
 }
 
 // AccessTokenExpiry retrieves the configured or default access token expiry

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -362,6 +362,9 @@ func TestAuthClaims(t *testing.T) {
 
 	assert.Equal(t, "https://slack.com/#team_ID", config.Auth.Claims[0].Key)
 	assert.Equal(t, "teamId", config.Auth.Claims[0].Field)
+	assert.Equal(t, true, config.Auth.Claims[0].Unique)
+
 	assert.Equal(t, "something-else", config.Auth.Claims[1].Key)
 	assert.Equal(t, "somethingElse", config.Auth.Claims[1].Field)
+	assert.Equal(t, false, config.Auth.Claims[1].Unique)
 }

--- a/config/fixtures/test_auth_identity_claims.yaml
+++ b/config/fixtures/test_auth_identity_claims.yaml
@@ -7,5 +7,6 @@ auth:
   claims:
     - key: https://slack.com/#team_ID
       field: teamId
+      unique: true
     - key: something-else
       field: somethingElse

--- a/integration/testdata/identity_claims/keelconfig.yaml
+++ b/integration/testdata/identity_claims/keelconfig.yaml
@@ -1,0 +1,10 @@
+auth:
+  claims:
+    - key: teamId
+      field: teamId
+      unique: true
+    - key: my_key_1
+      field: myField1
+      unique: false
+    - key: my_key_2
+      field: myField2

--- a/integration/testdata/identity_claims/schema.keel
+++ b/integration/testdata/identity_claims/schema.keel
@@ -1,0 +1,3 @@
+model Thing {
+    
+}

--- a/integration/testdata/identity_claims/tests.test.ts
+++ b/integration/testdata/identity_claims/tests.test.ts
@@ -1,0 +1,70 @@
+import { actions, models, resetDatabase } from "@teamkeel/testing";
+import { test, expect, beforeEach } from "vitest";
+
+beforeEach(resetDatabase);
+
+test("custom identity claims", async () => {
+  const identity = await models.identity.create({
+    email: "keel@keel.xyz",
+    issuer: "google|123",
+    teamId: "abc",
+    myField1: "f1",
+    myField2: "f2",
+  });
+
+  expect(identity.teamId).toEqual("abc");
+  expect(identity.myField1).toEqual("f1");
+  expect(identity.myField2).toEqual("f2");
+});
+
+test("custom identity claims - empty", async () => {
+  const identity = await models.identity.create({
+    email: "keel@keel.xyz",
+    issuer: "google|123",
+  });
+
+  expect(identity.teamId).toBeNull();
+  expect(identity.myField1).toBeNull();
+  expect(identity.myField2).toBeNull();
+});
+
+test("custom identity claims - duplicate", async () => {
+  await models.identity.create({
+    email: "keel@keel.xyz",
+    issuer: "google|123",
+    teamId: "abc",
+    myField1: "f1",
+    myField2: "f2",
+  });
+  await models.identity.create({
+    email: "keel@keel.xyz",
+    issuer: "google|123",
+    teamId: "mnu",
+    myField1: "f1",
+    myField2: "f2",
+  });
+  await models.identity.create({
+    email: "keel@keel.xyz",
+    issuer: "google|987",
+    teamId: "mnu",
+    myField1: "f1",
+    myField2: "f2",
+  });
+  await models.identity.create({
+    email: "keel@keel.xyz",
+    issuer: "google|123",
+    teamId: "xyz",
+    myField1: "f1",
+    myField2: "f2",
+  });
+
+  await expect(
+    models.identity.create({
+      email: "keel@keel.xyz",
+      issuer: "google|987",
+      teamId: "mnu",
+      myField1: "f1",
+      myField2: "f2",
+    })
+  ).toHaveError({});
+});


### PR DESCRIPTION
## Custom unique fields for Identity

By default, the Identity fields `email` and `issuer` form a composite unique constraint.  However, it may be possible that additional fields need to be included in that constraint.  In particular, claims from the 3rd party provider's token.  An example of this would be "team ID".

To include a claim, simply set `unique: true` in the keelconfig:

```yaml
auth:
  providers:
    - type: google
      name: google
      clientId: 123456

  claims:
    - key: https://slack.com/#team_ID
      field: teamId
      unique: true
```