### PR TITLE
fix: reuse inlinefile transform function in jobs

### DIFF
--- a/runtime/actions/parsing.go
+++ b/runtime/actions/parsing.go
@@ -183,23 +183,15 @@ var toDate = func(value any) (types.Date, error) {
 //
 // e.g. for InlineFile inputs, whcih are given as a dataURL string, they need to be transformed into an object
 // including the typename
-func TransformCustomFunctionsInputTypes(schema *proto.Schema, action *proto.Action, input any) (any, error) {
-	inputsAsMap, isMap := input.(map[string]any)
-	if !isMap {
-		return input, nil
-	}
-
-	msg := proto.FindMessage(schema.Messages, action.InputMessageName)
-	if msg == nil {
-		return input, nil
-	}
+func TransformCustomFunctionsInputTypes(schema *proto.Schema, messageName string, input map[string]any) (map[string]any, error) {
+	message := proto.FindMessage(schema.Messages, messageName)
 
 	// for now the only complex input field is InlineFile
-	if msg.HasFiles() {
-		for _, f := range msg.FileFields() {
-			if inputsAsMap[f.GetName()] != nil {
-				dataURL := inputsAsMap[f.GetName()]
-				inputsAsMap[f.GetName()] = map[string]any{
+	if message.HasFiles() {
+		for _, f := range message.FileFields() {
+			if input[f.GetName()] != nil {
+				dataURL := input[f.GetName()]
+				input[f.GetName()] = map[string]any{
 					"__typename": parser.FieldTypeInlineFile,
 					"dataURL":    dataURL,
 				}
@@ -207,5 +199,5 @@ func TransformCustomFunctionsInputTypes(schema *proto.Schema, action *proto.Acti
 		}
 	}
 
-	return inputsAsMap, nil
+	return input, nil
 }

--- a/runtime/actions/parsing_test.go
+++ b/runtime/actions/parsing_test.go
@@ -289,15 +289,12 @@ message FileResponse {
 	err = json.Unmarshal([]byte(input), &data)
 	assert.NoError(t, err)
 
-	parsed, err := actions.TransformCustomFunctionsInputTypes(scope.Schema, action, data)
+	parsed, err := actions.TransformCustomFunctionsInputTypes(scope.Schema, action.InputMessageName, data)
 	assert.NoError(t, err)
 
-	assert.IsType(t, map[string]any{}, parsed)
-	asMap, _ := parsed.(map[string]any)
+	assert.IsType(t, map[string]any{}, parsed["file"])
 
-	assert.IsType(t, map[string]any{}, asMap["file"])
-
-	file := asMap["file"].(map[string]any)
+	file := parsed["file"].(map[string]any)
 	assert.Equal(t, "InlineFile", file["__typename"])
 	assert.Equal(t, dataUrl, file["dataURL"])
 }

--- a/runtime/actions/scope.go
+++ b/runtime/actions/scope.go
@@ -106,11 +106,13 @@ func Execute(scope *Scope, input any) (result any, meta *common.ResponseMetadata
 
 	switch scope.Action.Implementation {
 	case proto.ActionImplementation_ACTION_IMPLEMENTATION_CUSTOM:
-		parsedInputs, parseErr := TransformCustomFunctionsInputTypes(scope.Schema, scope.Action, input)
-		if parseErr != nil {
-			return nil, nil, parseErr
+		if isMap {
+			input, err = TransformCustomFunctionsInputTypes(scope.Schema, scope.Action.InputMessageName, inputsAsMap)
+			if err != nil {
+				return nil, nil, err
+			}
 		}
-		result, meta, err = executeCustomFunction(scope, parsedInputs)
+		result, meta, err = executeCustomFunction(scope, input)
 	case proto.ActionImplementation_ACTION_IMPLEMENTATION_RUNTIME:
 		if !isMap {
 			if input == nil {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -181,7 +181,7 @@ func NewJobHandler(currSchema *proto.Schema) JobHandler {
 }
 
 // RunJob will run the job function in the runtime.
-func (handler JobHandler) RunJob(ctx context.Context, jobName string, inputs map[string]any, trigger functions.TriggerType) error {
+func (handler JobHandler) RunJob(ctx context.Context, jobName string, input map[string]any, trigger functions.TriggerType) error {
 	ctx, span := tracer.Start(ctx, "Run job")
 	defer span.End()
 
@@ -209,10 +209,15 @@ func (handler JobHandler) RunJob(ctx context.Context, jobName string, inputs map
 		}
 	}
 
-	err := functions.CallJob(
+	input, err := actions.TransformCustomFunctionsInputTypes(handler.schema, job.InputMessageName, input)
+	if err != nil {
+		return err
+	}
+
+	err = functions.CallJob(
 		ctx,
 		job,
-		inputs,
+		input,
 		permissionState,
 		trigger,
 	)


### PR DESCRIPTION
Reusing the `InlineFile` transform function in the job handler.  