### PR TITLE
test: header tests with x prefix

### DIFF
--- a/integration/testdata/headers/schema.keel
+++ b/integration/testdata/headers/schema.keel
@@ -8,6 +8,10 @@ model Person {
             @set(person.name = ctx.headers.PersonName)
             @permission(expression: true)
         }
+        create createPersonX() {
+            @set(person.name = ctx.headers.XPersonName)
+            @permission(expression: true)
+        }
         create createPersonCamelCase() {
             @set(person.name = ctx.headers.personName)
             @permission(expression: true)

--- a/integration/testdata/headers/tests.test.ts
+++ b/integration/testdata/headers/tests.test.ts
@@ -21,6 +21,24 @@ test("set with http header", async () => {
   expect(data?.name).toEqual("Pedro");
 });
 
+test("set with http header with X prefix", async () => {
+  const response = await fetch(
+    process.env.KEEL_TESTING_ACTIONS_API_URL + "/createPersonX",
+    {
+      body: "{}",
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Person-Name": "Pedro",
+      },
+    }
+  );
+
+  expect(response.status).toEqual(200);
+  const data = await response.json();
+  expect(data?.name).toEqual("Pedro");
+});
+
 test("set with http header camel case in schema", async () => {
   const response = await fetch(
     process.env.KEEL_TESTING_ACTIONS_API_URL + "/createPerson",


### PR DESCRIPTION
Test case with a x-prefixed header such as `X-Api-Key`