### PR TITLE
fix: afterIdentityCreated occurs before afterAuthentication

### DIFF
--- a/functions/functions.go
+++ b/functions/functions.go
@@ -3,8 +3,9 @@ package functions
 import (
 	"context"
 	"errors"
-	"slices"
 	"strings"
+
+	"golang.org/x/exp/slices"
 
 	"github.com/iancoleman/strcase"
 	"github.com/segmentio/ksuid"

--- a/functions/functions.go
+++ b/functions/functions.go
@@ -3,6 +3,7 @@ package functions
 import (
 	"context"
 	"errors"
+	"slices"
 	"strings"
 
 	"github.com/iancoleman/strcase"
@@ -92,15 +93,22 @@ func WithFunctionsTransport(ctx context.Context, transport Transport) context.Co
 }
 
 func CallPredefinedHook(ctx context.Context, hook config.FunctionHook) error {
-	permissionState := common.NewPermissionState()
-	permissionState.Grant()
+	cfg, err := runtimectx.GetOAuthConfig(ctx)
+	if err != nil {
+		return err
+	}
 
-	_, _, err := CallFunction(
-		ctx,
-		string(hook),
-		nil,
-		permissionState,
-	)
+	if slices.Contains(cfg.EnabledHooks(), hook) {
+		permissionState := common.NewPermissionState()
+		permissionState.Grant()
+
+		_, _, err = CallFunction(
+			ctx,
+			string(hook),
+			nil,
+			permissionState,
+		)
+	}
 
 	return err
 }

--- a/integration/testdata/functions_auth_hooks/schema.keel
+++ b/integration/testdata/functions_auth_hooks/schema.keel
@@ -2,6 +2,6 @@ model Account {
     fields {
         name Text
         identity Identity @unique
-        loginCount Number @default(1)
+        loginCount Number @default(0)
     }
 }


### PR DESCRIPTION
 - The `afterIdentityCreated` hook now executes before the `afterAuthentication`
 - Errors in hook functions now cause the request to error