### PR TITLE
chore: re-enable staticcheck linter. update deprecated method

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,7 @@ linters:
   enable:
     - errcheck
     - misspell
+    - staticcheck
     - unconvert
     - unparam
     - unused
@@ -10,8 +11,3 @@ linters:
     - whitespace
   disable:
     - govet
-linters-settings:
- staticcheck:
-    checks:
-      - all
-      - '-SA1019' # allow the use of deprecated functions (since we have some)

--- a/events/events.go
+++ b/events/events.go
@@ -15,6 +15,7 @@ import (
 	"github.com/teamkeel/keel/util"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 // Event names
@@ -56,7 +57,7 @@ var contextKey handlerContextKey = "eventHandler"
 func WithEventHandler(ctx context.Context, handler EventHandler) (context.Context, error) {
 	// If no tracing provider is set up, then events will not work.
 	// It is better to error than to let events silently malfunction.
-	if otel.GetTracerProvider() == trace.NewNoopTracerProvider() {
+	if otel.GetTracerProvider() == noop.NewTracerProvider() {
 		return nil, errors.New("cannot use events when there is no trace provider configured")
 	}
 


### PR DESCRIPTION
Re-enabling staticcheck. Update trace check for noop to use new package