### PR TITLE
fix: json output format from keel validate

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,7 @@ var (
 	flagVerboseTracing   bool
 	flagEnvironment      string
 	flagHostname         string
+	flagJsonOutput       bool
 )
 
 var rootCmd = &cobra.Command{
@@ -54,7 +55,7 @@ func init() {
 	}
 
 	rootCmd.PersistentFlags().StringVarP(&flagProjectDir, "dir", "d", workingDir, "directory containing a Keel project")
-	rootCmd.PersistentFlags().BoolVarP(&flagVersion, "version", "v", false, "Print the Keel CLI version")
+	rootCmd.PersistentFlags().BoolVarP(&flagVersion, "version", "v", false, "print the Keel CLI version")
 }
 
 func resolvePackageManager(dir string, isInit bool) (string, error) {


### PR DESCRIPTION
Using the `--json` flag on `keel validate` will output JSON formatted schema and config validations.