### PR TITLE
fix: remove warnings from validate cli output

### DIFF
--- a/cmd/program/views.go
+++ b/cmd/program/views.go
@@ -194,7 +194,7 @@ func renderError(m *Model) string {
 		switch {
 		case errors.As(m.Err, &validationErrors):
 			b.WriteString("❌ The following errors were found in your schema files:\n\n")
-			s := validationErrors.ToAnnotatedSchema(m.SchemaFiles)
+			s := validationErrors.ErrorsToAnnotatedSchema(m.SchemaFiles)
 			b.WriteString(s)
 		case errors.As(m.Err, &configErrors):
 			b.WriteString("❌ The following errors were found in your ")

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -89,7 +89,7 @@ var validateCmd = &cobra.Command{
 		case errors.As(err, &validationErrors):
 			fmt.Println("❌ The following errors were found in your schema files:")
 			fmt.Println("")
-			s := validationErrors.ToAnnotatedSchema(b.SchemaFiles())
+			s := validationErrors.ErrorsToAnnotatedSchema(b.SchemaFiles())
 			fmt.Println(s)
 			return nil
 		case errors.As(err, &configErrors):


### PR DESCRIPTION
When running `keel validate` we do not need to render any warnings since at the moment warnings are not fully used in a cli environment.