### PR TITLE
fix: ignore file handling when no files on model

### DIFF
--- a/runtime/actions/create.go
+++ b/runtime/actions/create.go
@@ -23,15 +23,17 @@ func Create(scope *Scope, input map[string]any) (res map[string]any, err error) 
 		return nil, err
 	}
 
-	// handle file uploads
-	in, err := handleFileUploads(scope, input)
-	if err != nil {
-		return nil, fmt.Errorf("handling file uploads: %w", err)
+	if scope.Model.HasFiles() {
+		// handle file uploads
+		input, err = handleFileUploads(scope, input)
+		if err != nil {
+			return nil, fmt.Errorf("handling file uploads: %w", err)
+		}
 	}
 
 	// Generate the SQL statement
 	query := NewQuery(scope.Model)
-	statement, err := GenerateCreateStatement(query, scope, in)
+	statement, err := GenerateCreateStatement(query, scope, input)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/actions/update.go
+++ b/runtime/actions/update.go
@@ -15,13 +15,15 @@ func Update(scope *Scope, input map[string]any) (res map[string]any, err error) 
 		return nil, err
 	}
 
-	// handle file uploads and change input values to file data if applicable
-	if values, ok := input["values"].(map[string]any); ok {
-		in, err := handleFileUploads(scope, values)
-		if err != nil {
-			return nil, fmt.Errorf("handling file uploads: %w", err)
+	if scope.Model.HasFiles() {
+		// handle file uploads and change input values to file data if applicable
+		if values, ok := input["values"].(map[string]any); ok {
+			in, err := handleFileUploads(scope, values)
+			if err != nil {
+				return nil, fmt.Errorf("handling file uploads: %w", err)
+			}
+			input["values"] = in
 		}
-		input["values"] = in
 	}
 
 	// Generate SQL statement


### PR DESCRIPTION
When no files exist on a model, there is no reason to run `handleFileUploads`.  Also, this was causing a runtime error in the hosted environment.