### PR TITLE
fix: add completions for embed attributes

### DIFF
--- a/schema/completions/completions.go
+++ b/schema/completions/completions.go
@@ -652,6 +652,8 @@ func getAttributeArgCompletions(asts []*parser.AST, t *TokensAtPosition, cfg *co
 		return getPermissionArgCompletions(asts, t, cfg)
 	case parser.AttributeSortable:
 		return getSortableArgCompletions(asts, t)
+	case parser.AttributeEmbed:
+		return getEmbedArgCompletions(asts, t)
 	case parser.AttributeOrderBy:
 		return getOrderByArgCompletions(asts, t)
 	case parser.AttributeSchedule:
@@ -739,6 +741,28 @@ func getSortableArgCompletions(asts []*parser.AST, t *TokensAtPosition) []*Compl
 			Description: field.Type.Value,
 			Kind:        KindField,
 		})
+	}
+
+	return completions
+}
+
+func getEmbedArgCompletions(asts []*parser.AST, t *TokensAtPosition) []*CompletionItem {
+	modelName := getParentModelName(t)
+	model := query.Model(asts, modelName)
+	fields := query.ModelFields(model)
+
+	completions := []*CompletionItem{}
+
+	for _, field := range fields {
+		fieldName := field.Name.Value
+
+		if query.IsModel(asts, field.Type.Value) {
+			completions = append(completions, &CompletionItem{
+				Label:       fieldName,
+				Description: field.Type.Value,
+				Kind:        KindField,
+			})
+		}
 	}
 
 	return completions

--- a/schema/completions/completions_test.go
+++ b/schema/completions/completions_test.go
@@ -1481,6 +1481,33 @@ func TestSortableCompletions(t *testing.T) {
 	runTestsCases(t, cases)
 }
 
+func TestEmbedCompletions(t *testing.T) {
+	cases := []testCase{
+		{
+			name: "embed-attribute-values",
+			schema: `
+			model Country {}
+			model Company {}
+			model Person {
+				fields {
+					name Text
+					age Number
+					nationality Country
+					employer Company
+				}
+				actions {
+					list people() {
+						@embed(<Cursor>
+					}
+				}
+		    }`,
+			expected: []string{"nationality", "employer"},
+		},
+	}
+
+	runTestsCases(t, cases)
+}
+
 func TestOnCompletions(t *testing.T) {
 	cases := []testCase{
 		{


### PR DESCRIPTION
Adding completions for `@embed` attributes. The completions will be reduced to a set of model fields (relationships) available on the given model.