### PR TITLE
chore: refactor proto query

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -134,7 +134,7 @@ func SendEvents(ctx context.Context, schema *proto.Schema) error {
 			return fmt.Errorf("event '%s' does not exist", eventName)
 		}
 
-		subscribers := proto.FindEventSubscriptions(schema, protoEvent)
+		subscribers := schema.FindEventSubscribers(protoEvent)
 		if len(subscribers) == 0 {
 			return fmt.Errorf("event '%s' must have at least one subscriber", eventName)
 		}

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -198,7 +198,7 @@ func New(ctx context.Context, schema *proto.Schema, database db.Database) (*Migr
 	pushAuditModel(schema)
 	defer popAuditModel(schema)
 
-	modelNames := proto.ModelNames(schema)
+	modelNames := schema.ModelNames()
 
 	// Add any new models
 	for _, modelName := range modelNames {
@@ -467,7 +467,7 @@ func GetCurrentSchema(ctx context.Context, database db.Database) (*proto.Schema,
 // fkConstraintsForModel generates foreign key constraint statements for each of fields marked as
 // being foreign keys in the given model.
 func fkConstraintsForModel(model *proto.Model) (fkStatements []string) {
-	fkFields := proto.ForeignKeyFields(model)
+	fkFields := model.ForeignKeyFields()
 	for _, field := range fkFields {
 		stmt := fkConstraint(field, model)
 		fkStatements = append(fkStatements, stmt)

--- a/migrations/sql.go
+++ b/migrations/sql.go
@@ -120,11 +120,11 @@ func addUniqueConstraintStmt(schema *proto.Schema, modelName string, fieldNames 
 	for _, name := range fieldNames {
 		field := proto.FindField(schema.Models, modelName, name)
 
-		if proto.IsBelongsTo(field) {
+		if field.IsBelongsTo() {
 			name = fmt.Sprintf("%sId", name)
 		}
 
-		if proto.IsHasMany(field) || proto.IsHasOne(field) {
+		if field.IsHasMany() || field.IsHasOne() {
 			return "", fmt.Errorf("cannot create unique constraint on has-many or has-one model field '%s'", name)
 		}
 

--- a/node/client.go
+++ b/node/client.go
@@ -153,7 +153,7 @@ func writeClientApiClass(w *codegen.Writer, schema *proto.Schema, api *proto.Api
 
 func writeClientActions(w *codegen.Writer, schema *proto.Schema, api *proto.Api) {
 	for _, a := range proto.GetActionNamesForApi(schema, api) {
-		action := proto.FindAction(schema, a)
+		action := schema.FindAction(a)
 		msg := proto.FindMessage(schema.Messages, action.InputMessageName)
 
 		w.Writef("%s: (i", action.Name)
@@ -195,7 +195,7 @@ func writeClientApiDefinition(w *codegen.Writer, schema *proto.Schema, api *prot
 	mutations := []string{}
 
 	for _, a := range proto.GetActionNamesForApi(schema, api) {
-		action := proto.FindAction(schema, a)
+		action := schema.FindAction(a)
 		if action.Type == proto.ActionType_ACTION_TYPE_GET || action.Type == proto.ActionType_ACTION_TYPE_LIST || action.Type == proto.ActionType_ACTION_TYPE_READ {
 			queries = append(queries, action.Name)
 		} else {
@@ -241,7 +241,7 @@ func writeClientTypes(w *codegen.Writer, schema *proto.Schema, api *proto.Api) {
 
 	// writing embedded response types
 	for _, a := range proto.GetActionNamesForApi(schema, api) {
-		action := proto.FindAction(schema, a)
+		action := schema.FindAction(a)
 		embeds := action.GetResponseEmbeds()
 		if len(embeds) == 0 {
 			continue

--- a/node/scaffold.go
+++ b/node/scaffold.go
@@ -53,7 +53,7 @@ func Scaffold(dir string, schema *proto.Schema, cfg *config.ProjectConfig) (code
 
 	generatedFiles := codegen.GeneratedFiles{}
 
-	functions := proto.FilterActions(schema, func(op *proto.Action) bool {
+	functions := schema.FilterActions(func(op *proto.Action) bool {
 		return op.Implementation == proto.ActionImplementation_ACTION_IMPLEMENTATION_CUSTOM
 	})
 
@@ -135,7 +135,7 @@ func ensureDir(dirName string) error {
 func writeFunctionWrapper(function *proto.Action) string {
 	functionName := casing.ToCamel(function.Name)
 
-	if proto.ActionIsArbitraryFunction(function) {
+	if function.IsArbitraryFunction() {
 		return fmt.Sprintf(`import { %s } from '@teamkeel/sdk';
 
 // To learn more about what you can do with custom functions, visit https://docs.keel.so/functions

--- a/permissions/permissions.go
+++ b/permissions/permissions.go
@@ -41,7 +41,7 @@ type Value struct {
 // what values should be provided to the query at runtime.
 func ToSQL(s *proto.Schema, m *proto.Model, action *proto.Action) (sql string, values []*Value, err error) {
 	tableName := identifier(m.Name)
-	pkField := identifier(proto.PrimaryKeyFieldName(m))
+	pkField := identifier(m.PrimaryKeyFieldName())
 
 	stmt := &statement{}
 	permissions := proto.PermissionsForAction(s, action)
@@ -298,11 +298,11 @@ func handleModel(s *proto.Schema, model *proto.Model, ident *parser.Ident, stmt 
 				}
 
 				leftFieldName := proto.GetForeignKeyFieldName(s.Models, field)
-				rightFieldName := proto.PrimaryKeyFieldName(joinModel)
+				rightFieldName := joinModel.PrimaryKeyFieldName()
 
 				// If not belongs to then swap foreign/primary key
-				if !proto.IsBelongsTo(field) {
-					leftFieldName = proto.PrimaryKeyFieldName(model)
+				if !field.IsBelongsTo() {
+					leftFieldName = model.PrimaryKeyFieldName()
 					rightFieldName = proto.GetForeignKeyFieldName(s.Models, field)
 				}
 

--- a/proto/action.go
+++ b/proto/action.go
@@ -1,0 +1,27 @@
+package proto
+
+func (a *Action) IsFunction() bool {
+	return a.Implementation == ActionImplementation_ACTION_IMPLEMENTATION_CUSTOM
+}
+
+func (a *Action) IsArbitraryFunction() bool {
+	return ActionIsFunction(a) && (a.Type == ActionType_ACTION_TYPE_READ || a.Type == ActionType_ACTION_TYPE_WRITE)
+}
+
+func (a *Action) IsWriteAction() bool {
+	switch a.Type {
+	case ActionType_ACTION_TYPE_CREATE, ActionType_ACTION_TYPE_DELETE, ActionType_ACTION_TYPE_WRITE, ActionType_ACTION_TYPE_UPDATE:
+		return true
+	default:
+		return false
+	}
+}
+
+func (a *Action) IsReadAction() bool {
+	switch a.Type {
+	case ActionType_ACTION_TYPE_GET, ActionType_ACTION_TYPE_LIST, ActionType_ACTION_TYPE_READ:
+		return true
+	default:
+		return false
+	}
+}

--- a/proto/action.go
+++ b/proto/action.go
@@ -5,7 +5,7 @@ func (a *Action) IsFunction() bool {
 }
 
 func (a *Action) IsArbitraryFunction() bool {
-	return ActionIsFunction(a) && (a.Type == ActionType_ACTION_TYPE_READ || a.Type == ActionType_ACTION_TYPE_WRITE)
+	return a.IsFunction() && (a.Type == ActionType_ACTION_TYPE_READ || a.Type == ActionType_ACTION_TYPE_WRITE)
 }
 
 func (a *Action) IsWriteAction() bool {

--- a/proto/field.go
+++ b/proto/field.go
@@ -1,0 +1,33 @@
+package proto
+
+// IsFile tells us if the field is a file
+func (f *Field) IsFile() bool {
+	if f.Type == nil {
+		return false
+	}
+
+	return f.Type.Type == Type_TYPE_INLINE_FILE
+}
+
+// IsTypeModel returns true of the field's type is Model.
+func (f *Field) IsTypeModel() bool {
+	return f.Type.Type == Type_TYPE_MODEL
+}
+
+// IsTypeRepeated returns true if the field is specified as
+// being "repeated".
+func (f *Field) IsRepeated() bool {
+	return f.Type.Repeated
+}
+
+func (f *Field) IsHasMany() bool {
+	return f.Type.Type == Type_TYPE_MODEL && f.ForeignKeyFieldName == nil && f.Type.Repeated
+}
+
+func (f *Field) IsHasOne() bool {
+	return f.Type.Type == Type_TYPE_MODEL && f.ForeignKeyFieldName == nil && !f.Type.Repeated
+}
+
+func (f *Field) IsBelongsTo() bool {
+	return f.Type.Type == Type_TYPE_MODEL && f.ForeignKeyFieldName != nil && !f.Type.Repeated
+}

--- a/proto/message.go
+++ b/proto/message.go
@@ -1,0 +1,42 @@
+package proto
+
+import "github.com/samber/lo"
+
+// HasFiles checks if the message has any Inline file fields
+func (m *Message) HasFiles() bool {
+	return len(m.FileFields()) > 0
+}
+
+// FileFields will return a slice of fields for the model that are of type file
+func (m *Message) FileFields() []*MessageField {
+	return lo.Filter(m.Fields, func(f *MessageField, _ int) bool {
+		return f.IsFile()
+	})
+}
+
+// IsModelField returns true if the input targets a model field
+// and is handled automatically by the runtime.
+// This will only be true for inputs that are built-in actions,
+// as functions never have this behaviour.
+func (f *MessageField) IsModelField() bool {
+	return len(f.Target) > 0
+}
+
+// IsFile tells us if the field is a file
+func (f *MessageField) IsFile() bool {
+	if f.Type == nil {
+		return false
+	}
+
+	return f.Type.Type == Type_TYPE_INLINE_FILE
+}
+
+func (m *Message) FindField(fieldName string) *MessageField {
+	for _, field := range m.Fields {
+		if field.Name == fieldName {
+			return field
+		}
+	}
+
+	return nil
+}

--- a/proto/model.go
+++ b/proto/model.go
@@ -1,0 +1,48 @@
+package proto
+
+import (
+	"sort"
+
+	"github.com/samber/lo"
+)
+
+// FileFields will return a slice of fields for the model that are of type file
+func (m *Model) FileFields() []*Field {
+	return lo.Filter(m.Fields, func(f *Field, _ int) bool {
+		return f.IsFile()
+	})
+}
+
+// HasFiles checks if the model has any fields that are files
+func (m *Model) HasFiles() bool {
+	return len(m.FileFields()) > 0
+}
+
+// FieldNames provides a (sorted) list of the fields in the model of the given name.
+func (m *Model) FieldNames() []string {
+	names := lo.Map(m.Fields, func(x *Field, _ int) string {
+		return x.Name
+	})
+	sort.Strings(names)
+	return names
+}
+
+// ForeignKeyFields returns all the fields in the given model which have their ForeignKeyInfo
+// populated.
+func (m *Model) ForeignKeyFields() []*Field {
+	return lo.Filter(m.Fields, func(f *Field, _ int) bool {
+		return f.ForeignKeyInfo != nil
+	})
+}
+
+// PrimaryKeyFieldName returns the name of the field in the given model,
+// that is marked as being the model's primary key. (Or empty string).
+func (m *Model) PrimaryKeyFieldName() string {
+	field, _ := lo.Find(m.Fields, func(f *Field) bool {
+		return f.PrimaryKey
+	})
+	if field != nil {
+		return field.Name
+	}
+	return ""
+}

--- a/proto/model_test.go
+++ b/proto/model_test.go
@@ -1,0 +1,12 @@
+package proto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFieldNames(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, []string{"Field1", "Field2"}, referenceSchema.Models[0].FieldNames())
+}

--- a/proto/query.go
+++ b/proto/query.go
@@ -197,7 +197,7 @@ func FilterActions(p *Schema, filter func(op *Action) bool) (ops []*Action) {
 
 // Deprecated: Use Schema.FindAction() instead
 func FindAction(schema *Schema, actionName string) *Action {
-	actions := FilterActions(schema, func(op *Action) bool {
+	actions := schema.FilterActions(func(op *Action) bool {
 		return op.Name == actionName
 	})
 	if len(actions) != 1 {
@@ -213,7 +213,7 @@ func ActionIsFunction(action *Action) bool {
 
 // Deprecated: Use Action.IsArbitraryFunction() instead
 func ActionIsArbitraryFunction(action *Action) bool {
-	return ActionIsFunction(action) && (action.Type == ActionType_ACTION_TYPE_READ || action.Type == ActionType_ACTION_TYPE_WRITE)
+	return action.IsFunction() && (action.Type == ActionType_ACTION_TYPE_READ || action.Type == ActionType_ACTION_TYPE_WRITE)
 }
 
 // Deprecated: Use Action.IsWriteAction() instead
@@ -413,7 +413,7 @@ func FindMessageField(message *Message, fieldName string) *MessageField {
 // For built-in action types, returns the "values" input message, which may be nested inside the
 // root message for some action types, or returns nil if not found.
 func FindValuesInputMessage(schema *Schema, actionName string) *Message {
-	action := FindAction(schema, actionName)
+	action := schema.FindAction(actionName)
 	message := FindMessage(schema.Messages, action.InputMessageName)
 
 	switch action.Type {
@@ -432,7 +432,7 @@ func FindValuesInputMessage(schema *Schema, actionName string) *Message {
 // For built-in action types, returns the "where" input message, which may be nested inside the
 // root message for some action types, or returns nil if not found.
 func FindWhereInputMessage(schema *Schema, actionName string) *Message {
-	action := FindAction(schema, actionName)
+	action := schema.FindAction(actionName)
 	message := FindMessage(schema.Messages, action.InputMessageName)
 
 	switch action.Type {

--- a/proto/query.go
+++ b/proto/query.go
@@ -24,6 +24,8 @@ func ApiModels(s *Schema, api *Api) []*Model {
 
 // ModelNames provides a (sorted) list of all the Model names used in the
 // given schema.
+//
+// Deprecated: Use Schema.ModelNames() instead
 func ModelNames(p *Schema) []string {
 	names := lo.Map(p.Models, func(x *Model, _ int) string {
 		return x.Name
@@ -34,6 +36,8 @@ func ModelNames(p *Schema) []string {
 
 // FieldNames provides a (sorted) list of the fields in the model of
 // the given name.
+//
+// Deprecated: Please use Model.FieldNames() instead
 func FieldNames(m *Model) []string {
 	names := lo.Map(m.Fields, func(x *Field, _ int) string {
 		return x.Name
@@ -42,31 +46,25 @@ func FieldNames(m *Model) []string {
 	return names
 }
 
-// FileFields will return a slice of fields for the model that are of type file
-func (m *Model) FileFields() []*Field {
-	return lo.Filter(m.Fields, func(f *Field, _ int) bool {
-		return f.IsFile()
-	})
-}
-
-// HasFiles checks if the model has any fields that are files
-func (m *Model) HasFiles() bool {
-	return len(m.FileFields()) > 0
-}
-
 // IsTypeModel returns true of the field's type is Model.
+//
+// Deprecated: Please use Field.IsTypeModel() instead
 func IsTypeModel(field *Field) bool {
 	return field.Type.Type == Type_TYPE_MODEL
 }
 
 // IsTypeRepeated returns true if the field is specified as
 // being "repeated".
+//
+// Deprecated: Please use Field.IsRepeated() instead
 func IsRepeated(field *Field) bool {
 	return field.Type.Repeated
 }
 
 // PrimaryKeyFieldName returns the name of the field in the given model,
 // that is marked as being the model's primary key. (Or empty string).
+//
+// Deprecated: please use Model.PrimaryKeyFieldName() instead
 func PrimaryKeyFieldName(model *Model) string {
 	field, _ := lo.Find(model.Fields, func(f *Field) bool {
 		return f.PrimaryKey
@@ -78,6 +76,8 @@ func PrimaryKeyFieldName(model *Model) string {
 }
 
 // AllFields provides a list of all the model fields specified in the schema.
+//
+// Deprecated: please use Schema.AllFields() instead
 func AllFields(p *Schema) []*Field {
 	fields := []*Field{}
 	for _, model := range p.Models {
@@ -88,31 +88,27 @@ func AllFields(p *Schema) []*Field {
 
 // ForeignKeyFields returns all the fields in the given model which have their ForeignKeyInfo
 // populated.
+//
+// Deprecated: please use Model.ForeignKeyFields() instead
 func ForeignKeyFields(model *Model) []*Field {
 	return lo.Filter(model.Fields, func(f *Field, _ int) bool {
 		return f.ForeignKeyInfo != nil
 	})
 }
 
+// Deprecated: please use Field.IsHasMany() instead
 func IsHasMany(field *Field) bool {
 	return field.Type.Type == Type_TYPE_MODEL && field.ForeignKeyFieldName == nil && field.Type.Repeated
 }
 
+// Deprecated: please use Field.IsHasOne() instead
 func IsHasOne(field *Field) bool {
 	return field.Type.Type == Type_TYPE_MODEL && field.ForeignKeyFieldName == nil && !field.Type.Repeated
 }
 
+// Deprecated: please use Field.IsBelongsTo() instead
 func IsBelongsTo(field *Field) bool {
 	return field.Type.Type == Type_TYPE_MODEL && field.ForeignKeyFieldName != nil && !field.Type.Repeated
-}
-
-// IsFile tells us if the field is a file
-func (f *Field) IsFile() bool {
-	if f.Type == nil {
-		return false
-	}
-
-	return f.Type.Type == Type_TYPE_INLINE_FILE
 }
 
 // GetForeignKeyFieldName returns the foreign key field name for the given field if it
@@ -184,17 +180,7 @@ func FindEnum(enums []*Enum, name string) *Enum {
 	return enum
 }
 
-// HasFiles checks if the given schema has any models with fields that are files
-func (p *Schema) HasFiles() bool {
-	for _, model := range p.Models {
-		if model.HasFiles() {
-			return true
-		}
-	}
-
-	return false
-}
-
+// Deprecated: Use Schema.FilterActions() instead
 func FilterActions(p *Schema, filter func(op *Action) bool) (ops []*Action) {
 	for _, model := range p.Models {
 		actions := model.Actions
@@ -209,6 +195,7 @@ func FilterActions(p *Schema, filter func(op *Action) bool) (ops []*Action) {
 	return ops
 }
 
+// Deprecated: Use Schema.FindAction() instead
 func FindAction(schema *Schema, actionName string) *Action {
 	actions := FilterActions(schema, func(op *Action) bool {
 		return op.Name == actionName
@@ -219,14 +206,17 @@ func FindAction(schema *Schema, actionName string) *Action {
 	return actions[0]
 }
 
+// Deprecated: Use Action.IsFunction() instead
 func ActionIsFunction(action *Action) bool {
 	return action.Implementation == ActionImplementation_ACTION_IMPLEMENTATION_CUSTOM
 }
 
+// Deprecated: Use Action.IsArbitraryFunction() instead
 func ActionIsArbitraryFunction(action *Action) bool {
 	return ActionIsFunction(action) && (action.Type == ActionType_ACTION_TYPE_READ || action.Type == ActionType_ACTION_TYPE_WRITE)
 }
 
+// Deprecated: Use Action.IsWriteAction() instead
 func IsWriteAction(action *Action) bool {
 	switch action.Type {
 	case ActionType_ACTION_TYPE_CREATE, ActionType_ACTION_TYPE_DELETE, ActionType_ACTION_TYPE_WRITE, ActionType_ACTION_TYPE_UPDATE:
@@ -236,6 +226,7 @@ func IsWriteAction(action *Action) bool {
 	}
 }
 
+// Deprecated: Use Action.IsReadAction() instead
 func IsReadAction(action *Action) bool {
 	switch action.Type {
 	case ActionType_ACTION_TYPE_GET, ActionType_ACTION_TYPE_LIST, ActionType_ACTION_TYPE_READ:
@@ -397,23 +388,6 @@ func PermissionsWithExpression(permissions []*PermissionRule) []*PermissionRule 
 	return withPermissions
 }
 
-// IsModelField returns true if the input targets a model field
-// and is handled automatically by the runtime.
-// This will only be true for inputs that are built-in actions,
-// as functions never have this behaviour.
-func (f *MessageField) IsModelField() bool {
-	return len(f.Target) > 0
-}
-
-// IsFile tells us if the field is a file
-func (f *MessageField) IsFile() bool {
-	if f.Type == nil {
-		return false
-	}
-
-	return f.Type.Type == Type_TYPE_INLINE_FILE
-}
-
 // FindMessage will find a message type defined in a Keel schema based on the name of the message
 // e.g
 // FindMessage("MyMessage") will return this node:
@@ -425,6 +399,7 @@ func FindMessage(messages []*Message, messageName string) *Message {
 	return message
 }
 
+// Deprecated: Use Message.FindField() instead
 func FindMessageField(message *Message, fieldName string) *MessageField {
 	for _, field := range message.Fields {
 		if field.Name == fieldName {
@@ -433,18 +408,6 @@ func FindMessageField(message *Message, fieldName string) *MessageField {
 	}
 
 	return nil
-}
-
-// HasFiles checks if the message has any Inline file fields
-func (m *Message) HasFiles() bool {
-	return len(m.FileFields()) > 0
-}
-
-// FileFields will return a slice of fields for the model that are of type file
-func (m *Message) FileFields() []*MessageField {
-	return lo.Filter(m.Fields, func(f *MessageField, _ int) bool {
-		return f.IsFile()
-	})
 }
 
 // For built-in action types, returns the "values" input message, which may be nested inside the
@@ -515,7 +478,9 @@ func FindEvent(subscribers []*Event, name string) *Event {
 	return event
 }
 
-// FindSubscriber locates the subscriber of the given name.
+// FindEventSubscriptions locates the subscriber of the given name.
+//
+// Deprecated: use Schema.FindEventSubscribers instead
 func FindEventSubscriptions(schema *Schema, event *Event) []*Subscriber {
 	subscribers := lo.Filter(schema.Subscribers, func(m *Subscriber, _ int) bool {
 		return lo.Contains(m.EventNames, event.Name)

--- a/proto/query_test.go
+++ b/proto/query_test.go
@@ -7,16 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestModelNames(t *testing.T) {
-	t.Parallel()
-	require.Equal(t, []string{"ModelA", "ModelB", "ModelC"}, ModelNames(referenceSchema))
-}
-
-func TestFieldNames(t *testing.T) {
-	t.Parallel()
-	require.Equal(t, []string{"Field1", "Field2"}, FieldNames(referenceSchema.Models[0]))
-}
-
 func TestFindModel(t *testing.T) {
 	t.Parallel()
 	require.Equal(t, "ModelA", FindModel(referenceSchema.Models, "ModelA").Name)
@@ -66,53 +56,4 @@ var referenceSchema *Schema = &Schema{
 			},
 		},
 	},
-}
-
-func TestSchema_HasFiles(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name   string
-		schema *Schema
-		want   bool
-	}{
-		{
-			name: "schema with files",
-			schema: &Schema{
-				Models: []*Model{
-					{
-						Name: "Model",
-						Fields: []*Field{
-							{Name: "field_1"},
-							{Name: "image", Type: &TypeInfo{Type: Type_TYPE_INLINE_FILE}},
-						},
-					},
-				},
-			},
-			want: true,
-		},
-		{
-			name: "schema without files",
-			schema: &Schema{
-				Models: []*Model{
-					{
-						Name: "Model",
-						Fields: []*Field{
-							{Name: "field_1"},
-							{Name: "image", Type: &TypeInfo{Type: Type_TYPE_STRING}},
-						},
-					},
-				},
-			},
-			want: false,
-		},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			if got := tt.schema.HasFiles(); got != tt.want {
-				t.Errorf("Schema.HasFiles() = %v, want %v", got, tt.want)
-			}
-		})
-	}
 }

--- a/proto/schema.go
+++ b/proto/schema.go
@@ -51,7 +51,7 @@ func (s *Schema) FilterActions(filter func(op *Action) bool) (ops []*Action) {
 }
 
 func (s *Schema) FindAction(actionName string) *Action {
-	actions := FilterActions(s, func(op *Action) bool {
+	actions := s.FilterActions(func(op *Action) bool {
 		return op.Name == actionName
 	})
 	if len(actions) != 1 {

--- a/proto/schema.go
+++ b/proto/schema.go
@@ -1,0 +1,69 @@
+package proto
+
+import (
+	"sort"
+
+	"github.com/samber/lo"
+)
+
+// HasFiles checks if the given schema has any models with fields that are files
+func (p *Schema) HasFiles() bool {
+	for _, model := range p.Models {
+		if model.HasFiles() {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ModelNames provides a (sorted) list of all the Model names used in the
+// given schema.
+func (s *Schema) ModelNames() []string {
+	names := lo.Map(s.Models, func(x *Model, _ int) string {
+		return x.Name
+	})
+	sort.Strings(names)
+	return names
+}
+
+// AllFields provides a list of all the model fields specified in the schema.
+func (s *Schema) AllFields() []*Field {
+	fields := []*Field{}
+	for _, model := range s.Models {
+		fields = append(fields, model.Fields...)
+	}
+	return fields
+}
+
+func (s *Schema) FilterActions(filter func(op *Action) bool) (ops []*Action) {
+	for _, model := range s.Models {
+		actions := model.Actions
+
+		for _, o := range actions {
+			if filter(o) {
+				ops = append(ops, o)
+			}
+		}
+	}
+
+	return ops
+}
+
+func (s *Schema) FindAction(actionName string) *Action {
+	actions := FilterActions(s, func(op *Action) bool {
+		return op.Name == actionName
+	})
+	if len(actions) != 1 {
+		return nil
+	}
+	return actions[0]
+}
+
+// FindEventSubscribers locates the subscribers for the given event.
+func (s *Schema) FindEventSubscribers(event *Event) []*Subscriber {
+	subscribers := lo.Filter(s.Subscribers, func(m *Subscriber, _ int) bool {
+		return lo.Contains(m.EventNames, event.Name)
+	})
+	return subscribers
+}

--- a/proto/schema_test.go
+++ b/proto/schema_test.go
@@ -1,0 +1,60 @@
+package proto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestModelNames(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, []string{"ModelA", "ModelB", "ModelC"}, referenceSchema.ModelNames())
+}
+func TestSchema_HasFiles(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		schema *Schema
+		want   bool
+	}{
+		{
+			name: "schema with files",
+			schema: &Schema{
+				Models: []*Model{
+					{
+						Name: "Model",
+						Fields: []*Field{
+							{Name: "field_1"},
+							{Name: "image", Type: &TypeInfo{Type: Type_TYPE_INLINE_FILE}},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "schema without files",
+			schema: &Schema{
+				Models: []*Model{
+					{
+						Name: "Model",
+						Fields: []*Field{
+							{Name: "field_1"},
+							{Name: "image", Type: &TypeInfo{Type: Type_TYPE_STRING}},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.schema.HasFiles(); got != tt.want {
+				t.Errorf("Schema.HasFiles() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/runtime/actions/embed.go
+++ b/runtime/actions/embed.go
@@ -21,7 +21,7 @@ func resolveEmbeddedData(ctx context.Context, schema *proto.Schema, sourceModel 
 		return nil, fmt.Errorf("embed target field (%s) does not exist in model %s", embedTargetField, sourceModel.GetName())
 	}
 
-	if !proto.IsTypeModel(field) {
+	if !field.IsTypeModel() {
 		return nil, fmt.Errorf("field (%s) is not a embeddable model field", embedTargetField)
 	}
 
@@ -42,7 +42,7 @@ func resolveEmbeddedData(ctx context.Context, schema *proto.Schema, sourceModel 
 	}
 
 	switch {
-	case proto.IsBelongsTo(field):
+	case field.IsBelongsTo():
 		dbQuery.Join(
 			sourceModel.Name,
 			&QueryOperand{
@@ -83,7 +83,7 @@ func resolveEmbeddedData(ctx context.Context, schema *proto.Schema, sourceModel 
 		}
 
 		return result, nil
-	case proto.IsHasMany(field):
+	case field.IsHasMany():
 		dbQuery.Join(
 			sourceModel.Name,
 			&QueryOperand{
@@ -130,7 +130,7 @@ func resolveEmbeddedData(ctx context.Context, schema *proto.Schema, sourceModel 
 		}
 
 		return result, nil
-	case proto.IsHasOne(field):
+	case field.IsHasOne():
 		dbQuery.Join(
 			sourceModel.Name,
 			&QueryOperand{

--- a/runtime/actions/expression.go
+++ b/runtime/actions/expression.go
@@ -204,7 +204,7 @@ func (query *QueryBuilder) addJoinFromFragments(scope *Scope, fragments []string
 		var rightOperand *QueryOperand
 
 		switch {
-		case proto.IsBelongsTo(relatedModelField):
+		case relatedModelField.IsBelongsTo():
 			// In a "belongs to" the foreign key is on _this_ model
 			leftOperand = ExpressionField(fragments[:i+1], primaryKey)
 			rightOperand = ExpressionField(fragments[:i], foreignKeyField)

--- a/runtime/actions/query_test.go
+++ b/runtime/actions/query_test.go
@@ -3441,7 +3441,7 @@ func generateQueryScope(ctx context.Context, schemaString string, actionName str
 		return nil, nil, nil, err
 	}
 
-	action := proto.FindAction(schema, actionName)
+	action := schema.FindAction(actionName)
 	if action == nil {
 		return nil, nil, nil, fmt.Errorf("action not found in schema: %s", actionName)
 	}

--- a/runtime/actions/writeinputs.go
+++ b/runtime/actions/writeinputs.go
@@ -193,9 +193,9 @@ func (query *QueryBuilder) captureWriteValuesFromMessage(scope *Scope, message *
 				var foreignKeys map[string]any
 				var err error
 
-				if proto.IsHasMany(field) || proto.IsHasOne(field) {
-					// if proto.IsHasMany(field) then we have a 1:M relationship and the FK is on this model.
-					// if proto.IsHasOne(field) then we have a 1:1 relationship with the FK on this model.
+				if field.IsHasMany() || field.IsHasOne() {
+					// if field.IsHasMany() then we have a 1:M relationship and the FK is on this model.
+					// if field.IsHasOne() then we have a 1:1 relationship with the FK on this model.
 
 					arg, hasArg := args[input.Name]
 					if !hasArg && !input.Optional {
@@ -205,7 +205,7 @@ func (query *QueryBuilder) captureWriteValuesFromMessage(scope *Scope, message *
 					}
 
 					var argsArraySectioned []any
-					if proto.IsHasOne(field) {
+					if field.IsHasOne() {
 						argsArraySectioned = []any{arg}
 					} else {
 						var ok bool

--- a/runtime/apis/httpjson/httpjson.go
+++ b/runtime/apis/httpjson/httpjson.go
@@ -62,7 +62,7 @@ func NewHandler(p *proto.Schema, api *proto.Api) common.HandlerFunc {
 			return NewErrorResponse(ctx, common.NewHttpMethodNotAllowedError("only HTTP POST or GET accepted"), nil)
 		}
 
-		action := proto.FindAction(p, actionName)
+		action := p.FindAction(actionName)
 		if action == nil {
 			return NewErrorResponse(ctx, common.NewMethodNotFoundError(), nil)
 		}

--- a/runtime/apis/jsonrpc/jsonrpc.go
+++ b/runtime/apis/jsonrpc/jsonrpc.go
@@ -67,7 +67,7 @@ func NewHandler(schema *proto.Schema, api *proto.Api) common.HandlerFunc {
 			attribute.String("api.protocol", "RPC"),
 		)
 
-		action := proto.FindAction(schema, req.Method)
+		action := schema.FindAction(req.Method)
 		if action == nil {
 			err = common.NewMethodNotFoundError()
 			return NewErrorResponse(ctx, &req.ID, err)

--- a/runtime/expressions/operand.go
+++ b/runtime/expressions/operand.go
@@ -80,7 +80,7 @@ func (resolver *OperandResolver) NormalisedFragments() ([]string, error) {
 			}
 		}
 
-		if proto.IsHasOne(fieldTarget) || proto.IsHasMany(fieldTarget) {
+		if fieldTarget.IsHasOne() || fieldTarget.IsHasMany() {
 			// Add a new fragment 'id'
 			fragments = append(fragments, parser.FieldNameId)
 		} else {
@@ -299,16 +299,16 @@ func (resolver *OperandResolver) GetOperandType() (proto.Type, bool, error) {
 		switch action.Type {
 		case proto.ActionType_ACTION_TYPE_CREATE:
 			message := proto.FindValuesInputMessage(schema, action.Name)
-			field = proto.FindMessageField(message, inputName)
+			field = message.FindField(inputName)
 		case proto.ActionType_ACTION_TYPE_GET, proto.ActionType_ACTION_TYPE_LIST, proto.ActionType_ACTION_TYPE_DELETE:
 			message := proto.FindWhereInputMessage(schema, action.Name)
-			field = proto.FindMessageField(message, inputName)
+			field = message.FindField(inputName)
 		case proto.ActionType_ACTION_TYPE_UPDATE:
 			message := proto.FindValuesInputMessage(schema, action.Name)
-			field = proto.FindMessageField(message, inputName)
+			field = message.FindField(inputName)
 			if field == nil {
 				message := proto.FindWhereInputMessage(schema, action.Name)
-				field = proto.FindMessageField(message, inputName)
+				field = message.FindField(inputName)
 			}
 		default:
 			return proto.Type_TYPE_UNKNOWN, false, fmt.Errorf("unhandled action type %s for explicit input", action.Type)

--- a/runtime/jsonschema/jsonschema_test.go
+++ b/runtime/jsonschema/jsonschema_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/teamkeel/keel/config"
-	"github.com/teamkeel/keel/proto"
 	"github.com/teamkeel/keel/runtime/jsonschema"
 	"github.com/teamkeel/keel/schema"
 )
@@ -59,7 +58,7 @@ func TestJSONSchemaGeneration(t *testing.T) {
 			schema, err := builder.MakeFromString(c.keelSchema, config.Empty)
 			require.NoError(t, err)
 
-			action := proto.FindAction(schema, "testAction")
+			action := schema.FindAction("testAction")
 			require.NotNil(t, action, "action with name testAction could not be found")
 
 			jsonSchema := jsonschema.JSONSchemaForActionInput(context.Background(), schema, action)
@@ -899,7 +898,7 @@ func TestValidateRequest(t *testing.T) {
 				err = json.Unmarshal([]byte(f.request), &req)
 				require.NoError(t, err)
 
-				action := proto.FindAction(schema, f.opName)
+				action := schema.FindAction(f.opName)
 
 				result, err := jsonschema.ValidateRequest(context.Background(), schema, action, req)
 				require.NoError(t, err)

--- a/runtime/openapi/openapi.go
+++ b/runtime/openapi/openapi.go
@@ -99,7 +99,7 @@ func Generate(ctx context.Context, schema *proto.Schema, api *proto.Api) OpenAPI
 	}
 
 	for _, actionName := range proto.GetActionNamesForApi(schema, api) {
-		action := proto.FindAction(schema, actionName)
+		action := schema.FindAction(actionName)
 
 		inputSchema := jsonschema.JSONSchemaForActionInput(ctx, schema, action)
 		endpoint := fmt.Sprintf("/%s/json/%s", strings.ToLower(api.Name), action.Name)

--- a/runtime/runtime_audit_test.go
+++ b/runtime/runtime_audit_test.go
@@ -58,7 +58,7 @@ func TestAuditCreateAction(t *testing.T) {
 	ctx, identity := withIdentity(t, ctx, schema)
 
 	_, err := actions.Create(
-		actions.NewScope(ctx, proto.FindAction(schema, "createWedding"), schema),
+		actions.NewScope(ctx, schema.FindAction("createWedding"), schema),
 		map[string]any{"name": "Dave"})
 	require.NoError(t, err)
 
@@ -102,7 +102,7 @@ func TestAuditNestedCreateAction(t *testing.T) {
 	ctx, identity := withIdentity(t, ctx, schema)
 
 	_, err := actions.Create(
-		actions.NewScope(ctx, proto.FindAction(schema, "createWeddingWithGuests"), schema),
+		actions.NewScope(ctx, schema.FindAction("createWeddingWithGuests"), schema),
 		map[string]any{
 			"name": "Dave",
 			"guests": []any{
@@ -208,13 +208,13 @@ func TestAuditUpdateAction(t *testing.T) {
 
 	ctx, identity := withIdentity(t, ctx, schema)
 
-	create := proto.FindAction(schema, "createWedding")
+	create := schema.FindAction("createWedding")
 	createResult, _, err := actions.Execute(
 		actions.NewScope(ctx, create, schema),
 		map[string]any{"name": "Dave"})
 	require.NoError(t, err)
 
-	update := proto.FindAction(schema, "updateWedding")
+	update := schema.FindAction("updateWedding")
 	_, _, err = actions.Execute(
 		actions.NewScope(ctx, update, schema),
 		map[string]any{
@@ -266,7 +266,7 @@ func TestAuditDeleteAction(t *testing.T) {
 
 	ctx, identity := withIdentity(t, ctx, schema)
 
-	create := proto.FindAction(schema, "createWedding")
+	create := schema.FindAction("createWedding")
 	createResult, _, err := actions.Execute(
 		actions.NewScope(ctx, create, schema),
 		map[string]any{"name": "Dave"})
@@ -281,7 +281,7 @@ func TestAuditDeleteAction(t *testing.T) {
 	wedding["created_at"] = wedding["created_at"].(time.Time).UTC().Format("2006-01-02T15:04:05.999999999-07:00")
 	wedding["updated_at"] = wedding["updated_at"].(time.Time).UTC().Format("2006-01-02T15:04:05.999999999-07:00")
 
-	delete := proto.FindAction(schema, "deleteWedding")
+	delete := schema.FindAction("deleteWedding")
 	_, _, err = actions.Execute(
 		actions.NewScope(ctx, delete, schema),
 		map[string]any{"id": createResult.(map[string]any)["id"]},
@@ -326,7 +326,7 @@ func TestAuditTablesWithOnlyIdentity(t *testing.T) {
 	spanContext := trace.NewSpanContext(trace.SpanContextConfig{})
 	ctx = trace.ContextWithSpanContext(ctx, spanContext)
 
-	action := proto.FindAction(schema, "createWedding")
+	action := schema.FindAction("createWedding")
 	input := map[string]any{"name": "Dave"}
 	scope := actions.NewScope(ctx, action, schema)
 	_, err := actions.Create(scope, input)
@@ -351,7 +351,7 @@ func TestAuditTablesWithOnlyTracing(t *testing.T) {
 	defer database.Close()
 	db := database.GetDB()
 
-	action := proto.FindAction(schema, "createWedding")
+	action := schema.FindAction("createWedding")
 	input := map[string]any{"name": "Dave"}
 	scope := actions.NewScope(ctx, action, schema)
 	_, err := actions.Create(scope, input)
@@ -379,11 +379,11 @@ func TestAuditOnStatementExecuteWithoutResult(t *testing.T) {
 	ctx, identity := withIdentity(t, ctx, schema)
 
 	result, err := actions.Create(
-		actions.NewScope(ctx, proto.FindAction(schema, "createWedding"), schema),
+		actions.NewScope(ctx, schema.FindAction("createWedding"), schema),
 		map[string]any{"name": "Dave"})
 	require.NoError(t, err)
 
-	action := proto.FindAction(schema, "createWedding")
+	action := schema.FindAction("createWedding")
 
 	scope := actions.NewScope(ctx, action, schema)
 	query := actions.NewQuery(scope.Model)
@@ -419,7 +419,7 @@ func TestAuditFieldsAreDroppedOnCreate(t *testing.T) {
 	ctx, _ = withIdentity(t, ctx, schema)
 
 	result, err := actions.Create(
-		actions.NewScope(ctx, proto.FindAction(schema, "createWedding"), schema),
+		actions.NewScope(ctx, schema.FindAction("createWedding"), schema),
 		map[string]any{"name": "Dave"})
 	require.NoError(t, err)
 
@@ -444,7 +444,7 @@ func TestAuditDatabaseMigration(t *testing.T) {
 
 	ctx, database, pSchema := keeltesting.MakeContext(t, context.TODO(), keelSchema, true)
 
-	create := proto.FindAction(pSchema, "createPerson")
+	create := pSchema.FindAction("createPerson")
 	_, _, err := actions.Execute(
 		actions.NewScope(ctx, create, pSchema),
 		map[string]any{"name": "Dave"})

--- a/runtime/runtime_events_test.go
+++ b/runtime/runtime_events_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/karlseguin/typed"
 	"github.com/stretchr/testify/require"
 	"github.com/teamkeel/keel/events"
-	"github.com/teamkeel/keel/proto"
 	"github.com/teamkeel/keel/runtime/actions"
 	"github.com/teamkeel/keel/schema/parser"
 	keeltesting "github.com/teamkeel/keel/testing"
@@ -92,7 +91,7 @@ func TestCreateEvent(t *testing.T) {
 	require.NoError(t, err)
 
 	result, _, err := actions.Execute(
-		actions.NewScope(ctx, proto.FindAction(schema, "createWedding"), schema),
+		actions.NewScope(ctx, schema.FindAction("createWedding"), schema),
 		map[string]any{"name": "Dave"})
 	require.NoError(t, err)
 
@@ -131,7 +130,7 @@ func TestUpdateEvent(t *testing.T) {
 	defer database.Close()
 
 	result, _, err := actions.Execute(
-		actions.NewScope(ctx, proto.FindAction(schema, "createWedding"), schema),
+		actions.NewScope(ctx, schema.FindAction("createWedding"), schema),
 		map[string]any{"name": "Dave"})
 	require.NoError(t, err)
 
@@ -145,7 +144,7 @@ func TestUpdateEvent(t *testing.T) {
 	require.NoError(t, err)
 
 	updated, _, err := actions.Execute(
-		actions.NewScope(ctx, proto.FindAction(schema, "updateWedding"), schema),
+		actions.NewScope(ctx, schema.FindAction("updateWedding"), schema),
 		map[string]any{
 			"where":  map[string]any{"id": wedding["id"]},
 			"values": map[string]any{"name": "Adam"},
@@ -203,7 +202,7 @@ func TestDeleteEvent(t *testing.T) {
 	defer database.Close()
 
 	result, _, err := actions.Execute(
-		actions.NewScope(ctx, proto.FindAction(schema, "createWedding"), schema),
+		actions.NewScope(ctx, schema.FindAction("createWedding"), schema),
 		map[string]any{"name": "Dave"})
 	require.NoError(t, err)
 
@@ -217,7 +216,7 @@ func TestDeleteEvent(t *testing.T) {
 	require.NoError(t, err)
 
 	_, _, err = actions.Execute(
-		actions.NewScope(ctx, proto.FindAction(schema, "deleteWedding"), schema),
+		actions.NewScope(ctx, schema.FindAction("deleteWedding"), schema),
 		map[string]any{"id": wedding["id"]})
 	require.NoError(t, err)
 
@@ -268,7 +267,7 @@ func TestNoIdentityEvent(t *testing.T) {
 	require.NoError(t, err)
 
 	_, _, err = actions.Execute(
-		actions.NewScope(ctx, proto.FindAction(schema, "createWedding"), schema),
+		actions.NewScope(ctx, schema.FindAction("createWedding"), schema),
 		map[string]any{"name": "Dave"})
 	require.NoError(t, err)
 
@@ -291,7 +290,7 @@ func TestNestedCreateEvent(t *testing.T) {
 	require.NoError(t, err)
 
 	result, _, err := actions.Execute(
-		actions.NewScope(ctx, proto.FindAction(schema, "createWeddingWithGuests"), schema),
+		actions.NewScope(ctx, schema.FindAction("createWeddingWithGuests"), schema),
 		map[string]any{
 			"name": "Dave",
 			"guests": []any{
@@ -333,14 +332,14 @@ func TestMultipleEvents(t *testing.T) {
 	require.NoError(t, err)
 
 	result, _, err := actions.Execute(
-		actions.NewScope(ctx, proto.FindAction(schema, "createInvitee"), schema),
+		actions.NewScope(ctx, schema.FindAction("createInvitee"), schema),
 		map[string]any{"firstName": "Dave"})
 	require.NoError(t, err)
 	wedding, ok := result.(map[string]any)
 	require.True(t, ok)
 
 	updated, _, err := actions.Execute(
-		actions.NewScope(ctx, proto.FindAction(schema, "updateInvitee"), schema),
+		actions.NewScope(ctx, schema.FindAction("updateInvitee"), schema),
 		map[string]any{
 			"where":  map[string]any{"id": wedding["id"]},
 			"values": map[string]any{"firstName": "Adam"},
@@ -380,14 +379,14 @@ func TestAuditTableEventCreatedAtUpdated(t *testing.T) {
 	require.NoError(t, err)
 
 	result, _, err := actions.Execute(
-		actions.NewScope(ctx, proto.FindAction(schema, "createWedding"), schema),
+		actions.NewScope(ctx, schema.FindAction("createWedding"), schema),
 		map[string]any{"name": "Dave"})
 	require.NoError(t, err)
 	_, ok := result.(map[string]any)
 	require.True(t, ok)
 
 	result2, _, err := actions.Execute(
-		actions.NewScope(ctx, proto.FindAction(schema, "createPerson"), schema),
+		actions.NewScope(ctx, schema.FindAction("createPerson"), schema),
 		map[string]any{})
 	require.NoError(t, err)
 	_, ok2 := result2.(map[string]any)
@@ -420,7 +419,7 @@ func TestFailedEventHandling(t *testing.T) {
 	require.NoError(t, err)
 
 	result, _, err := actions.Execute(
-		actions.NewScope(ctx, proto.FindAction(schema, "createWeddingWithGuests"), schema),
+		actions.NewScope(ctx, schema.FindAction("createWeddingWithGuests"), schema),
 		map[string]any{
 			"name": "Dave",
 			"guests": []any{

--- a/runtime/runtime_rpc_test.go
+++ b/runtime/runtime_rpc_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/teamkeel/keel/db"
-	"github.com/teamkeel/keel/proto"
 	"github.com/teamkeel/keel/runtime"
 	"github.com/teamkeel/keel/runtime/jsonschema"
 	"github.com/teamkeel/keel/runtime/runtimectx"
@@ -96,7 +95,7 @@ func TestRuntimeRPC(t *testing.T) {
 				tCase.assertResponse(t, res)
 			}
 
-			action := proto.FindAction(schema, tCase.Path)
+			action := schema.FindAction(tCase.Path)
 
 			if response.Status == 200 {
 				_, result, err := jsonschema.ValidateResponse(ctx, schema, action, res)


### PR DESCRIPTION
Housekeeping update of the proto package:

Duplicated most functions as methods on their respective structures; e.g. `func (f *Field) IsHasMany() bool` instead of ` func IsHasMany(field *Field)` and deprecated original functions. Migrate all usage of newly deprecated function to the new definitions. 

Split the methods across multiple smaller and easier to follow files relevant to the receiver of the method (e.g. `model.go`, `field.go` etc. )