### PR TITLE
fix: remove embedded field's ID from jsonschema

### DIFF
--- a/runtime/actions/embed.go
+++ b/runtime/actions/embed.go
@@ -67,6 +67,9 @@ func resolveEmbeddedData(ctx context.Context, schema *proto.Schema, sourceModel 
 					return nil, fmt.Errorf("retrieving child embed: %w", err)
 				}
 				result[fragments[1]] = childEmbed
+
+				// we now need to remove the foreign key field from the result (e.g. if we're embedding author, we want to remove authorId)
+				delete(result, fragments[1]+"Id")
 			}
 		}
 
@@ -119,6 +122,9 @@ func resolveEmbeddedData(ctx context.Context, schema *proto.Schema, sourceModel 
 					return nil, fmt.Errorf("retrieving child embed: %w", err)
 				}
 				result[i][fragments[1]] = childEmbed
+
+				// we now need to remove the foreign key field from the result (e.g. if we're embedding author, we want to remove authorId)
+				delete(result[i], fragments[1]+"Id")
 			}
 		}
 
@@ -157,6 +163,9 @@ func resolveEmbeddedData(ctx context.Context, schema *proto.Schema, sourceModel 
 					return nil, fmt.Errorf("retrieving child embed: %w", err)
 				}
 				result[fragments[1]] = childEmbed
+
+				// we now need to remove the foreign key field from the result (e.g. if we're embedding author, we want to remove authorId)
+				delete(result, fragments[1]+"Id")
 			}
 		}
 

--- a/runtime/jsonschema/jsonschema.go
+++ b/runtime/jsonschema/jsonschema.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/samber/lo"
-	"github.com/teamkeel/keel/casing"
 	"github.com/teamkeel/keel/proto"
 	"github.com/teamkeel/keel/schema/parser"
 	"github.com/xeipuuv/gojsonschema"
@@ -340,7 +339,7 @@ func objectSchemaForModel(ctx context.Context, schema *proto.Schema, model *prot
 
 		// if the field is of ID type, and the related model is embedded, we do not want to include it in the schema
 		if field.Type.Type == proto.Type_TYPE_ID && field.ForeignKeyInfo != nil {
-			relatedModel := casing.ToLowerCamel(field.ForeignKeyInfo.RelatedModelName)
+			relatedModel := strings.TrimSuffix(field.Name, "Id")
 			skip := false
 			for _, embed := range embeddings {
 				frags := strings.Split(embed, ".")

--- a/runtime/openapi/testdata/embedded_data.json
+++ b/runtime/openapi/testdata/embedded_data.json
@@ -26,7 +26,7 @@
             "description": "createAuthor Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Author" }
+                "schema": { "$ref": "#/components/schemas/User" }
               }
             }
           },
@@ -431,7 +431,7 @@
                     },
                     "results": {
                       "type": "array",
-                      "items": { "$ref": "#/components/schemas/Author" }
+                      "items": { "$ref": "#/components/schemas/User" }
                     }
                   }
                 }
@@ -729,7 +729,7 @@
   },
   "components": {
     "schemas": {
-      "Author": {
+      "User": {
         "properties": {
           "createdAt": { "type": "string", "format": "date-time" },
           "firstName": { "type": "string" },

--- a/runtime/openapi/testdata/embedded_data.keel
+++ b/runtime/openapi/testdata/embedded_data.keel
@@ -1,4 +1,4 @@
-model Author {
+model User {
     fields {
         firstName Text
         surname Text @unique
@@ -42,7 +42,7 @@ model Review {
 model Book {
     fields {
         title Text
-        author Author
+        author User
         reviews Review[]
         code Code?
     }


### PR DESCRIPTION
Removing the id field of an embedded relation: e.g.

when embedding `author` for a `Book`, remove `authorId` from returned response. This fix ensures that the id field is removed even when the field is related to a different type of Model (e.g. `author` is of type `User` instead of `Author`)