### PR TITLE
fix: boolean in wasm definition

### DIFF
--- a/packages/wasm/index.d.ts
+++ b/packages/wasm/index.d.ts
@@ -33,7 +33,7 @@ export interface GetDefinitionRequest {
 export interface ValidateRequest {
   schemaFiles: SchemaFile[];
   config?: string;
-  includeWarnings?: bool;
+  includeWarnings?: boolean;
 }
 
 export interface SchemaFile {


### PR DESCRIPTION
WASM's `ValidationRequest.includeWarnings` Incorrectly defined as `bool`