### PR TITLE
fix: formatter issue when using IDs in job input types

### DIFF
--- a/schema/format/format.go
+++ b/schema/format/format.go
@@ -100,10 +100,15 @@ func printJob(writer *Writer, job *parser.JobNode) {
 						writer.block(func() {
 							for _, input := range section.Inputs {
 								writer.comments(input, func() {
+									// CamelCase input types except for ID
+									inputType := input.Type.Value
+									if inputType != parser.FieldTypeID {
+										inputType = camel(inputType)
+									}
 									writer.write(
 										"%s %s",
 										lowerCamel(input.Name.Value),
-										camel(input.Type.Value),
+										inputType,
 									)
 									if input.Optional {
 										writer.write("?")

--- a/schema/format/testdata/job_inputs.txt
+++ b/schema/format/testdata/job_inputs.txt
@@ -2,6 +2,7 @@ job MyJob {
     inputs {
         name      Text
  Age Number
+ ThingID ID
     }
 
     @permission( "admin")
@@ -13,6 +14,7 @@ job MyJob {
     inputs {
         name Text
         age Number
+        thingId ID
     }
 
     @permission("admin")


### PR DESCRIPTION
 When formatting job inputs, `ID` is a valid type but the formatter was CamelCasing it to `Id`. This small PR fixes this issue