### PR TITLE
fix: fix generated client types for embeds

### DIFF
--- a/node/codegen.go
+++ b/node/codegen.go
@@ -252,7 +252,7 @@ func writeEmbeddedModelFields(w *codegen.Writer, schema *proto.Schema, model *pr
 	for _, field := range model.Fields {
 		// if the field is of ID type, and the related model is embedded, we do not want to include it in the schema
 		if field.Type.Type == proto.Type_TYPE_ID && field.ForeignKeyInfo != nil {
-			relatedModel := casing.ToLowerCamel(field.ForeignKeyInfo.RelatedModelName)
+			relatedModel := strings.TrimSuffix(field.Name, "Id")
 			skip := false
 			for _, embed := range embeddings {
 				frags := strings.Split(embed, ".")

--- a/node/codegen_test.go
+++ b/node/codegen_test.go
@@ -1398,10 +1398,13 @@ model Person {
 	fields {
 		age Number
 		city City
+		birthplace City
+		country Country
 	}
 	actions {
 		get getPerson(id) {
 			@embed(city.country)
+			@embed(birthplace)
 		}
 	}
 }
@@ -1416,13 +1419,15 @@ model Person {
 		createdAt: Date
 		updatedAt: Date
 	}
+	birthplace: City
 	id: string
 	createdAt: Date
 	updatedAt: Date
+	countryId: string
 }`
 
 	runWriterTest(t, schema, expected, func(s *proto.Schema, w *codegen.Writer) {
-		writeEmbeddedModelInterface(w, s, proto.FindModel(s.Models, "Person"), "GetPersonResponse", []string{"city.country"})
+		writeEmbeddedModelInterface(w, s, proto.FindModel(s.Models, "Person"), "GetPersonResponse", []string{"city.country", "birthplace"})
 	})
 }
 


### PR DESCRIPTION
When embedding files, the js sdk generated types must remove the foreign key, regardless of the naming of the field: i.e. 

```
fields {
  city City
  birthplace City
}
```

will need both `cityId` and `birthplaceId` removed if they are embedded