### PR TITLE
fix: reading content type for local inlinefiles

### DIFF
--- a/storage/database_storer.go
+++ b/storage/database_storer.go
@@ -122,7 +122,7 @@ func (s *DbStore) GetFileInfo(key string) (FileInfo, error) {
 func (s *DbStore) HydrateFileInfo(fi *FileInfo) (FileInfo, error) {
 	sql := `SELECT
 			filename,
-			content_type,
+			contentType,
 			data
 		FROM ` + dbTable + ` WHERE id = ?`
 


### PR DESCRIPTION
When running the CLI locally the InlineFile wasn't parsing `contentType` correctly from the database and resulted in the following panic:

```
dataurl: invalid mediatype
```