### PR TITLE
feat: functions-runtime errors

### DIFF
--- a/functions/functions.go
+++ b/functions/functions.go
@@ -313,13 +313,7 @@ func toRuntimeError(errorResponse *FunctionsRuntimeError) error {
 	case UniqueConstraintError:
 		return common.NewUniquenessError(strings.Split(data["column"].(string), ", "))
 	case RecordNotFoundError:
-		if errorResponse.Message != "" {
-			return common.RuntimeError{
-				Code:    common.ErrRecordNotFound,
-				Message: errorResponse.Message,
-			}
-		}
-		return common.NewNotFoundError()
+		return common.NewNotFoundError(errorResponse.Message)
 	case BadRequestError:
 		return common.NewValidationError(errorResponse.Message)
 	case DatabaseError:

--- a/integration/testdata/events_basic/tests.test.ts
+++ b/integration/testdata/events_basic/tests.test.ts
@@ -58,7 +58,7 @@ test("events from failed hook function with rollback", async () => {
   await expect(
     actions.createPersonFn({ name: "", email: "keelson@keel.so" })
   ).toHaveError({
-    code: "ERR_INTERNAL",
+    code: "ERR_UNKNOWN",
   });
 
   const persons = await models.person.findMany();
@@ -67,7 +67,7 @@ test("events from failed hook function with rollback", async () => {
 
 test("events from failed job", async () => {
   await expect(jobs.createRandomPersons({ raiseException: true })).toHaveError({
-    code: "ERR_INTERNAL",
+    code: "ERR_UNKNOWN",
   });
 
   const persons = await models.person.findMany();
@@ -83,7 +83,7 @@ test("events from failed custom function with rollback", async () => {
   await expect(
     actions.writeRandomPersons({ raiseException: true })
   ).toHaveError({
-    code: "ERR_INTERNAL",
+    code: "ERR_UNKNOWN",
   });
 
   const persons = await models.person.findMany();

--- a/integration/testdata/functions_errors/functions/badRequest.ts
+++ b/integration/testdata/functions_errors/functions/badRequest.ts
@@ -1,0 +1,8 @@
+import { BadRequest, errors } from "@teamkeel/sdk";
+
+// To learn more about what you can do with custom functions, visit https://docs.keel.so/functions
+export default BadRequest(async (ctx, inputs) => {
+  throw new errors.BadRequest("invalid inputs");
+
+  return;
+});

--- a/integration/testdata/functions_errors/functions/hookNotFound.ts
+++ b/integration/testdata/functions_errors/functions/hookNotFound.ts
@@ -1,0 +1,11 @@
+import { errors, HookNotFound, HookNotFoundHooks } from "@teamkeel/sdk";
+
+// To learn more about what you can do with hooks, visit https://docs.keel.so/functions
+const hooks: HookNotFoundHooks = {
+  beforeQuery(ctx, inputs, query) {
+    throw new errors.NotFound();
+    return query;
+  },
+};
+
+export default HookNotFound(hooks);

--- a/integration/testdata/functions_errors/functions/hookNotFoundCustomMessage.ts
+++ b/integration/testdata/functions_errors/functions/hookNotFoundCustomMessage.ts
@@ -1,0 +1,15 @@
+import {
+  errors,
+  HookNotFoundCustomMessage,
+  HookNotFoundCustomMessageHooks,
+} from "@teamkeel/sdk";
+
+// To learn more about what you can do with hooks, visit https://docs.keel.so/functions
+const hooks: HookNotFoundCustomMessageHooks = {
+  beforeQuery(ctx, inputs, query) {
+    throw new errors.NotFound("nothing here");
+    return query;
+  },
+};
+
+export default HookNotFoundCustomMessage(hooks);

--- a/integration/testdata/functions_errors/main.test.ts
+++ b/integration/testdata/functions_errors/main.test.ts
@@ -1,0 +1,46 @@
+import { models, actions, resetDatabase } from "@teamkeel/testing";
+import { test, beforeEach, expect } from "vitest";
+
+beforeEach(resetDatabase);
+
+class CustomError extends Error {
+  code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+test("Not found errors", async () => {
+  await expect(
+    (async () => {
+      await actions.hookNotFound({
+        id: "123",
+      });
+    })()
+  ).rejects.toThrowError(
+    new CustomError("ERR_RECORD_NOT_FOUND", "record not found")
+  );
+
+  await expect(
+    (async () => {
+      await actions.hookNotFoundCustomMessage({
+        id: "123",
+      });
+    })()
+  ).rejects.toThrowError(
+    new CustomError("ERR_RECORD_NOT_FOUND", "nothing here")
+  );
+});
+
+test("Bad request errors", async () => {
+  await expect(
+    (async () => {
+      await actions.badRequest({
+        id: "123",
+      });
+    })()
+  ).rejects.toThrowError(
+    new CustomError("ERR_INVALID_INPUT", "invalid inputs")
+  );
+});

--- a/integration/testdata/functions_errors/schema.keel
+++ b/integration/testdata/functions_errors/schema.keel
@@ -1,0 +1,16 @@
+model Foo {
+    fields {
+        bar Text
+    }
+
+    actions {
+        get hookNotFound(id) @function
+        get hookNotFoundCustomMessage(id) @function
+        read badRequest(id) returns (Any)
+    }
+
+    @permission(
+        actions: [get],
+        expression: true
+    )
+}

--- a/integration/testdata/functions_hooks/main.test.ts
+++ b/integration/testdata/functions_hooks/main.test.ts
@@ -69,7 +69,7 @@ test("create afterWrite - error and rollback", async () => {
       title: "Lady Chatterley's Lover",
     })
   ).rejects.toEqual({
-    code: "ERR_INTERNAL",
+    code: "ERR_UNKNOWN",
     message: "this book is banned",
   });
 

--- a/integration/testdata/jobs_permissions/tests.test.ts
+++ b/integration/testdata/jobs_permissions/tests.test.ts
@@ -236,7 +236,7 @@ test("job - exception - internal error without rollback transaction", async () =
   await expect(
     jobs.withIdentity(identity).manualJobWithException({ id })
   ).toHaveError({
-    code: "ERR_INTERNAL",
+    code: "ERR_UNKNOWN",
     message: "something bad has happened!",
   });
 

--- a/integration/testdata/subscribers_basic/tests.test.ts
+++ b/integration/testdata/subscribers_basic/tests.test.ts
@@ -52,7 +52,7 @@ test("subscriber - exception - internal error without rollback transaction", asy
   };
 
   await expect(subscribers.subscriberWithException(event)).toHaveError({
-    code: "ERR_INTERNAL",
+    code: "ERR_UNKNOWN",
     message: "something bad has happened!",
   });
 

--- a/node/codegen.go
+++ b/node/codegen.go
@@ -1252,7 +1252,7 @@ func toCustomFunctionReturnType(model *proto.Model, op *proto.Action, isTestingP
 			returnType += op.ResponseMessageName
 		}
 	}
-	returnType += ">"
+	returnType += "| Error>"
 	return returnType
 }
 

--- a/node/codegen.go
+++ b/node/codegen.go
@@ -83,6 +83,7 @@ func generateSdkPackage(schema *proto.Schema, cfg *config.ProjectConfig) codegen
 	writeAPIFactory(sdk, schema)
 	sdk.Writeln("module.exports.useDatabase = runtime.useDatabase;")
 	sdk.Writeln("module.exports.InlineFile = runtime.InlineFile;")
+	sdk.Writeln("module.exports.errors = runtime.ErrorPresets;")
 
 	for _, model := range schema.Models {
 		writeTableInterface(sdkTypes, model)
@@ -846,6 +847,7 @@ func writeAPIDeclarations(w *codegen.Writer, schema *proto.Schema) {
 	w.Writeln("}")
 	w.Writeln("export declare const models: ModelsAPI;")
 	w.Writeln("export declare const permissions: runtime.Permissions;")
+	w.Writeln("export declare const errors: runtime.Errors;")
 
 	w.Writeln("type Environment = {")
 
@@ -1661,6 +1663,7 @@ func writeTestingTypes(w *codegen.Writer, schema *proto.Schema) {
 	w.Writeln("export declare const actions: ActionExecutor;")
 	w.Writeln("export declare const models: sdk.ModelsAPI;")
 	w.Writeln("export declare function resetDatabase(): Promise<void>;")
+
 }
 
 func toTypeScriptType(t *proto.TypeInfo, isTestingPackage bool) (ret string) {

--- a/node/codegen_test.go
+++ b/node/codegen_test.go
@@ -494,6 +494,7 @@ export type ModelsAPI = {
 }
 export declare const models: ModelsAPI;
 export declare const permissions: runtime.Permissions;
+export declare const errors: runtime.Errors;
 type Environment = {
 	TEST: string;
 }
@@ -2420,6 +2421,7 @@ func runWriterTest(t *testing.T, schemaString string, expected string, fn func(s
 	diff := diffmatchpatch.New()
 	diffs := diff.DiffMain(normalise(expected), normalise(w.String()), true)
 	if !strings.Contains(normalise(w.String()), normalise(expected)) {
+
 		t.Errorf("generated code does not match expected:\n%s", diffPrettyText(diffs))
 		t.Errorf("\nExpected:\n---------\n%s", normalise(expected))
 		t.Errorf("\nActual:\n---------\n%s", normalise(w.String()))

--- a/node/templates/functions/types.d.ts
+++ b/node/templates/functions/types.d.ts
@@ -9,8 +9,12 @@ type GetFunctionHooks<M, QB, I> = {
     ctx: ContextAPI,
     inputs: I,
     query: QB
-  ) => Promise<QB | M | null> | QB | M | null;
-  afterQuery?: (ctx: ContextAPI, inputs: I, record: M) => Promise<M> | M;
+  ) => Promise<QB | M | null | Error> | QB | M | null | Error;
+  afterQuery?: (
+    ctx: ContextAPI,
+    inputs: I,
+    record: M
+  ) => Promise<M | Error> | M | Error;
 };
 
 /**
@@ -24,12 +28,12 @@ type ListFunctionHooks<M, QB, I> = {
     ctx: ContextAPI,
     inputs: I,
     query: QB
-  ) => Promise<QB | Array<M>> | QB | Array<M>;
+  ) => Promise<QB | Array<M> | Error> | QB | Array<M> | Error;
   afterQuery?: (
     ctx: ContextAPI,
     inputs: I,
     records: Array<M>
-  ) => Promise<Array<M>> | Array<M>;
+  ) => Promise<Array<M> | Error> | Array<M> | Error;
 };
 
 /**
@@ -41,12 +45,16 @@ type ListFunctionHooks<M, QB, I> = {
  * @typeParam C - The values that will be used to create an M record
  */
 type CreateFunctionHooks<M, QB, I, V, C> = {
-  beforeWrite?: (ctx: ContextAPI, inputs: I, values: V) => Promise<C> | C;
+  beforeWrite?: (
+    ctx: ContextAPI,
+    inputs: I,
+    values: V
+  ) => Promise<C | Error> | C | Error;
   afterWrite?: (
     ctx: ContextAPI,
     inputs: I,
     data: M
-  ) => Promise<M | void> | M | void;
+  ) => Promise<M | void | Error> | M | void | Error;
 };
 
 /**
@@ -61,18 +69,18 @@ type UpdateFunctionHooks<M, QB, I, V> = {
     ctx: ContextAPI,
     inputs: I,
     query: QB
-  ) => Promise<M | QB> | M | QB;
+  ) => Promise<M | QB | Error> | M | QB | Error;
   beforeWrite?: (
     ctx: ContextAPI,
     inputs: I,
     values: V,
     record: M
-  ) => Promise<Partial<M>> | Partial<M>;
+  ) => Promise<Partial<M> | Error> | Partial<M> | Error;
   afterWrite?: (
     ctx: ContextAPI,
     inputs: I,
     data: M
-  ) => Promise<M | void> | M | void;
+  ) => Promise<M | void | Error> | M | void | Error;
 };
 
 /**
@@ -86,7 +94,15 @@ type DeleteFunctionHooks<M, QB, I> = {
     ctx: ContextAPI,
     inputs: I,
     query: QB
-  ) => Promise<M | QB> | M | QB;
-  beforeWrite?: (ctx: ContextAPI, inputs: I, record: M) => Promise<void> | void;
-  afterWrite?: (ctx: ContextAPI, inputs: I, data: M) => Promise<void> | void;
+  ) => Promise<M | QB | Error> | M | QB | Error;
+  beforeWrite?: (
+    ctx: ContextAPI,
+    inputs: I,
+    record: M
+  ) => Promise<void | Error> | void | Error;
+  afterWrite?: (
+    ctx: ContextAPI,
+    inputs: I,
+    data: M
+  ) => Promise<void | Error> | void | Error;
 };

--- a/packages/functions-runtime/src/handleJob.test.js
+++ b/packages/functions-runtime/src/handleJob.test.js
@@ -163,7 +163,7 @@ describe("ModelAPI error handling", () => {
       jsonrpc: "2.0",
       error: {
         code: RuntimeErrors.RecordNotFoundError,
-        message: "no result",
+        message: "",
       },
     });
   });

--- a/packages/functions-runtime/src/handleRequest.js
+++ b/packages/functions-runtime/src/handleRequest.js
@@ -20,6 +20,10 @@ async function handleRequest(request, config) {
     request.meta?.tracing
   );
 
+  if (process.env.KEEL_LOG_LEVEL == "debug") {
+    console.log(request);
+  }
+
   // Run the whole request with the extracted context
   return opentelemetry.context.with(activeContext, () => {
     // Wrapping span for the whole request

--- a/packages/functions-runtime/src/handleRequest.js
+++ b/packages/functions-runtime/src/handleRequest.js
@@ -79,6 +79,15 @@ async function handleRequest(request, config) {
           }
         );
 
+        if (result instanceof Error) {
+          span.recordException(result);
+          span.setStatus({
+            code: opentelemetry.SpanStatusCode.ERROR,
+            message: result.message,
+          });
+          return errorToJSONRPCResponse(request, result);
+        }
+
         const response = createJSONRPCSuccessResponse(request.id, result);
 
         const responseHeaders = {};

--- a/packages/functions-runtime/src/handleRequest.test.js
+++ b/packages/functions-runtime/src/handleRequest.test.js
@@ -210,6 +210,38 @@ test("when a NotFound error preset is thrown in the custom function", async () =
   });
 });
 
+test("when a NotFound error preset is returned in the custom function", async () => {
+  const config = {
+    functions: {
+      createPost: async (ctx, inputs) => {
+        new Permissions().allow();
+        return new ErrorPresets.NotFound("not here");
+      },
+    },
+    actionTypes: {
+      createPost: PROTO_ACTION_TYPES.CREATE,
+    },
+    createContextAPI: () => {
+      return {
+        response: {
+          headers: new Headers(),
+        },
+      };
+    },
+  };
+
+  const rpcReq = createJSONRPCRequest("123", "createPost", { title: "a post" });
+
+  expect(await handleRequest(rpcReq, config)).toEqual({
+    id: "123",
+    jsonrpc: "2.0",
+    error: {
+      code: RuntimeErrors.RecordNotFoundError,
+      message: "not here",
+    },
+  });
+});
+
 test("when a BadRequest error preset is thrown in the custom function", async () => {
   const config = {
     functions: {

--- a/packages/functions-runtime/src/index.d.ts
+++ b/packages/functions-runtime/src/index.d.ts
@@ -77,15 +77,15 @@ export type NumberArrayQueryWhereCondition = {
 };
 
 export type BooleanArrayWhereCondition = {
-  equals?: bool[] | null;
-  notEquals?: bool[] | null;
+  equals?: boolean[] | null;
+  notEquals?: boolean[] | null;
   any?: BooleanArrayQueryWhereCondition | null;
   all?: BooleanArrayQueryWhereCondition | null;
 };
 
 export type BooleanArrayQueryWhereCondition = {
-  equals?: bool | null;
-  notEquals?: bool | null;
+  equals?: boolean | null;
+  notEquals?: boolean | null;
 };
 
 export type DateArrayWhereCondition = {
@@ -136,3 +136,25 @@ export declare class Permissions {
   // deny() can be used to explicitly deny access to an action
   deny(): never;
 }
+
+declare class NotFoundError extends Error {}
+declare class BadRequestError extends Error {}
+declare class UnknownError extends Error {}
+
+export type Errors = {
+  /**
+   * Returns a 404 HTTP status with an optional message.
+   * This error indicates that the requested resource could not be found.
+   */
+  NotFound: typeof NotFoundError;
+  /**
+   * Returns a 400 HTTP status with an optional message.
+   * This error indicates that the request made by the client is invalid or malformed.
+   */
+  BadRequest: typeof BadRequestError;
+  /**
+   * Returns a 500 HTTP status with an optional message.
+   * This error indicates that an unexpected condition was encountered, preventing the server from fulfilling the request.
+   */
+  Unknown: typeof UnknownError;
+};

--- a/packages/functions-runtime/src/index.js
+++ b/packages/functions-runtime/src/index.js
@@ -12,6 +12,7 @@ const {
 } = require("./permissions");
 const tracing = require("./tracing");
 const { InlineFile } = require("./InlineFile");
+const { ErrorPresets } = require("./errors");
 
 module.exports = {
   ModelAPI,
@@ -25,6 +26,7 @@ module.exports = {
   PERMISSION_STATE,
   checkBuiltInPermissions,
   tracing,
+  ErrorPresets,
   ksuid() {
     return KSUID.randomSync().string;
   },

--- a/runtime/actions/delete.go
+++ b/runtime/actions/delete.go
@@ -67,7 +67,7 @@ func Delete(scope *Scope, input map[string]any) (res *string, err error) {
 	}
 
 	if row == nil {
-		return nil, common.NewNotFoundError()
+		return nil, common.NewNotFoundError("")
 	}
 
 	id, ok := row["id"].(string)

--- a/runtime/actions/update.go
+++ b/runtime/actions/update.go
@@ -64,7 +64,7 @@ func Update(scope *Scope, input map[string]any) (res map[string]any, err error) 
 	}
 
 	if res == nil {
-		return nil, common.NewNotFoundError()
+		return nil, common.NewNotFoundError("")
 	}
 
 	// if we have any files in our results we need to transform them to the object structure required

--- a/runtime/common/common.go
+++ b/runtime/common/common.go
@@ -97,6 +97,8 @@ const (
 	ErrMethodNotFound = "ERR_ACTION_NOT_FOUND"
 	// The HTTP method is not allowed for this request.
 	ErrHttpMethodNotAllowed = "ERR_HTTP_METHOD_NOT_ALLOWED"
+	// An unexpected error happened from user code
+	ErrUnknown = "ERR_UNKNOWN"
 )
 
 type PermissionStatus string

--- a/runtime/common/common.go
+++ b/runtime/common/common.go
@@ -147,10 +147,13 @@ func NewValidationError(message string) RuntimeError {
 	}
 }
 
-func NewNotFoundError() RuntimeError {
+func NewNotFoundError(message string) RuntimeError {
+	if message == "" {
+		message = "record not found"
+	}
 	return RuntimeError{
 		Code:    ErrRecordNotFound,
-		Message: "record not found",
+		Message: message,
 	}
 }
 


### PR DESCRIPTION
* Export an `errors` object from the functions SDK with error classes which can be used to throw specific error types which when get transforms into the correct status codes in the response by the runtime
* Uses `ERR_UNKNOWN` instead of `ERR_INTERNAL` for general errors in the function to separate core runtime errors from user code errors

```typescript
import { errors } from "@teamkeel/sdk";

export default CustomFunction(async (ctx, inputs) => {
    throw new errors.NotFound("custom message"); // Returns a 404 with the standard runtime error strcuture
}
```