### PR TITLE
fix: validation for string args in @unique

### DIFF
--- a/schema/testdata/errors/attribute_unique.keel
+++ b/schema/testdata/errors/attribute_unique.keel
@@ -15,4 +15,20 @@ model Person {
 
     //expect-error:25:32:E016:Invalid value, expected any of the following identifiers - firstName, or lastName
     @unique([firstName, surname])
+
+    //expect-error:5:12:E024:2 argument(s) provided to @unique but expected 1
+    @unique(
+        unknown1,
+        unknown2
+    )
+
+    //expect-error:5:12:E024:2 argument(s) provided to @unique but expected 1
+    @unique(
+        "first_name",
+        "last_name"
+    )
+
+    //expect-error:14:26:E016:Invalid value, expected any of the following identifiers - firstName, or lastName
+    //expect-error:28:39:E016:Invalid value, expected any of the following identifiers - firstName, or lastName
+    @unique(["first_name", "last_name"])
 }

--- a/schema/validation/unique_attribute.go
+++ b/schema/validation/unique_attribute.go
@@ -59,6 +59,13 @@ func UniqueAttributeRule(asts []*parser.AST, errs *errorhandling.ValidationError
 					value, _ := attr.Arguments[0].Expression.ToValue()
 
 					if value.Array != nil {
+						invalidFieldNames := lo.SomeBy(value.Array.Values, func(o *parser.Operand) bool {
+							return o.Ident == nil
+						})
+						if invalidFieldNames {
+							return
+						}
+
 						fieldNames := lo.Map(value.Array.Values, func(o *parser.Operand, _ int) string {
 							return o.Ident.ToString()
 						})


### PR DESCRIPTION
Schema validation now catches the use of strings in `@unique` and provides appropriate validation errors.