### PR TITLE
fix: in operator using array operands

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
           go-version: "1.20"
       - uses: actions/checkout@v4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           version: latest
           args: --timeout=3m

--- a/cmd/program/views.go
+++ b/cmd/program/views.go
@@ -229,7 +229,7 @@ func renderError(m *Model) string {
 				b.WriteString("\n")
 			}
 
-			if dbErr.Columns != nil && len(dbErr.Columns) > 0 {
+			if len(dbErr.Columns) > 0 {
 				b.WriteString(colors.Red("Column(s): ").String())
 				b.WriteString(colors.Red(strings.Join(dbErr.Columns, ", ")).String())
 				b.WriteString("\n")

--- a/db/gorm.go
+++ b/db/gorm.go
@@ -73,7 +73,9 @@ func (db *GormDB) ExecuteStatement(ctx context.Context, sqlQuery string, args ..
 	return &ExecuteStatementResult{RowsAffected: result.RowsAffected}, nil
 }
 
-var transactionCtxKey struct{}
+type transactionContextKey string
+
+var transactionCtxKey transactionContextKey
 
 func (db *GormDB) Transaction(ctx context.Context, fn func(context.Context) error) error {
 	ctx, span := tracer.Start(ctx, "Database Transaction")

--- a/integration/testdata/arrays_relationships/schema.keel
+++ b/integration/testdata/arrays_relationships/schema.keel
@@ -5,12 +5,12 @@ model Collection {
     }
 
     actions {
-        create createCollection() with (name, books.title, books.genres) {
+        create createCollection() with (name, books.title, books.genres, books.author?) {
             @permission(expression: true)
         }
 
         create createCollectionSetGenres() with (name, books.title) {
-            @set(collection.books.genres = ["all", "new"])
+            @set(collection.books.genres = [Genre.All, Genre.New])
             @permission(expression: true)
         }
 
@@ -19,30 +19,71 @@ model Collection {
             @permission(expression: true)
         }
 
-         list listEqualsCollection() {
-            @where(collection.books.genres == ["fantasy", "science fiction"])
+        list listEqualsCollection() {
+            @where(collection.books.genres == [Genre.Fantasy, Genre.ScienceFiction])
             @orderBy(name: asc)
             @permission(expression: true)
         }
 
-         list listInCollection() {
-            @where("fantasy" in collection.books.genres)
+        list listInCollection(genre: Genre) {
+            @where(genre in collection.books.genres)
             @orderBy(name: asc)
             @permission(expression: true)
         }
 
-         list listNotInCollection() {
-            @where("thriller" not in collection.books.genres)
+        list listNotInCollection(genre: Genre) {
+            @where(genre not in collection.books.genres)
+            @orderBy(name: asc)
+            @permission(expression: true)
+        }
+
+        list suggestedCollections() {
+            @where(ctx.identity.person.favouriteGenre in collection.books.genres)
             @orderBy(name: asc)
             @permission(expression: true)
         }
     }
 }
 
+enum Genre {
+    Fantasy
+    ScienceFiction
+    All
+    New
+    Thriller
+    Science
+    School
+    Math
+    EasyReads
+}
+
 model Book {
     fields {
         col Collection
         title Text
-        genres Text[]
+        genres Genre[]
+        author Text?
+    }
+
+    actions {
+        list suggestedBooksByGenre() {
+            @where(ctx.identity.person.favouriteGenre in book.genres)
+            @orderBy(title: asc)
+            @permission(expression: true)
+        }
+
+        list suggestedBooksByAuthor() {
+            @where(book.author in ctx.identity.person.favouriteAuthors)
+            @orderBy(title: asc)
+            @permission(expression: true)
+        }
+    }
+}
+
+model Person {
+    fields {
+        favouriteGenre Genre
+        favouriteAuthors Text[]
+        identity Identity @unique
     }
 }

--- a/integration/testdata/arrays_relationships/tests.test.ts
+++ b/integration/testdata/arrays_relationships/tests.test.ts
@@ -1,71 +1,303 @@
 import { actions, models, resetDatabase } from "@teamkeel/testing";
+import { Genre } from "@teamkeel/sdk"
 import { test, expect, beforeEach } from "vitest";
 
 beforeEach(resetDatabase);
 
-test("array relationships - nested creates", async () => {
-  const collection = await actions.createCollection({
-    name: "Favourites",
-    books: [
-      {
-        title: "Lord of the Rings",
-        genres: ["fantasy", "science fiction"],
-      },
-      {
-        title: "Into Thin Air",
-        genres: ["thriller"],
-      },
-    ],
-  });
+// test("array relationships - nested creates", async () => {
+//   const collection = await actions.createCollection({
+//     name: "Favourites",
+//     books: [
+//       {
+//         title: "Lord of the Rings",
+//         genres: [Genre.Fantasy, Genre.ScienceFiction],
+//       },
+//       {
+//         title: "Into Thin Air",
+//         genres: [Genre.Thriller],
+//       },
+//     ],
+//   });
 
-  const books = await models.book.findMany({
-    where: { colId: collection.id },
-    orderBy: { title: "DESC" },
-  });
+//   const books = await models.book.findMany({
+//     where: { colId: collection.id },
+//     orderBy: { title: "DESC" },
+//   });
 
-  expect(books).toHaveLength(2);
-  expect(books[0].title).toEqual("Lord of the Rings");
-  expect(books[0].genres).toEqual(["fantasy", "science fiction"]);
-  expect(books[1].title).toEqual("Into Thin Air");
-  expect(books[1].genres).toEqual(["thriller"]);
-});
+//   expect(books).toHaveLength(2);
+//   expect(books[0].title).toEqual("Lord of the Rings");
+//   expect(books[0].genres).toEqual([Genre.Fantasy, Genre.ScienceFiction]);
+//   expect(books[1].title).toEqual("Into Thin Air");
+//   expect(books[1].genres).toEqual([Genre.Thriller]);
+// });
 
-test("array relationships - nested creates with @set", async () => {
-  const collection = await actions.createCollectionSetGenres({
-    name: "Favourites",
-    books: [
-      {
-        title: "Lord of the Rings",
-      },
-      {
-        title: "Into Thin Air",
-      },
-    ],
-  });
+// test("array relationships - nested creates with @set", async () => {
+//   const collection = await actions.createCollectionSetGenres({
+//     name: "Favourites",
+//     books: [
+//       {
+//         title: "Lord of the Rings",
+//       },
+//       {
+//         title: "Into Thin Air",
+//       },
+//     ],
+//   });
 
-  const books = await models.book.findMany({
-    where: { colId: collection.id },
-    orderBy: { title: "DESC" },
-  });
+//   const books = await models.book.findMany({
+//     where: { colId: collection.id },
+//     orderBy: { title: "DESC" },
+//   });
 
-  expect(books).toHaveLength(2);
-  expect(books[0].title).toEqual("Lord of the Rings");
-  expect(books[0].genres).toEqual(["all", "new"]);
-  expect(books[1].title).toEqual("Into Thin Air");
-  expect(books[1].genres).toEqual(["all", "new"]);
-});
+//   expect(books).toHaveLength(2);
+//   expect(books[0].title).toEqual("Lord of the Rings");
+//   expect(books[0].genres).toEqual([Genre.All, Genre.New]);
+//   expect(books[1].title).toEqual("Into Thin Air");
+//   expect(books[1].genres).toEqual([Genre.All, Genre.New]);
+// });
 
-test("array relationships - nested query by array equals", async () => {
+// test("array relationships - nested query by array equals", async () => {
+//   const favourites = await actions.createCollection({
+//     name: "Favourites",
+//     books: [
+//       {
+//         title: "Lord of the Rings",
+//         genres: [Genre.Fantasy, Genre.ScienceFiction],
+//       },
+//       {
+//         title: "Into Thin Air",
+//         genres: [Genre.Thriller],
+//       },
+//     ],
+//   });
+
+//   const children = await actions.createCollection({
+//     name: "Children",
+//     books: [
+//       {
+//         title: "Hobbit",
+//         genres: [Genre.Fantasy, Genre.ScienceFiction],
+//       },
+//       {
+//         title: "The Book of Why",
+//         genres: [Genre.Science],
+//       },
+//     ],
+//   });
+
+//   const collections = await actions.listCollection({
+//     where: { books: { genres: { equals: [Genre.Science] } } },
+//   });
+//   expect(collections.results).toHaveLength(1);
+//   expect(collections.results[0].id).toEqual(children.id);
+// });
+
+// test("array relationships - nested expression array equals", async () => {
+//   const favourites = await actions.createCollection({
+//     name: "Favourites",
+//     books: [
+//       {
+//         title: "Lord of the Rings",
+//         genres: [Genre.Fantasy, Genre.ScienceFiction],
+//       },
+//       {
+//         title: "Into Thin Air",
+//         genres: [Genre.Thriller],
+//       },
+//     ],
+//   });
+
+//   const children = await actions.createCollection({
+//     name: "Children",
+//     books: [
+//       {
+//         title: "Hobbit",
+//         genres: [Genre.Fantasy, Genre.ScienceFiction],
+//       },
+//       {
+//         title: "The Book of Why",
+//         genres: [Genre.Science],
+//       },
+//     ],
+//   });
+
+//   const maths = await actions.createCollection({
+//     name: "Education",
+//     books: [
+//       {
+//         title: "Maths 101",
+//         genres: [Genre.School, Genre.Math],
+//       },
+//     ],
+//   });
+
+//   const collections = await actions.listEqualsCollection();
+//   expect(collections.results).toHaveLength(2);
+//   expect(collections.results[0].id).toEqual(children.id);
+//   expect(collections.results[1].id).toEqual(favourites.id);
+// });
+
+// test("array relationships - nested expression array in 1", async () => {
+//   const favourites = await actions.createCollection({
+//     name: "Favourites",
+//     books: [
+//       {
+//         title: "Lord of the Rings",
+//         genres: [Genre.Fantasy,Genre.ScienceFiction],
+//       },
+//       {
+//         title: "Into Thin Air",
+//         genres: [Genre.Thriller],
+//       },
+//     ],
+//   });
+
+//   const children = await actions.createCollection({
+//     name: "Children",
+//     books: [
+//       {
+//         title: "The Book of Why",
+//         genres: [Genre.Science],
+//       },
+//       {
+//         title: "Hobbit",
+//         genres: [Genre.EasyReads,Genre.Fantasy],
+//       },
+//     ],
+//   });
+
+//   const maths = await actions.createCollection({
+//     name: "Education",
+//     books: [
+//       {
+//         title: "Maths 101",
+//         genres: [Genre.School, Genre.Math],
+//       },
+//     ],
+//   });
+
+//   const collections1 = await actions.listInCollection({ where: {genre: Genre.Fantasy}});
+//   expect(collections1.results).toHaveLength(2);
+//   expect(collections1.results[0].id).toEqual(children.id);
+//   expect(collections1.results[1].id).toEqual(favourites.id);
+
+//   const collections2 = await actions.listInCollection({ where: {genre: Genre.Science}});
+//   expect(collections2.results).toHaveLength(1);
+//   expect(collections2.results[0].id).toEqual(children.id);
+
+//   const collections3 = await actions.listInCollection({ where: {genre: Genre.New}});
+//   expect(collections3.results).toHaveLength(0);
+// });
+
+
+// // WTF!?
+// // test("array relationships - nested expression array not in", async () => {
+// //   const favourites = await actions.createCollection({
+// //     name: "Favourites",
+// //     books: [
+// //       {
+// //         title: "Lord of the Rings",
+// //         genres: ["fantasy", "science fiction"],
+// //       },
+// //       {
+// //         title: "Into Thin Air",
+// //         genres: ["thriller"],
+// //       },
+// //     ],
+// //   });
+
+// //   const children = await actions.createCollection({
+// //     name: "Children",
+// //     books: [
+// //       {
+// //         title: "The Book of Why",
+// //         genres: ["science"],
+// //       },
+// //       {
+// //         title: "Hobbit",
+// //         genres: ["easy reads", "fantasy"],
+// //       },
+// //     ],
+// //   });
+
+// //   const computers = await actions.createCollection({
+// //     name: "Computers",
+// //     books: [
+// //       {
+// //         title: "C++ For Dummies",
+// //         genres: ["computer science"],
+// //       },
+// //       {
+// //         title: "PC Master Race",
+// //         genres: ["technology"],
+// //       },
+// //     ],
+// //   });
+
+// //   console.log(await models.collection.findMany());
+// //   console.log(await models.book.findMany());
+
+// //   const collections = await actions.listNotInCollection({ where: {genre: "sdfsd"}});
+// //   console.log(collections.results);
+// //   expect(collections.results).toHaveLength(1);
+// //   expect(collections.results[0].id).toEqual(computers.id);
+
+// // });
+
+
+// test("array relationships - nested expression array in 2", async () => {
+//   const favourites = await actions.createCollection({
+//     name: "Favourites",
+//     books: [
+//       {
+//         title: "Lord of the Rings",
+//         genres: [Genre.Fantasy, Genre.ScienceFiction],
+//       },
+//       {
+//         title: "Into Thin Air",
+//         genres: [Genre.Thriller],
+//       },
+//     ],
+//   });
+
+//   const children = await actions.createCollection({
+//     name: "Children",
+//     books: [
+//       {
+//         title: "Hobbit",
+//         genres: [Genre.Fantasy, Genre.ScienceFiction],
+//       },
+//       {
+//         title: "The Book of Why",
+//         genres: [Genre.Science],
+//       },
+//     ],
+//   });
+
+//   const identity = await models.identity.create({ });
+//   await models.person.create({ identityId: identity.id, favouriteGenre: Genre.Fantasy, favouriteAuthors: ["Tolkien", "Tom"]});
+
+
+//   const books = await actions.withIdentity(identity).suggestedBooksByGenre();
+//   expect(books.results).toHaveLength(2);
+//   expect(books.results[0].title).toEqual("Hobbit");
+//   expect(books.results[1].title).toEqual("Lord of the Rings");
+// });
+
+
+test("array relationships - nested expression array in 3", async () => {
   const favourites = await actions.createCollection({
     name: "Favourites",
     books: [
       {
         title: "Lord of the Rings",
-        genres: ["fantasy", "science fiction"],
+        genres: [Genre.Fantasy, Genre.ScienceFiction],
+         author: "Tolkien"
       },
       {
         title: "Into Thin Air",
-        genres: ["thriller"],
+        genres: [Genre.Thriller],
+         author: "Tom"
       },
     ],
   });
@@ -75,33 +307,42 @@ test("array relationships - nested query by array equals", async () => {
     books: [
       {
         title: "Hobbit",
-        genres: ["fantasy", "science fiction"],
+        genres: [Genre.Fantasy, Genre.ScienceFiction],
+        author: "Tolkien"
       },
       {
         title: "The Book of Why",
-        genres: ["science"],
+        genres: [Genre.Science],
+        author: "Dave"
       },
     ],
   });
 
-  const collections = await actions.listCollection({
-    where: { books: { genres: { equals: ["science"] } } },
-  });
-  expect(collections.results).toHaveLength(1);
-  expect(collections.results[0].id).toEqual(children.id);
+  const identity = await models.identity.create({ });
+  await models.person.create({ identityId: identity.id, favouriteGenre: Genre.Fantasy, favouriteAuthors: ["Tolkien", "Tom"]});
+
+
+  const books = await actions.withIdentity(identity).suggestedBooksByAuthor();
+  expect(books.results).toHaveLength(3);
+  expect(books.results[0].title).toEqual("Hobbit");
+  expect(books.results[1].title).toEqual("Into Thin Air");
+  expect(books.results[2].title).toEqual("Lord of the Rings");
 });
 
-test("array relationships - nested expression array equals", async () => {
+
+test("array relationships - nested expression array in 4", async () => {
   const favourites = await actions.createCollection({
     name: "Favourites",
     books: [
       {
         title: "Lord of the Rings",
-        genres: ["fantasy", "science fiction"],
+        genres: [Genre.Fantasy, Genre.ScienceFiction],
+         author: "Tolkien"
       },
       {
         title: "Into Thin Air",
-        genres: ["thriller"],
+        genres: [Genre.Thriller],
+         author: "Tom"
       },
     ],
   });
@@ -111,107 +352,31 @@ test("array relationships - nested expression array equals", async () => {
     books: [
       {
         title: "Hobbit",
-        genres: ["fantasy", "science fiction"],
+        genres: [Genre.Fantasy, Genre.ScienceFiction],
+        author: "Tolkien"
       },
       {
         title: "The Book of Why",
-        genres: ["science"],
+        genres: [Genre.Science],
+        author: "Dave"
       },
     ],
   });
 
-  const maths = await actions.createCollection({
-    name: "Education",
-    books: [
-      {
-        title: "Maths 101",
-        genres: ["school", "math"],
-      },
-    ],
-  });
 
-  const collections = await actions.listEqualsCollection();
-  expect(collections.results).toHaveLength(2);
-  expect(collections.results[0].id).toEqual(children.id);
-  expect(collections.results[1].id).toEqual(favourites.id);
-});
+  const identity1 = await models.identity.create({ });
+  await models.person.create({ identityId: identity1.id, favouriteGenre: Genre.Thriller, favouriteAuthors: []});
 
-test("array relationships - nested expression array in", async () => {
-  const favourites = await actions.createCollection({
-    name: "Favourites",
-    books: [
-      {
-        title: "Lord of the Rings",
-        genres: ["fantasy", "science fiction"],
-      },
-      {
-        title: "Into Thin Air",
-        genres: ["thriller"],
-      },
-    ],
-  });
+  const collections1 = await actions.withIdentity(identity1).suggestedCollections();
+  expect(collections1.results).toHaveLength(1);
+  expect(collections1.results[0].name).toEqual("Favourites");
 
-  const children = await actions.createCollection({
-    name: "Children",
-    books: [
-      {
-        title: "Hobbit",
-        genres: ["fantasy", "science fiction"],
-      },
-      {
-        title: "The Book of Why",
-        genres: ["science"],
-      },
-    ],
-  });
+  const identity2 = await models.identity.create({ });
+  await models.person.create({ identityId: identity2.id, favouriteGenre: Genre.Fantasy, favouriteAuthors: []});
 
-  const maths = await actions.createCollection({
-    name: "Education",
-    books: [
-      {
-        title: "Maths 101",
-        genres: ["school", "math"],
-      },
-    ],
-  });
+  const collections2 = await actions.withIdentity(identity2).suggestedCollections();
+  expect(collections2.results).toHaveLength(2);
+  expect(collections2.results[0].name).toEqual("Children")
+  expect(collections2.results[1].name).toEqual("Favourites");
 
-  const collections = await actions.listEqualsCollection();
-  expect(collections.results).toHaveLength(2);
-  expect(collections.results[0].id).toEqual(children.id);
-  expect(collections.results[1].id).toEqual(favourites.id);
-});
-
-test("array relationships - nested expression array not in", async () => {
-  const favourites = await actions.createCollection({
-    name: "Favourites",
-    books: [
-      {
-        title: "Lord of the Rings",
-        genres: ["fantasy", "science fiction"],
-      },
-      {
-        title: "Into Thin Air",
-        genres: ["thriller"],
-      },
-    ],
-  });
-
-  const children = await actions.createCollection({
-    name: "Children",
-    books: [
-      {
-        title: "Hobbit",
-        genres: ["fantasy", "science fiction"],
-      },
-      {
-        title: "The Book of Why",
-        genres: ["science"],
-      },
-    ],
-  });
-
-  const collections = await actions.listEqualsCollection();
-  expect(collections.results).toHaveLength(2);
-  expect(collections.results[0].id).toEqual(children.id);
-  expect(collections.results[1].id).toEqual(favourites.id);
 });

--- a/integration/testdata/arrays_relationships/tests.test.ts
+++ b/integration/testdata/arrays_relationships/tests.test.ts
@@ -1,72 +1,213 @@
 import { actions, models, resetDatabase } from "@teamkeel/testing";
-import { Genre } from "@teamkeel/sdk"
+import { Genre } from "@teamkeel/sdk";
 import { test, expect, beforeEach } from "vitest";
 
 beforeEach(resetDatabase);
 
-// test("array relationships - nested creates", async () => {
-//   const collection = await actions.createCollection({
-//     name: "Favourites",
-//     books: [
-//       {
-//         title: "Lord of the Rings",
-//         genres: [Genre.Fantasy, Genre.ScienceFiction],
-//       },
-//       {
-//         title: "Into Thin Air",
-//         genres: [Genre.Thriller],
-//       },
-//     ],
-//   });
+test("array relationships - nested creates", async () => {
+  const collection = await actions.createCollection({
+    name: "Favourites",
+    books: [
+      {
+        title: "Lord of the Rings",
+        genres: [Genre.Fantasy, Genre.ScienceFiction],
+      },
+      {
+        title: "Into Thin Air",
+        genres: [Genre.Thriller],
+      },
+    ],
+  });
 
-//   const books = await models.book.findMany({
-//     where: { colId: collection.id },
-//     orderBy: { title: "DESC" },
-//   });
+  const books = await models.book.findMany({
+    where: { colId: collection.id },
+    orderBy: { title: "DESC" },
+  });
 
-//   expect(books).toHaveLength(2);
-//   expect(books[0].title).toEqual("Lord of the Rings");
-//   expect(books[0].genres).toEqual([Genre.Fantasy, Genre.ScienceFiction]);
-//   expect(books[1].title).toEqual("Into Thin Air");
-//   expect(books[1].genres).toEqual([Genre.Thriller]);
-// });
+  expect(books).toHaveLength(2);
+  expect(books[0].title).toEqual("Lord of the Rings");
+  expect(books[0].genres).toEqual([Genre.Fantasy, Genre.ScienceFiction]);
+  expect(books[1].title).toEqual("Into Thin Air");
+  expect(books[1].genres).toEqual([Genre.Thriller]);
+});
 
-// test("array relationships - nested creates with @set", async () => {
-//   const collection = await actions.createCollectionSetGenres({
-//     name: "Favourites",
-//     books: [
-//       {
-//         title: "Lord of the Rings",
-//       },
-//       {
-//         title: "Into Thin Air",
-//       },
-//     ],
-//   });
+test("array relationships - nested creates with @set", async () => {
+  const collection = await actions.createCollectionSetGenres({
+    name: "Favourites",
+    books: [
+      {
+        title: "Lord of the Rings",
+      },
+      {
+        title: "Into Thin Air",
+      },
+    ],
+  });
 
-//   const books = await models.book.findMany({
-//     where: { colId: collection.id },
-//     orderBy: { title: "DESC" },
-//   });
+  const books = await models.book.findMany({
+    where: { colId: collection.id },
+    orderBy: { title: "DESC" },
+  });
 
-//   expect(books).toHaveLength(2);
-//   expect(books[0].title).toEqual("Lord of the Rings");
-//   expect(books[0].genres).toEqual([Genre.All, Genre.New]);
-//   expect(books[1].title).toEqual("Into Thin Air");
-//   expect(books[1].genres).toEqual([Genre.All, Genre.New]);
-// });
+  expect(books).toHaveLength(2);
+  expect(books[0].title).toEqual("Lord of the Rings");
+  expect(books[0].genres).toEqual([Genre.All, Genre.New]);
+  expect(books[1].title).toEqual("Into Thin Air");
+  expect(books[1].genres).toEqual([Genre.All, Genre.New]);
+});
 
-// test("array relationships - nested query by array equals", async () => {
+test("array relationships - nested query by array equals", async () => {
+  const favourites = await actions.createCollection({
+    name: "Favourites",
+    books: [
+      {
+        title: "Lord of the Rings",
+        genres: [Genre.Fantasy, Genre.ScienceFiction],
+      },
+      {
+        title: "Into Thin Air",
+        genres: [Genre.Thriller],
+      },
+    ],
+  });
+
+  const children = await actions.createCollection({
+    name: "Children",
+    books: [
+      {
+        title: "Hobbit",
+        genres: [Genre.Fantasy, Genre.ScienceFiction],
+      },
+      {
+        title: "The Book of Why",
+        genres: [Genre.Science],
+      },
+    ],
+  });
+
+  const collections = await actions.listCollection({
+    where: { books: { genres: { equals: [Genre.Science] } } },
+  });
+  expect(collections.results).toHaveLength(1);
+  expect(collections.results[0].id).toEqual(children.id);
+});
+
+test("array relationships - nested expression array equals", async () => {
+  const favourites = await actions.createCollection({
+    name: "Favourites",
+    books: [
+      {
+        title: "Lord of the Rings",
+        genres: [Genre.Fantasy, Genre.ScienceFiction],
+      },
+      {
+        title: "Into Thin Air",
+        genres: [Genre.Thriller],
+      },
+    ],
+  });
+
+  const children = await actions.createCollection({
+    name: "Children",
+    books: [
+      {
+        title: "Hobbit",
+        genres: [Genre.Fantasy, Genre.ScienceFiction],
+      },
+      {
+        title: "The Book of Why",
+        genres: [Genre.Science],
+      },
+    ],
+  });
+
+  const maths = await actions.createCollection({
+    name: "Education",
+    books: [
+      {
+        title: "Maths 101",
+        genres: [Genre.School, Genre.Math],
+      },
+    ],
+  });
+
+  const collections = await actions.listEqualsCollection();
+  expect(collections.results).toHaveLength(2);
+  expect(collections.results[0].id).toEqual(children.id);
+  expect(collections.results[1].id).toEqual(favourites.id);
+});
+
+test("array relationships - nested expression array in 1", async () => {
+  const favourites = await actions.createCollection({
+    name: "Favourites",
+    books: [
+      {
+        title: "Lord of the Rings",
+        genres: [Genre.Fantasy, Genre.ScienceFiction],
+      },
+      {
+        title: "Into Thin Air",
+        genres: [Genre.Thriller],
+      },
+    ],
+  });
+
+  const children = await actions.createCollection({
+    name: "Children",
+    books: [
+      {
+        title: "The Book of Why",
+        genres: [Genre.Science],
+      },
+      {
+        title: "Hobbit",
+        genres: [Genre.EasyReads, Genre.Fantasy],
+      },
+    ],
+  });
+
+  const maths = await actions.createCollection({
+    name: "Education",
+    books: [
+      {
+        title: "Maths 101",
+        genres: [Genre.School, Genre.Math],
+      },
+    ],
+  });
+
+  const collections1 = await actions.listInCollection({
+    where: { genre: Genre.Fantasy },
+  });
+  expect(collections1.results).toHaveLength(2);
+  expect(collections1.results[0].id).toEqual(children.id);
+  expect(collections1.results[1].id).toEqual(favourites.id);
+
+  const collections2 = await actions.listInCollection({
+    where: { genre: Genre.Science },
+  });
+  expect(collections2.results).toHaveLength(1);
+  expect(collections2.results[0].id).toEqual(children.id);
+
+  const collections3 = await actions.listInCollection({
+    where: { genre: Genre.New },
+  });
+  expect(collections3.results).toHaveLength(0);
+});
+
+// There is a bug with 'not in'. See https://linear.app/keel/issue/KE-2194/arrays-and-not-in
+//
+// test("array relationships - nested expression array not in", async () => {
 //   const favourites = await actions.createCollection({
 //     name: "Favourites",
 //     books: [
 //       {
 //         title: "Lord of the Rings",
-//         genres: [Genre.Fantasy, Genre.ScienceFiction],
+//         genres: ["fantasy", "science fiction"],
 //       },
 //       {
 //         title: "Into Thin Air",
-//         genres: [Genre.Thriller],
+//         genres: ["thriller"],
 //       },
 //     ],
 //   });
@@ -75,215 +216,81 @@ beforeEach(resetDatabase);
 //     name: "Children",
 //     books: [
 //       {
-//         title: "Hobbit",
-//         genres: [Genre.Fantasy, Genre.ScienceFiction],
+//         title: "The Book of Why",
+//         genres: ["science"],
 //       },
 //       {
-//         title: "The Book of Why",
-//         genres: [Genre.Science],
+//         title: "Hobbit",
+//         genres: ["easy reads", "fantasy"],
 //       },
 //     ],
 //   });
 
-//   const collections = await actions.listCollection({
-//     where: { books: { genres: { equals: [Genre.Science] } } },
+//   const computers = await actions.createCollection({
+//     name: "Computers",
+//     books: [
+//       {
+//         title: "C++ For Dummies",
+//         genres: ["computer science"],
+//       },
+//       {
+//         title: "PC Master Race",
+//         genres: ["technology"],
+//       },
+//     ],
 //   });
+
+//   console.log(await models.collection.findMany());
+//   console.log(await models.book.findMany());
+
+//   const collections = await actions.listNotInCollection({ where: {genre: "sdfsd"}});
+//   console.log(collections.results);
 //   expect(collections.results).toHaveLength(1);
-//   expect(collections.results[0].id).toEqual(children.id);
+//   expect(collections.results[0].id).toEqual(computers.id);
+
 // });
 
-// test("array relationships - nested expression array equals", async () => {
-//   const favourites = await actions.createCollection({
-//     name: "Favourites",
-//     books: [
-//       {
-//         title: "Lord of the Rings",
-//         genres: [Genre.Fantasy, Genre.ScienceFiction],
-//       },
-//       {
-//         title: "Into Thin Air",
-//         genres: [Genre.Thriller],
-//       },
-//     ],
-//   });
+test("array relationships - nested expression array in 2", async () => {
+  const favourites = await actions.createCollection({
+    name: "Favourites",
+    books: [
+      {
+        title: "Lord of the Rings",
+        genres: [Genre.Fantasy, Genre.ScienceFiction],
+      },
+      {
+        title: "Into Thin Air",
+        genres: [Genre.Thriller],
+      },
+    ],
+  });
 
-//   const children = await actions.createCollection({
-//     name: "Children",
-//     books: [
-//       {
-//         title: "Hobbit",
-//         genres: [Genre.Fantasy, Genre.ScienceFiction],
-//       },
-//       {
-//         title: "The Book of Why",
-//         genres: [Genre.Science],
-//       },
-//     ],
-//   });
+  const children = await actions.createCollection({
+    name: "Children",
+    books: [
+      {
+        title: "Hobbit",
+        genres: [Genre.Fantasy, Genre.ScienceFiction],
+      },
+      {
+        title: "The Book of Why",
+        genres: [Genre.Science],
+      },
+    ],
+  });
 
-//   const maths = await actions.createCollection({
-//     name: "Education",
-//     books: [
-//       {
-//         title: "Maths 101",
-//         genres: [Genre.School, Genre.Math],
-//       },
-//     ],
-//   });
+  const identity = await models.identity.create({});
+  await models.person.create({
+    identityId: identity.id,
+    favouriteGenre: Genre.Fantasy,
+    favouriteAuthors: ["Tolkien", "Tom"],
+  });
 
-//   const collections = await actions.listEqualsCollection();
-//   expect(collections.results).toHaveLength(2);
-//   expect(collections.results[0].id).toEqual(children.id);
-//   expect(collections.results[1].id).toEqual(favourites.id);
-// });
-
-// test("array relationships - nested expression array in 1", async () => {
-//   const favourites = await actions.createCollection({
-//     name: "Favourites",
-//     books: [
-//       {
-//         title: "Lord of the Rings",
-//         genres: [Genre.Fantasy,Genre.ScienceFiction],
-//       },
-//       {
-//         title: "Into Thin Air",
-//         genres: [Genre.Thriller],
-//       },
-//     ],
-//   });
-
-//   const children = await actions.createCollection({
-//     name: "Children",
-//     books: [
-//       {
-//         title: "The Book of Why",
-//         genres: [Genre.Science],
-//       },
-//       {
-//         title: "Hobbit",
-//         genres: [Genre.EasyReads,Genre.Fantasy],
-//       },
-//     ],
-//   });
-
-//   const maths = await actions.createCollection({
-//     name: "Education",
-//     books: [
-//       {
-//         title: "Maths 101",
-//         genres: [Genre.School, Genre.Math],
-//       },
-//     ],
-//   });
-
-//   const collections1 = await actions.listInCollection({ where: {genre: Genre.Fantasy}});
-//   expect(collections1.results).toHaveLength(2);
-//   expect(collections1.results[0].id).toEqual(children.id);
-//   expect(collections1.results[1].id).toEqual(favourites.id);
-
-//   const collections2 = await actions.listInCollection({ where: {genre: Genre.Science}});
-//   expect(collections2.results).toHaveLength(1);
-//   expect(collections2.results[0].id).toEqual(children.id);
-
-//   const collections3 = await actions.listInCollection({ where: {genre: Genre.New}});
-//   expect(collections3.results).toHaveLength(0);
-// });
-
-
-// // WTF!?
-// // test("array relationships - nested expression array not in", async () => {
-// //   const favourites = await actions.createCollection({
-// //     name: "Favourites",
-// //     books: [
-// //       {
-// //         title: "Lord of the Rings",
-// //         genres: ["fantasy", "science fiction"],
-// //       },
-// //       {
-// //         title: "Into Thin Air",
-// //         genres: ["thriller"],
-// //       },
-// //     ],
-// //   });
-
-// //   const children = await actions.createCollection({
-// //     name: "Children",
-// //     books: [
-// //       {
-// //         title: "The Book of Why",
-// //         genres: ["science"],
-// //       },
-// //       {
-// //         title: "Hobbit",
-// //         genres: ["easy reads", "fantasy"],
-// //       },
-// //     ],
-// //   });
-
-// //   const computers = await actions.createCollection({
-// //     name: "Computers",
-// //     books: [
-// //       {
-// //         title: "C++ For Dummies",
-// //         genres: ["computer science"],
-// //       },
-// //       {
-// //         title: "PC Master Race",
-// //         genres: ["technology"],
-// //       },
-// //     ],
-// //   });
-
-// //   console.log(await models.collection.findMany());
-// //   console.log(await models.book.findMany());
-
-// //   const collections = await actions.listNotInCollection({ where: {genre: "sdfsd"}});
-// //   console.log(collections.results);
-// //   expect(collections.results).toHaveLength(1);
-// //   expect(collections.results[0].id).toEqual(computers.id);
-
-// // });
-
-
-// test("array relationships - nested expression array in 2", async () => {
-//   const favourites = await actions.createCollection({
-//     name: "Favourites",
-//     books: [
-//       {
-//         title: "Lord of the Rings",
-//         genres: [Genre.Fantasy, Genre.ScienceFiction],
-//       },
-//       {
-//         title: "Into Thin Air",
-//         genres: [Genre.Thriller],
-//       },
-//     ],
-//   });
-
-//   const children = await actions.createCollection({
-//     name: "Children",
-//     books: [
-//       {
-//         title: "Hobbit",
-//         genres: [Genre.Fantasy, Genre.ScienceFiction],
-//       },
-//       {
-//         title: "The Book of Why",
-//         genres: [Genre.Science],
-//       },
-//     ],
-//   });
-
-//   const identity = await models.identity.create({ });
-//   await models.person.create({ identityId: identity.id, favouriteGenre: Genre.Fantasy, favouriteAuthors: ["Tolkien", "Tom"]});
-
-
-//   const books = await actions.withIdentity(identity).suggestedBooksByGenre();
-//   expect(books.results).toHaveLength(2);
-//   expect(books.results[0].title).toEqual("Hobbit");
-//   expect(books.results[1].title).toEqual("Lord of the Rings");
-// });
-
+  const books = await actions.withIdentity(identity).suggestedBooksByGenre();
+  expect(books.results).toHaveLength(2);
+  expect(books.results[0].title).toEqual("Hobbit");
+  expect(books.results[1].title).toEqual("Lord of the Rings");
+});
 
 test("array relationships - nested expression array in 3", async () => {
   const favourites = await actions.createCollection({
@@ -292,12 +299,12 @@ test("array relationships - nested expression array in 3", async () => {
       {
         title: "Lord of the Rings",
         genres: [Genre.Fantasy, Genre.ScienceFiction],
-         author: "Tolkien"
+        author: "Tolkien",
       },
       {
         title: "Into Thin Air",
         genres: [Genre.Thriller],
-         author: "Tom"
+        author: "Tom",
       },
     ],
   });
@@ -308,19 +315,22 @@ test("array relationships - nested expression array in 3", async () => {
       {
         title: "Hobbit",
         genres: [Genre.Fantasy, Genre.ScienceFiction],
-        author: "Tolkien"
+        author: "Tolkien",
       },
       {
         title: "The Book of Why",
         genres: [Genre.Science],
-        author: "Dave"
+        author: "Dave",
       },
     ],
   });
 
-  const identity = await models.identity.create({ });
-  await models.person.create({ identityId: identity.id, favouriteGenre: Genre.Fantasy, favouriteAuthors: ["Tolkien", "Tom"]});
-
+  const identity = await models.identity.create({});
+  await models.person.create({
+    identityId: identity.id,
+    favouriteGenre: Genre.Fantasy,
+    favouriteAuthors: ["Tolkien", "Tom"],
+  });
 
   const books = await actions.withIdentity(identity).suggestedBooksByAuthor();
   expect(books.results).toHaveLength(3);
@@ -329,7 +339,6 @@ test("array relationships - nested expression array in 3", async () => {
   expect(books.results[2].title).toEqual("Lord of the Rings");
 });
 
-
 test("array relationships - nested expression array in 4", async () => {
   const favourites = await actions.createCollection({
     name: "Favourites",
@@ -337,12 +346,12 @@ test("array relationships - nested expression array in 4", async () => {
       {
         title: "Lord of the Rings",
         genres: [Genre.Fantasy, Genre.ScienceFiction],
-         author: "Tolkien"
+        author: "Tolkien",
       },
       {
         title: "Into Thin Air",
         genres: [Genre.Thriller],
-         author: "Tom"
+        author: "Tom",
       },
     ],
   });
@@ -353,30 +362,40 @@ test("array relationships - nested expression array in 4", async () => {
       {
         title: "Hobbit",
         genres: [Genre.Fantasy, Genre.ScienceFiction],
-        author: "Tolkien"
+        author: "Tolkien",
       },
       {
         title: "The Book of Why",
         genres: [Genre.Science],
-        author: "Dave"
+        author: "Dave",
       },
     ],
   });
 
+  const identity1 = await models.identity.create({});
+  await models.person.create({
+    identityId: identity1.id,
+    favouriteGenre: Genre.Thriller,
+    favouriteAuthors: [],
+  });
 
-  const identity1 = await models.identity.create({ });
-  await models.person.create({ identityId: identity1.id, favouriteGenre: Genre.Thriller, favouriteAuthors: []});
-
-  const collections1 = await actions.withIdentity(identity1).suggestedCollections();
+  const collections1 = await actions
+    .withIdentity(identity1)
+    .suggestedCollections();
   expect(collections1.results).toHaveLength(1);
   expect(collections1.results[0].name).toEqual("Favourites");
 
-  const identity2 = await models.identity.create({ });
-  await models.person.create({ identityId: identity2.id, favouriteGenre: Genre.Fantasy, favouriteAuthors: []});
+  const identity2 = await models.identity.create({});
+  await models.person.create({
+    identityId: identity2.id,
+    favouriteGenre: Genre.Fantasy,
+    favouriteAuthors: [],
+  });
 
-  const collections2 = await actions.withIdentity(identity2).suggestedCollections();
+  const collections2 = await actions
+    .withIdentity(identity2)
+    .suggestedCollections();
   expect(collections2.results).toHaveLength(2);
-  expect(collections2.results[0].name).toEqual("Children")
+  expect(collections2.results[0].name).toEqual("Children");
   expect(collections2.results[1].name).toEqual("Favourites");
-
 });

--- a/integration/testdata/functions_use_database/main.test.ts
+++ b/integration/testdata/functions_use_database/main.test.ts
@@ -11,7 +11,7 @@ test("testing raw kysely", async () => {
   const goodResult = await actions.getPostButOnlyIfItsAfter2020({
     id: postCreatedAfter2020.id,
   });
-  
+
   expect(goodResult?.id).toEqual(postCreatedAfter2020.id);
 
   const postCreatedBefore2020 = await models.post.create({

--- a/integration/testdata/functions_use_database/main.test.ts
+++ b/integration/testdata/functions_use_database/main.test.ts
@@ -11,7 +11,7 @@ test("testing raw kysely", async () => {
   const goodResult = await actions.getPostButOnlyIfItsAfter2020({
     id: postCreatedAfter2020.id,
   });
-
+  
   expect(goodResult?.id).toEqual(postCreatedAfter2020.id);
 
   const postCreatedBefore2020 = await models.post.create({

--- a/node/node.go
+++ b/node/node.go
@@ -31,9 +31,9 @@ func HasFunctions(sch *proto.Schema, cfg *config.ProjectConfig) bool {
 
 	hasHooks := len(cfg.Auth.EnabledHooks()) > 0
 
-	hasJobs := sch.Jobs != nil && len(sch.Jobs) > 0
+	hasJobs := len(sch.Jobs) > 0
 
-	hasSubscribers := sch.Subscribers != nil && len(sch.Subscribers) > 0
+	hasSubscribers := len(sch.Subscribers) > 0
 
 	return hasCustomFunctions || hasHooks || hasJobs || hasSubscribers
 }

--- a/runtime/actions/authorization.go
+++ b/runtime/actions/authorization.go
@@ -224,7 +224,7 @@ func GeneratePermissionStatement(scope *Scope, permissions []*proto.PermissionRu
 	}
 
 	// Check that the number of authorised rows matches
-	query.AppendSelectClause(fmt.Sprintf("COUNT(DISTINCT %s) = %v AS authorised", IdField().toSqlOperandString(query), len(idsToAuthorise)))
+	query.SelectClause(fmt.Sprintf("COUNT(DISTINCT %s) = %v AS authorised", IdField().toSqlOperandString(query), len(idsToAuthorise)))
 
 	return query.SelectStatement(), nil
 }

--- a/runtime/actions/delete.go
+++ b/runtime/actions/delete.go
@@ -38,7 +38,7 @@ func Delete(scope *Scope, input map[string]any) (res *string, err error) {
 		if err != nil {
 			return nil, err
 		}
-		authQuery.AppendSelect(IdField())
+		authQuery.Select(IdField())
 		authQuery.AppendDistinctOn(IdField())
 		rows, err := authQuery.SelectStatement().ExecuteToSingle(scope.Context)
 		if err != nil {

--- a/runtime/actions/delete.go
+++ b/runtime/actions/delete.go
@@ -39,7 +39,7 @@ func Delete(scope *Scope, input map[string]any) (res *string, err error) {
 			return nil, err
 		}
 		authQuery.Select(IdField())
-		authQuery.AppendDistinctOn(IdField())
+		authQuery.DistinctOn(IdField())
 		rows, err := authQuery.SelectStatement().ExecuteToSingle(scope.Context)
 		if err != nil {
 			return nil, err

--- a/runtime/actions/expression.go
+++ b/runtime/actions/expression.go
@@ -252,7 +252,7 @@ func operandFromFragments(schema *proto.Schema, fragments []string) (*QueryOpera
 // Generates a database QueryOperand, either representing a field, inline query, a value or null.
 func generateQueryOperand(resolver *expressions.OperandResolver, args map[string]any) (*QueryOperand, error) {
 	var queryOperand *QueryOperand
-
+	resolver.IsContextDbColumn()
 	switch {
 	case resolver.IsContextDbColumn():
 		// If this is a value from ctx that requires a database read (such as with identity backlinks),
@@ -267,9 +267,9 @@ func generateQueryOperand(resolver *expressions.OperandResolver, args map[string
 		// Remove the ctx fragment
 		fragments = fragments[1:]
 
-		model := proto.FindModel(resolver.Schema.Models, strcase.ToCamel(fragments[0]))
-		ctxScope := NewModelScope(resolver.Context, model, resolver.Schema)
-		query := NewQuery(model)
+		identityModel := proto.FindModel(resolver.Schema.Models, strcase.ToCamel(fragments[0]))
+		ctxScope := NewModelScope(resolver.Context, identityModel, resolver.Schema)
+		query := NewQuery(identityModel)
 
 		identityId := ""
 		if auth.IsAuthenticated(resolver.Context) {
@@ -290,6 +290,28 @@ func generateQueryOperand(resolver *expressions.OperandResolver, args map[string
 			return nil, err
 		}
 
+		currModel := identityModel
+
+		for i := 1; i < len(fragments)-1; i++ {
+			name := proto.FindField(resolver.Schema.Models, currModel.Name, fragments[i]).Type.ModelName.Value
+			currModel = proto.FindModel(resolver.Schema.Models, name)
+		}
+		currField := proto.FindField(resolver.Schema.Models, currModel.Name, fragments[len(fragments)-1])
+
+		// var currModel *proto.Model
+		// 	var currField *proto.Field
+		// 	for i := 1; i < len(fragments); i++ {
+		// 		fieldTarget = proto.FindField(resolver.Schema.Models, modelTarget.Name, fragments[i])
+		// 		if fieldTarget.Type.Type == proto.Type_TYPE_MODEL {
+		// 			modelTarget = proto.FindModel(resolver.Schema.Models, fieldTarget.Type.ModelName.Value)
+		// 			if modelTarget == nil {
+		// 				return nil, fmt.Errorf("model '%s' does not exist in schema", fieldTarget.Type.ModelName.Value)
+		// 			}
+		// 		}
+		// 	}
+
+		//field := proto.FindField(resolver.Schema.Models, fragments[len(fragments)-2], fragments[len(fragments)-1])
+
 		selectField := ExpressionField(fragments[:len(fragments)-1], fragments[len(fragments)-1])
 
 		// If there are no matches in the subquery then null will be returned, but null
@@ -301,7 +323,11 @@ func generateQueryOperand(resolver *expressions.OperandResolver, args map[string
 			return nil, err
 		}
 
-		query.AppendSelect(selectField)
+		if currField.Type.Repeated {
+			query.SelectUnnested(selectField)
+		} else {
+			query.Select(selectField)
+		}
 
 		queryOperand = InlineQuery(query, selectField)
 

--- a/runtime/actions/get.go
+++ b/runtime/actions/get.go
@@ -93,7 +93,7 @@ func GenerateGetStatement(query *QueryBuilder, scope *Scope, input map[string]an
 
 	// Select all columns and distinct on id
 	query.Select(AllFields())
-	query.AppendDistinctOn(IdField())
+	query.DistinctOn(IdField())
 
 	return query.SelectStatement(), nil
 }

--- a/runtime/actions/get.go
+++ b/runtime/actions/get.go
@@ -92,7 +92,7 @@ func GenerateGetStatement(query *QueryBuilder, scope *Scope, input map[string]an
 	}
 
 	// Select all columns and distinct on id
-	query.AppendSelect(AllFields())
+	query.Select(AllFields())
 	query.AppendDistinctOn(IdField())
 
 	return query.SelectStatement(), nil

--- a/runtime/actions/identity.go
+++ b/runtime/actions/identity.go
@@ -20,7 +20,7 @@ func FindIdentityById(ctx context.Context, schema *proto.Schema, id string) (aut
 		return nil, err
 	}
 
-	query.AppendSelect(AllFields())
+	query.Select(AllFields())
 	result, err := query.SelectStatement().ExecuteToSingle(ctx)
 
 	if err != nil {
@@ -46,7 +46,7 @@ func FindIdentityByEmail(ctx context.Context, schema *proto.Schema, email string
 		return nil, err
 	}
 
-	query.AppendSelect(AllFields())
+	query.Select(AllFields())
 	result, err := query.SelectStatement().ExecuteToSingle(ctx)
 
 	if err != nil {
@@ -72,7 +72,7 @@ func FindIdentityByExternalId(ctx context.Context, schema *proto.Schema, externa
 		return nil, err
 	}
 
-	query.AppendSelect(AllFields())
+	query.Select(AllFields())
 	result, err := query.SelectStatement().ExecuteToSingle(ctx)
 
 	if err != nil {
@@ -94,7 +94,7 @@ func CreateIdentity(ctx context.Context, schema *proto.Schema, email string, pas
 		"password": Value(password),
 		"issuer":   Value(issuer),
 	})
-	query.AppendSelect(AllFields())
+	query.Select(AllFields())
 	query.AppendReturning(IdField())
 
 	result, err := query.InsertStatement(ctx).ExecuteToSingle(ctx)
@@ -143,7 +143,7 @@ func CreateIdentityWithClaims(ctx context.Context, schema *proto.Schema, externa
 		query.AddWriteValue(Field(k), ValueOrNullIfEmpty(v))
 	}
 
-	query.AppendSelect(AllFields())
+	query.Select(AllFields())
 	query.AppendReturning(IdField())
 
 	result, err := query.InsertStatement(ctx).ExecuteToSingle(ctx)
@@ -200,7 +200,7 @@ func UpdateIdentityWithClaims(ctx context.Context, schema *proto.Schema, externa
 		query.AddWriteValue(Field(k), ValueOrNullIfEmpty(v))
 	}
 
-	query.AppendSelect(AllFields())
+	query.Select(AllFields())
 	query.AppendReturning(AllFields())
 
 	result, err := query.UpdateStatement(ctx).ExecuteToSingle(ctx)

--- a/runtime/actions/list.go
+++ b/runtime/actions/list.go
@@ -247,7 +247,7 @@ func GenerateListStatement(query *QueryBuilder, scope *Scope, input map[string]a
 	}
 
 	// Select all columns from this table and distinct on id
-	query.AppendDistinctOn(IdField())
+	query.DistinctOn(IdField())
 	query.Select(AllFields())
 
 	err = query.ApplyPaging(page)

--- a/runtime/actions/list.go
+++ b/runtime/actions/list.go
@@ -171,7 +171,6 @@ func List(scope *Scope, input map[string]any) (map[string]any, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	if !isAuthorised {
 		return nil, common.NewPermissionError()
 	}
@@ -249,7 +248,7 @@ func GenerateListStatement(query *QueryBuilder, scope *Scope, input map[string]a
 
 	// Select all columns from this table and distinct on id
 	query.AppendDistinctOn(IdField())
-	query.AppendSelect(AllFields())
+	query.Select(AllFields())
 
 	err = query.ApplyPaging(page)
 	if err != nil {

--- a/runtime/actions/query.go
+++ b/runtime/actions/query.go
@@ -367,7 +367,7 @@ func (query *QueryBuilder) Select(operand *QueryOperand) {
 	}
 }
 
-// Includes a column in SELECT and unnests it.
+// Includes an array column in SELECT and unnests it.
 func (query *QueryBuilder) SelectUnnested(operand *QueryOperand) {
 	c := fmt.Sprintf("unnest(%s)", operand.toSqlOperandString(query))
 

--- a/runtime/actions/update.go
+++ b/runtime/actions/update.go
@@ -35,7 +35,7 @@ func Update(scope *Scope, input map[string]any) (res map[string]any, err error) 
 	case canResolveEarly && !authorised:
 		return nil, common.NewPermissionError()
 	case !canResolveEarly:
-		query.AppendSelect(IdField())
+		query.Select(IdField())
 		query.AppendDistinctOn(IdField())
 		rowToAuthorise, err := query.SelectStatement().ExecuteToSingle(scope.Context)
 		if err != nil {

--- a/runtime/actions/update.go
+++ b/runtime/actions/update.go
@@ -36,7 +36,7 @@ func Update(scope *Scope, input map[string]any) (res map[string]any, err error) 
 		return nil, common.NewPermissionError()
 	case !canResolveEarly:
 		query.Select(IdField())
-		query.AppendDistinctOn(IdField())
+		query.DistinctOn(IdField())
 		rowToAuthorise, err := query.SelectStatement().ExecuteToSingle(scope.Context)
 		if err != nil {
 			return nil, err

--- a/runtime/actions/writeinputs.go
+++ b/runtime/actions/writeinputs.go
@@ -126,7 +126,7 @@ func (query *QueryBuilder) captureSetValues(scope *Scope, args map[string]any) e
 
 				selectField := ExpressionField(fragments[:len(fragments)-1], fragments[len(fragments)-1])
 
-				identityQuery.AppendSelect(selectField)
+				identityQuery.Select(selectField)
 
 				row.values[field] = InlineQuery(identityQuery, selectField)
 

--- a/runtime/apis/graphql/graphql.go
+++ b/runtime/apis/graphql/graphql.go
@@ -389,7 +389,7 @@ func (mk *graphqlSchemaBuilder) addModel(model *proto.Model) (*graphql.Object, e
 					}
 
 					// Select all columns from this table and distinct on id
-					query.AppendDistinctOn(actions.IdField())
+					query.DistinctOn(actions.IdField())
 					query.Select(actions.AllFields())
 					err = query.ApplyPaging(page)
 					if err != nil {

--- a/runtime/apis/graphql/graphql.go
+++ b/runtime/apis/graphql/graphql.go
@@ -309,7 +309,7 @@ func (mk *graphqlSchemaBuilder) addModel(model *proto.Model) (*graphql.Object, e
 
 				// Create a new query for the related model
 				query := actions.NewQuery(relatedModel)
-				query.AppendSelect(actions.AllFields())
+				query.Select(actions.AllFields())
 
 				foreignKeyField := proto.GetForeignKeyFieldName(mk.proto.Models, field)
 
@@ -390,7 +390,7 @@ func (mk *graphqlSchemaBuilder) addModel(model *proto.Model) (*graphql.Object, e
 
 					// Select all columns from this table and distinct on id
 					query.AppendDistinctOn(actions.IdField())
-					query.AppendSelect(actions.AllFields())
+					query.Select(actions.AllFields())
 					err = query.ApplyPaging(page)
 					if err != nil {
 						span.RecordError(err, trace.WithStackTrace(true))

--- a/runtime/openapi/openapi_test.go
+++ b/runtime/openapi/openapi_test.go
@@ -58,7 +58,7 @@ func TestGeneration(t *testing.T) {
 				diff, explanation := jsondiff.Compare([]byte(c.jsonSchema), actual, &opts)
 
 				if diff != jsondiff.FullMatch {
-					t.Errorf(string(actual))
+					t.Error(string(actual))
 					t.Errorf("actual JSON schema does not match expected: %s", explanation)
 				}
 			}
@@ -72,7 +72,7 @@ func TestGeneration(t *testing.T) {
 				diff, explanation := jsondiff.Compare([]byte(c.jsonSchema), actual, &opts)
 
 				if diff != jsondiff.FullMatch {
-					t.Errorf(string(actual))
+					t.Error(string(actual))
 					t.Errorf("actual JSON schema does not match expected: %s", explanation)
 				}
 			}

--- a/schema/makeproto.go
+++ b/schema/makeproto.go
@@ -1231,7 +1231,7 @@ func (scm *Builder) makeAPI(decl *parser.DeclarationNode) {
 				ModelActions: []*proto.ApiModelAction{},
 			}
 
-			if parserApiModel.Sections == nil || len(parserApiModel.Sections) == 0 {
+			if len(parserApiModel.Sections) == 0 {
 				model := query.Model(scm.asts, parserApiModel.Name.Value)
 				actions := query.ModelActions(model)
 

--- a/schema/query/query.go
+++ b/schema/query/query.go
@@ -228,7 +228,7 @@ type ModelActionFilter func(a *parser.ActionNode) bool
 
 func ModelActions(model *parser.ModelNode, filters ...ModelActionFilter) (res []*parser.ActionNode) {
 	for _, section := range model.Sections {
-		if section.Actions != nil && len(section.Actions) > 0 {
+		if len(section.Actions) > 0 {
 		actions:
 			for _, action := range section.Actions {
 				for _, filter := range filters {

--- a/storage/database_storer.go
+++ b/storage/database_storer.go
@@ -122,7 +122,7 @@ func (s *DbStore) GetFileInfo(key string) (FileInfo, error) {
 func (s *DbStore) HydrateFileInfo(fi *FileInfo) (FileInfo, error) {
 	sql := `SELECT
 			filename,
-			content_type,
+			contentType,
 			data
 		FROM ` + dbTable + ` WHERE id = ?`
 

--- a/storage/database_storer.go
+++ b/storage/database_storer.go
@@ -122,7 +122,7 @@ func (s *DbStore) GetFileInfo(key string) (FileInfo, error) {
 func (s *DbStore) HydrateFileInfo(fi *FileInfo) (FileInfo, error) {
 	sql := `SELECT
 			filename,
-			contentType,
+			content_type,
 			data
 		FROM ` + dbTable + ` WHERE id = ?`
 


### PR DESCRIPTION
In expressions, the `in` and `not in` operators can now be used to against array field operands.  For example:

```
list suggestedBooks() {
    @where(book.genre in ctx.identity.person.favouriteGenres) // 1:1 relationship between identity and person
    @orderBy(title: asc)
    @permission(expression: true)
}
```

And even in cases like this, where the arrays will be squashed:

```
list suggestedBooks() {
    @where(book.genre in ctx.identity.friends.favouriteGenres) // 1:M relationship between identity and person
    @orderBy(title: asc)
    @permission(expression: true)
}
```