### PR TITLE
fix: allow embeds from same model

### DIFF
--- a/integration/testdata/embedded_data/main.test.ts
+++ b/integration/testdata/embedded_data/main.test.ts
@@ -3,35 +3,28 @@ import { test, expect, beforeEach } from "vitest";
 
 beforeEach(resetDatabase);
 
-test("get action with embedded data", async () => {
+test("get - belongs to & has many", async () => {
   const post = await actions.createPost({
     title: "foo",
     content: "bcd",
     category: {
       title: "Test",
     },
+    comments: [{ title: "comment1" }, { title: "comment2" }],
   });
 
   const fetchedPost = await actions.getPost({ id: post.id });
   expect(fetchedPost!.id).toEqual(post.id);
   expect(fetchedPost!.category!.title).toEqual("Test");
+  expect(fetchedPost!.comments.length).toEqual(2);
+
+  const comments = fetchedPost!.comments.map((x) => x.title);
+  expect(comments).toHaveLength(2);
+  expect(comments).toContain("comment1");
+  expect(comments).toContain("comment2");
 });
 
-test("list action with embedded data", async () => {
-  const post = await actions.createPost({
-    title: "foo",
-    content: "bcd",
-    category: {
-      title: "Test",
-    },
-  });
-
-  const fetchedPost = await actions.getPost({ id: post.id });
-  expect(fetchedPost!.id).toEqual(post.id);
-  expect(fetchedPost!.category!.title).toEqual("Test");
-});
-
-test("list action - equals", async () => {
+test("list action - belongs to", async () => {
   await models.post.create({
     title: "foo",
     content: "bcd",
@@ -56,4 +49,31 @@ test("list action - equals", async () => {
   expect(posts.results.length).toEqual(2);
   expect(posts.results[0].category!.title).toEqual("Test");
   expect(posts.results[1].category!.title).toEqual("Testing again");
+});
+
+test("get - same table embed", async () => {
+  const parent = await actions.createPost({
+    title: "foo",
+    content: "bcd",
+    category: {
+      title: "Test",
+    },
+    comments: [{ title: "comment1" }, { title: "comment2" }],
+  });
+
+  const child = await actions.createPost({
+    title: "fooChild",
+    content: "bcdChild",
+    category: {
+      title: "Test2",
+    },
+    comments: [],
+    parent: { id: parent.id },
+  });
+
+  const fetchedPost = await actions.getPost({ id: child.id });
+  expect(fetchedPost!.id).toEqual(child.id);
+  expect(fetchedPost!.category!.title).toEqual("Test2");
+  expect(fetchedPost!.parent!.id).toEqual(parent.id);
+  expect(fetchedPost!.parent!.title).toEqual("foo");
 });

--- a/integration/testdata/embedded_data/schema.keel
+++ b/integration/testdata/embedded_data/schema.keel
@@ -4,12 +4,16 @@ model Post {
         content Markdown?
         category Category?
         order Number?
+        comments Comment[]
+        parent Post?
     }
 
     actions {
-        create createPost() with (title, content?, category.title, order?)
+        create createPost() with (title, content?, category.title, order?, comments.title, parent.id?)
         get getPost(id) {
             @embed(category)
+            @embed(comments)
+            @embed(parent)
         }
         list listPosts() {
             @embed(category)
@@ -29,3 +33,9 @@ model Category {
     }
 }
 
+model Comment {
+    fields {
+        title Text @unique
+        post Post
+    }
+}


### PR DESCRIPTION
A bug prevented embeds with relationships from the same model. This PR addresses it by joining the source model with an alias. The following embed will now work as intended

```
model Post {
    fields {
        title Text
        parent Post?
    }
    actions {
        list listPosts() {
            @embed(parent)
        }
    }
}
```