### PR TITLE
fix: do not store file url

### DIFF
--- a/runtime/actions/file_uploads.go
+++ b/runtime/actions/file_uploads.go
@@ -49,7 +49,7 @@ func handleFileUploads(scope *Scope, inputs map[string]any) (map[string]any, err
 				}
 
 				// ... and then change the input with the file data that should be saved in the db
-				fileInfo, err := fi.ToJSON()
+				fileInfo, err := fi.ToDbRecord()
 				if err != nil {
 					return inputs, err
 				}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -26,6 +26,7 @@ type Storer interface {
 	HydrateFileInfo(fi *FileResponse) (FileResponse, error)
 }
 
+// FileResponse is what is returned from our APIs
 type FileResponse struct {
 	Key         string  `json:"key"`
 	Filename    string  `json:"filename"`
@@ -34,8 +35,31 @@ type FileResponse struct {
 	URL         *string `json:"url,omitempty"`
 }
 
+// FileDbRecord is what is stored in the database
+type FileDbRecord struct {
+	Key         string `json:"key"`
+	Filename    string `json:"filename"`
+	ContentType string `json:"contentType"`
+	Size        int    `json:"size"`
+}
+
 func (fi *FileResponse) ToJSON() (string, error) {
 	json, err := json.Marshal(fi)
+	if err != nil {
+		return "", fmt.Errorf("marshalling to json: %w", err)
+	}
+	return string(json), nil
+}
+
+func (fi *FileResponse) ToDbRecord() (string, error) {
+	dbRec := &FileDbRecord{
+		Key:         fi.Key,
+		Filename:    fi.Filename,
+		ContentType: fi.ContentType,
+		Size:        fi.Size,
+	}
+
+	json, err := json.Marshal(dbRec)
 	if err != nil {
 		return "", fmt.Errorf("marshalling to json: %w", err)
 	}


### PR DESCRIPTION
This change prevents the presigned URL from being stored in the database.  The presigned URL is generated every time we include a `Feel` field within an API response, so it doesn't need to be stored.  Plus, it will expire anyway.