### PR TITLE
fix: pascal case headers in schema

### DIFF
--- a/integration/testdata/headers/functions/createPersonUsingHook.ts
+++ b/integration/testdata/headers/functions/createPersonUsingHook.ts
@@ -1,0 +1,14 @@
+import {
+  CreatePersonUsingHook,
+  CreatePersonUsingHookHooks,
+} from "@teamkeel/sdk";
+
+const hooks: CreatePersonUsingHookHooks = {};
+
+export default CreatePersonUsingHook({
+  beforeWrite: async (ctx, _) => {
+    return {
+      name: ctx.headers.get("Person-Name")!,
+    };
+  },
+});

--- a/integration/testdata/headers/functions/writePersonUsingCustomFunc.ts
+++ b/integration/testdata/headers/functions/writePersonUsingCustomFunc.ts
@@ -1,0 +1,5 @@
+import { WritePersonUsingCustomFunc, models } from "@teamkeel/sdk";
+
+export default WritePersonUsingCustomFunc(async (ctx, _) => {
+  return await models.person.create({ name: ctx.headers.get("Person-Name")! });
+});

--- a/integration/testdata/headers/schema.keel
+++ b/integration/testdata/headers/schema.keel
@@ -5,17 +5,28 @@ model Person {
 
     actions {
         create createPerson() {
-            @set(person.name = ctx.headers.PERSON_NAME)
+            @set(person.name = ctx.headers.PersonName)
+            @permission(expression: true)
+        }
+        create createPersonCamelCase() {
+            @set(person.name = ctx.headers.personName)
+            @permission(expression: true)
+        }
+        create createPersonUsingHook() {
+            @function
+            @permission(expression: true)
+        }
+        write writePersonUsingCustomFunc(Any) returns (Any) {
             @permission(expression: true)
         }
         get getBob(id) {
-            @permission(expression: ctx.headers.PERSON_NAME == "Bob")
+            @permission(expression: ctx.headers.PersonName == "Bob")
         }
         get getPedro(id) {
-            @permission(expression: ctx.headers.PERSON_NAME == "Pedro")
+            @permission(expression: ctx.headers.PersonName == "Pedro")
         }
         list listPedros() {
-            @where(person.name == ctx.headers.PERSON_NAME)
+            @where(person.name == ctx.headers.PersonName)
             @permission(expression: true)
         }
     }

--- a/integration/testdata/headers/tests.test.ts
+++ b/integration/testdata/headers/tests.test.ts
@@ -11,7 +11,115 @@ test("set with http header", async () => {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        PERSON_NAME: "Pedro",
+        "Person-Name": "Pedro",
+      },
+    }
+  );
+
+  expect(response.status).toEqual(200);
+  const data = await response.json();
+  expect(data?.name).toEqual("Pedro");
+});
+
+test("set with http header camel case in schema", async () => {
+  const response = await fetch(
+    process.env.KEEL_TESTING_ACTIONS_API_URL + "/createPerson",
+    {
+      body: "{}",
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Person-Name": "Pedro",
+      },
+    }
+  );
+
+  expect(response.status).toEqual(200);
+  const data = await response.json();
+  expect(data?.name).toEqual("Pedro");
+});
+
+test("set with http header - different casing but matching", async () => {
+  const response = await fetch(
+    process.env.KEEL_TESTING_ACTIONS_API_URL + "/createPerson",
+    {
+      body: "{}",
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "person-name": "Pedro",
+      },
+    }
+  );
+
+  expect(response.status).toEqual(200);
+  const data = await response.json();
+  expect(data?.name).toEqual("Pedro");
+});
+
+test("set with http header - not matching", async () => {
+  const response = await fetch(
+    process.env.KEEL_TESTING_ACTIONS_API_URL + "/createPerson",
+    {
+      body: "{}",
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        personname: "Pedro",
+      },
+    }
+  );
+
+  expect(response.status).toEqual(200);
+  const data = await response.json();
+  expect(data?.name).toEqual("");
+});
+
+test("set with http header - not matching", async () => {
+  const response = await fetch(
+    process.env.KEEL_TESTING_ACTIONS_API_URL + "/createPerson",
+    {
+      body: "{}",
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        person_name: "Pedro",
+      },
+    }
+  );
+
+  expect(response.status).toEqual(200);
+  const data = await response.json();
+  expect(data?.name).toEqual("");
+});
+
+test("create with http header in hook function", async () => {
+  const response = await fetch(
+    process.env.KEEL_TESTING_ACTIONS_API_URL + "/createPersonUsingHook",
+    {
+      body: "{}",
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Person-Name": "Pedro",
+      },
+    }
+  );
+
+  expect(response.status).toEqual(200);
+  const data = await response.json();
+  expect(data?.name).toEqual("Pedro");
+});
+
+test("create with http header in custom function", async () => {
+  const response = await fetch(
+    process.env.KEEL_TESTING_ACTIONS_API_URL + "/writePersonUsingCustomFunc",
+    {
+      body: "{}",
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Person-Name": "Pedro",
       },
     }
   );
@@ -29,7 +137,7 @@ test("permissions with http header", async () => {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        PERSON_NAME: "Pedro",
+        "Person-Name": "Pedro",
       },
     }
   );
@@ -44,7 +152,7 @@ test("permissions with http header", async () => {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        PERSON_NAME: "Pedro",
+        "Person-Name": "Pedro",
       },
     }
   );
@@ -58,7 +166,7 @@ test("permissions with http header", async () => {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        PERSON_NAME: "Pedro",
+        "Person-Name": "Pedro",
       },
     }
   );
@@ -77,7 +185,7 @@ test("where with http header", async () => {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        PERSON_NAME: "Pedro",
+        "Person-Name": "Pedro",
       },
     }
   );

--- a/runtime/expressions/operand.go
+++ b/runtime/expressions/operand.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/iancoleman/strcase"
 	"github.com/samber/lo"
 	"github.com/teamkeel/keel/casing"
 	"github.com/teamkeel/keel/proto"
@@ -401,9 +402,14 @@ func (resolver *OperandResolver) ResolveValue(args map[string]any) (any, error) 
 		return runtimectx.GetSecret(resolver.Context, secret)
 	case resolver.operand.Ident.IsContextHeadersField():
 		headerName := resolver.operand.Ident.Fragments[2].Fragment
-		// Get canonical name, as this is what header keys are transformed into
+
+		// First we parse the header name to kebab. MyCustomHeader will become my-custom-header.
+		asSnake := strcase.ToKebab(headerName)
+
+		// Then get canonical name. my-custom-header will become My-Custom-Header.
 		// https://pkg.go.dev/net/http#Header.Get
-		canonicalName := textproto.CanonicalMIMEHeaderKey(headerName)
+		canonicalName := textproto.CanonicalMIMEHeaderKey(asSnake)
+
 		headers, err := runtimectx.GetRequestHeaders(resolver.Context)
 		if err != nil {
 			return nil, err

--- a/runtime/expressions/operand.go
+++ b/runtime/expressions/operand.go
@@ -404,11 +404,11 @@ func (resolver *OperandResolver) ResolveValue(args map[string]any) (any, error) 
 		headerName := resolver.operand.Ident.Fragments[2].Fragment
 
 		// First we parse the header name to kebab. MyCustomHeader will become my-custom-header.
-		asSnake := strcase.ToKebab(headerName)
+		kebab := strcase.ToKebab(headerName)
 
 		// Then get canonical name. my-custom-header will become My-Custom-Header.
 		// https://pkg.go.dev/net/http#Header.Get
-		canonicalName := textproto.CanonicalMIMEHeaderKey(asSnake)
+		canonicalName := textproto.CanonicalMIMEHeaderKey(kebab)
 
 		headers, err := runtimectx.GetRequestHeaders(resolver.Context)
 		if err != nil {


### PR DESCRIPTION
Because the Keel schema does not support dashes well, we have opted to represent canonical kebab style header names in Pascal case in expressions.

For example, if the header provided into the request is `My-Data-Key`, then that header can be resolved in expressions with `ctx.headers.MyDataKey`.

Note that headers are case insensitive.  Also, Keel does not support headers with underscores (as with NGINX, these are dropped by default)