### PR TITLE
fix: inline files used in input messages to jobs & custom functions 

### DIFF
--- a/runtime/openapi/openapi.go
+++ b/runtime/openapi/openapi.go
@@ -180,7 +180,7 @@ func GenerateJob(ctx context.Context, schema *proto.Schema, jobName string) Open
 			if msg == nil {
 				continue
 			}
-			inputSchema := jsonschema.JSONSchemaForMessage(ctx, schema, nil, msg)
+			inputSchema := jsonschema.JSONSchemaForMessage(ctx, schema, nil, msg, true)
 			endpoint := "/"
 
 			// Merge components from this request schema into OpenAPI components

--- a/runtime/openapi/testdata/job.json
+++ b/runtime/openapi/testdata/job.json
@@ -20,10 +20,14 @@
                   },
                   "input2": {
                     "type": "boolean"
+                  },
+                  "input3": {
+                    "type": "string",
+                    "format": "data-url"
                   }
                 },
                 "additionalProperties": false,
-                "required": ["input1", "input2"]
+                "required": ["input1", "input2", "input3"]
               }
             }
           }

--- a/runtime/openapi/testdata/job.keel
+++ b/runtime/openapi/testdata/job.keel
@@ -2,6 +2,7 @@ job TestJob {
     inputs {
         input1 Text
         input2 Boolean
+        input3 InlineFile
     }
 
     @permission(roles: [Admin])


### PR DESCRIPTION
When defining InlineFiles as inputs to jobs & custom functions, the openapi schema generated must be a string with format: `data-url`