### PR TITLE
feat: remove foreign key from schema when object is embedded

### DIFF
--- a/integration/testdata/embedded_data/main.test.ts
+++ b/integration/testdata/embedded_data/main.test.ts
@@ -14,7 +14,6 @@ test("get action with embedded data", async () => {
 
   const fetchedPost = await actions.getPost({ id: post.id });
   expect(fetchedPost!.id).toEqual(post.id);
-  expect(fetchedPost!.categoryId).toBeUndefined();
   expect(fetchedPost!.category!.title).toEqual("Test");
 });
 
@@ -29,7 +28,6 @@ test("list action with embedded data", async () => {
 
   const fetchedPost = await actions.getPost({ id: post.id });
   expect(fetchedPost!.id).toEqual(post.id);
-  expect(fetchedPost!.categoryId).toBeUndefined();
   expect(fetchedPost!.category!.title).toEqual("Test");
 });
 
@@ -57,7 +55,5 @@ test("list action - equals", async () => {
 
   expect(posts.results.length).toEqual(2);
   expect(posts.results[0].category!.title).toEqual("Test");
-  expect(posts.results[0].categoryId).toBeUndefined();
   expect(posts.results[1].category!.title).toEqual("Testing again");
-  expect(posts.results[1].categoryId).toBeUndefined();
 });

--- a/integration/testdata/embedded_data/main.test.ts
+++ b/integration/testdata/embedded_data/main.test.ts
@@ -14,6 +14,7 @@ test("get action with embedded data", async () => {
 
   const fetchedPost = await actions.getPost({ id: post.id });
   expect(fetchedPost!.id).toEqual(post.id);
+  expect(fetchedPost!.categoryId).toBeUndefined();
   expect(fetchedPost!.category!.title).toEqual("Test");
 });
 
@@ -28,6 +29,7 @@ test("list action with embedded data", async () => {
 
   const fetchedPost = await actions.getPost({ id: post.id });
   expect(fetchedPost!.id).toEqual(post.id);
+  expect(fetchedPost!.categoryId).toBeUndefined();
   expect(fetchedPost!.category!.title).toEqual("Test");
 });
 
@@ -55,5 +57,7 @@ test("list action - equals", async () => {
 
   expect(posts.results.length).toEqual(2);
   expect(posts.results[0].category!.title).toEqual("Test");
+  expect(posts.results[0].categoryId).toBeUndefined();
   expect(posts.results[1].category!.title).toEqual("Testing again");
+  expect(posts.results[1].categoryId).toBeUndefined();
 });

--- a/node/codegen.go
+++ b/node/codegen.go
@@ -238,6 +238,22 @@ func writeEmbeddedModelFields(w *codegen.Writer, schema *proto.Schema, model *pr
 	w.Write("{\n")
 	w.Indent()
 	for _, field := range model.Fields {
+		// if the field is of ID type, and the related model is embedded, we do not want to include it in the schema
+		if field.Type.Type == proto.Type_TYPE_ID && field.ForeignKeyInfo != nil {
+			relatedModel := casing.ToLowerCamel(field.ForeignKeyInfo.RelatedModelName)
+			skip := false
+			for _, embed := range embeddings {
+				frags := strings.Split(embed, ".")
+				if frags[0] == relatedModel {
+					skip = true
+					break
+				}
+			}
+			if skip {
+				continue
+			}
+		}
+
 		fieldEmbeddings := []string{}
 		if field.Type.Type == proto.Type_TYPE_MODEL {
 			found := false

--- a/node/codegen_test.go
+++ b/node/codegen_test.go
@@ -1379,6 +1379,53 @@ export interface PersonNameResponse {
 	})
 }
 
+func TestWriteActionResponseTypesEmbeddings(t *testing.T) {
+	t.Parallel()
+	schema := `
+model Country {
+	fields {
+		code Text
+	}
+}
+
+model City {
+	fields {
+		name Text
+		country Country
+	}
+}
+model Person {
+	fields {
+		age Number
+		city City
+	}
+	actions {
+		get getPerson(id) {
+			@embed(city.country)
+		}
+	}
+}
+	`
+	expected := `
+ export interface GetPersonResponse {
+	age: number
+	city: {
+		name: string
+		country: Country
+		id: string
+		createdAt: Date
+		updatedAt: Date
+	}
+	id: string
+	createdAt: Date
+	updatedAt: Date
+}`
+
+	runWriterTest(t, schema, expected, func(s *proto.Schema, w *codegen.Writer) {
+		writeEmbeddedModelInterface(w, s, proto.FindModel(s.Models, "Person"), "GetPersonResponse", []string{"city.country"})
+	})
+}
+
 func TestWriteActionInputTypesInlineInputWrite(t *testing.T) {
 	t.Parallel()
 	schema := `

--- a/runtime/actions/get.go
+++ b/runtime/actions/get.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/teamkeel/keel/proto"
 	"github.com/teamkeel/keel/runtime/common"
+	"github.com/teamkeel/keel/schema/parser"
 )
 
 func Get(scope *Scope, input map[string]any) (map[string]any, error) {
@@ -61,7 +62,7 @@ func Get(scope *Scope, input map[string]any) (map[string]any, error) {
 			// a response embed will be something like: `book.author.country` where book is the model for the current action
 			fragments := strings.Split(embed, ".")
 
-			id, ok := res["id"].(string)
+			id, ok := res[parser.FieldNameId].(string)
 			if !ok {
 				return nil, errors.New("missing identifier")
 			}
@@ -70,6 +71,9 @@ func Get(scope *Scope, input map[string]any) (map[string]any, error) {
 				return nil, err
 			}
 			res[fragments[0]] = data
+
+			// we now need to remove the foreign key field from the result (e.g. if we're embedding author, we want to remove authorId)
+			delete(res, fragments[0]+"Id")
 		}
 	}
 

--- a/runtime/actions/list.go
+++ b/runtime/actions/list.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/teamkeel/keel/proto"
 	"github.com/teamkeel/keel/runtime/common"
+	"github.com/teamkeel/keel/schema/parser"
 )
 
 func (query *QueryBuilder) applyImplicitFiltersForList(scope *Scope, args map[string]any) error {
@@ -191,7 +192,7 @@ func List(scope *Scope, input map[string]any) (map[string]any, error) {
 			fragments := strings.Split(embed, ".")
 
 			for _, res := range results {
-				id, ok := res["id"].(string)
+				id, ok := res[parser.FieldNameId].(string)
 				if !ok {
 					return nil, errors.New("missing identifier")
 				}
@@ -200,6 +201,9 @@ func List(scope *Scope, input map[string]any) (map[string]any, error) {
 					return nil, err
 				}
 				res[fragments[0]] = data
+
+				// we now need to remove the foreign key field from the result (e.g. if we're embedding author, we want to remove authorId)
+				delete(res, fragments[0]+"Id")
 			}
 		}
 	}

--- a/runtime/openapi/testdata/embedded_data.json
+++ b/runtime/openapi/testdata/embedded_data.json
@@ -224,7 +224,6 @@
                       ]
                     },
                     "code": { "$ref": "#/components/schemas/Code" },
-                    "authorId": { "type": "string" },
                     "createdAt": { "type": "string", "format": "date-time" },
                     "id": { "type": "string" },
                     "reviews": {
@@ -240,8 +239,7 @@
                     "reviews",
                     "id",
                     "createdAt",
-                    "updatedAt",
-                    "authorId"
+                    "updatedAt"
                   ]
                 }
               }


### PR DESCRIPTION
When embedding a related object, we want to remove the foreign key; i.e.:

```
    actions {
        list listBooks() {
            @embed(author)
        }
    }
```

```
 "results": [
    {
      "author": {
        "createdAt": "2024-06-24T12:49:02.765243Z",
        "firstName": "Radu",
        "id": "2iKJTcMSCRsnNA1ifJSQkZ7Kl8d",
        "surname": "Gruia",
        "updatedAt": "2024-06-24T12:49:02.765243Z"
      },
      "authorId": "2iKJTcMSCRsnNA1ifJSQkZ7Kl8d",   <=== This should be removed from responses
      "createdAt": "2024-06-24T12:49:13.964459Z",
      "id": "2iKJV1XbGfE7DhzCxS6gSuP8mK2",
      "title": "A book",
      "updatedAt": "2024-06-24T12:49:13.964459Z"
    }
]