### PR TITLE
fix: skip transforming null inline files json data

### DIFF
--- a/runtime/actions/file_uploads.go
+++ b/runtime/actions/file_uploads.go
@@ -63,7 +63,7 @@ func transformFileResponses(ctx context.Context, model *proto.Model, results map
 	}
 
 	for _, field := range model.FileFields() {
-		if fileJSON, found := results[field.Name]; found {
+		if fileJSON, found := results[field.Name]; found && fileJSON != nil {
 			data, ok := fileJSON.(string)
 			if !ok {
 				return results, fmt.Errorf("invalid response for field: %s", field.Name)


### PR DESCRIPTION
When attempting to transform json data from the db representing inline file data, we should be skipping null entries