### PR TITLE
fix: neon serverless client

### DIFF
--- a/packages/functions-runtime/package.json
+++ b/packages/functions-runtime/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.617.0",
     "@aws-sdk/credential-providers": "^3.617.0",
-    "@neondatabase/serverless": "^0.9.3",
+    "@neondatabase/serverless": "^0.9.4",
     "@opentelemetry/api": "^1.7.0",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.46.0",
     "@opentelemetry/resources": "^1.19.0",
@@ -31,7 +31,6 @@
     "json-rpc-2.0": "^1.7.0",
     "ksuid": "^3.0.0",
     "kysely": "^0.25.0",
-    "kysely-neon": "^1.3.0",
     "pg": "^8.11.3",
     "traceparent": "^1.0.0",
     "ws": "^8.17.1"

--- a/packages/functions-runtime/pnpm-lock.yaml
+++ b/packages/functions-runtime/pnpm-lock.yaml
@@ -12,7 +12,7 @@ dependencies:
     specifier: ^3.617.0
     version: 3.621.0(@aws-sdk/client-sso-oidc@3.621.0)
   '@neondatabase/serverless':
-    specifier: ^0.9.3
+    specifier: ^0.9.4
     version: 0.9.4
   '@opentelemetry/api':
     specifier: ^1.7.0
@@ -41,9 +41,6 @@ dependencies:
   kysely:
     specifier: ^0.25.0
     version: 0.25.0
-  kysely-neon:
-    specifier: ^1.3.0
-    version: 1.3.0(@neondatabase/serverless@0.9.4)(kysely@0.25.0)(ws@8.18.0)
   pg:
     specifier: ^8.11.3
     version: 8.12.0
@@ -2122,21 +2119,6 @@ packages:
     resolution: {integrity: sha512-81CkBGn/06ZVAjGvFZi6fVG8VcPeMH0JpJ4V1Z9VwrMMaGIeAjY4jrVdrIcxhL9I2ZUU6t5uiyswcmkk+KZegA==}
     dependencies:
       base-convert-int-array: 1.0.1
-    dev: false
-
-  /kysely-neon@1.3.0(@neondatabase/serverless@0.9.4)(kysely@0.25.0)(ws@8.18.0):
-    resolution: {integrity: sha512-CIIlbmqpIXVJDdBEYtEOwbmALag0jmqYrGfBeM4cHKb9AgBGs+X1SvXUZ8TqkDacQEqEZN2XtsDoUkcMIISjHw==}
-    peerDependencies:
-      '@neondatabase/serverless': ^0.4.3
-      kysely: 0.x.x
-      ws: ^8.13.0
-    peerDependenciesMeta:
-      ws:
-        optional: true
-    dependencies:
-      '@neondatabase/serverless': 0.9.4
-      kysely: 0.25.0
-      ws: 8.18.0
     dev: false
 
   /kysely@0.25.0:

--- a/packages/functions-runtime/src/database.js
+++ b/packages/functions-runtime/src/database.js
@@ -229,7 +229,6 @@ function mustEnv(key) {
   return v;
 }
 
-
 function connectionTimeout() {
   const v = Number(process.env["KEEL_DB_CONN_TIMEOUT"]);
   if (!v || isNaN(v)) {


### PR DESCRIPTION
- Ditching the neon-kysely dialect for the neon/serverless client
- Connection timeout value based on KEEL_DB_CONN_TIMEOUT or set to 45s
- Monkey patching the serverless client for our tracing needs
- Log the pg/neon dialect and timeout in db spans