### PR TITLE
fix: pass keel schema and config as cli args on validate

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,6 +27,8 @@ var (
 	flagEnvironment      string
 	flagHostname         string
 	flagJsonOutput       bool
+	flagSchema           string
+	flagConfig           string
 )
 
 var rootCmd = &cobra.Command{

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -23,7 +23,14 @@ var validateCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		b := schema.Builder{}
-		_, err := b.MakeFromDirectory(flagProjectDir)
+
+		var err error
+		if flagSchema != "" || flagConfig != "" {
+			_, err = b.MakeFromString(flagSchema, flagConfig)
+		} else {
+			_, err = b.MakeFromDirectory(flagProjectDir)
+		}
+
 		if err == nil && !flagJsonOutput {
 			fmt.Println("✨ Everything's looking good!")
 			return nil
@@ -89,4 +96,6 @@ var validateCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(validateCmd)
 	validateCmd.Flags().BoolVar(&flagJsonOutput, "json", false, "output validation and config errors as json")
+	validateCmd.Flags().StringVar(&flagSchema, "schema", "", "the Keel schema passed as an argument")
+	validateCmd.Flags().StringVar(&flagConfig, "config", "", "the Keel config passed as an argument")
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,7 +22,7 @@ func TestFailConfigValue(t *testing.T) {
 	_, err := Load("fixtures/test_failing_config.yaml")
 	assert.Error(t, err)
 
-	assert.Equal(t, "could not unmarshal config file: yaml: unmarshal errors:\n  line 4: cannot unmarshal !!seq into string", err.Error())
+	assert.Equal(t, "could not unmarshal config file: yaml: unmarshal errors:\n  line 4: cannot unmarshal !!seq into string\n", err.Error())
 }
 
 func TestDuplicates(t *testing.T) {


### PR DESCRIPTION
Allow passing of Keel schema and config as arguments on CLI's validate action.  For example:

`keel validate --schema "model Thing{}" --config "auth:"`

This is necessary for the VS Code extension to be able to validate unsaved changes.