### PR TITLE
fix: create hierarchical input messages for write functions

### DIFF
--- a/runtime/jsonschema/testdata/write_optional_fields.json
+++ b/runtime/jsonschema/testdata/write_optional_fields.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" },
+    "name": { "type": "string" },
+    "people": { "$ref": "#/components/schemas/NullableTestActionPeopleInput" }
+  },
+  "additionalProperties": false,
+  "required": ["id"],
+  "components": {
+    "schemas": {
+      "NullableTestActionPeopleInput": {
+        "type": ["object", "null"],
+        "properties": { "id": { "type": "string" } },
+        "additionalProperties": false
+      }
+    }
+  }
+}

--- a/runtime/jsonschema/testdata/write_optional_fields.keel
+++ b/runtime/jsonschema/testdata/write_optional_fields.keel
@@ -1,0 +1,20 @@
+model People {
+    fields {
+        name Text
+    }
+}
+
+model Groups {
+    fields {
+        people People?
+        name Text
+    }
+
+    actions {
+        write testAction(id, name?, people.id?) returns (UpdateGroupResponse)
+    }
+}
+
+message UpdateGroupResponse {
+    status Text
+}

--- a/schema/makeproto.go
+++ b/schema/makeproto.go
@@ -1012,11 +1012,21 @@ func (scm *Builder) makeActionInputMessages(model *parser.ModelNode, action *par
 				})
 			}
 		}
-	case parser.ActionTypeGet, parser.ActionTypeDelete, parser.ActionTypeRead, parser.ActionTypeWrite:
+	case parser.ActionTypeGet, parser.ActionTypeDelete, parser.ActionTypeRead:
 		// Create message and add it to the proto schema
 		messageName := makeInputMessageName(action.Name.Value)
 		message := scm.makeMessageFromActionInputNodes(messageName, action.Inputs, model)
 		scm.proto.Messages = append(scm.proto.Messages, message)
+	case parser.ActionTypeWrite:
+		// Create message and add it to the proto schema
+		message := &proto.Message{
+			Name:   makeInputMessageName(action.Name.Value),
+			Fields: []*proto.MessageField{},
+		}
+		scm.proto.Messages = append(scm.proto.Messages, message)
+		for _, input := range action.Inputs {
+			scm.makeMessageHierarchyFromImplicitInput(message, input, model, action)
+		}
 	case parser.ActionTypeUpdate:
 		// Create where message and add it to the proto schema
 		whereMessageName := makeWhereMessageName(action.Name.Value)

--- a/schema/testdata/proto/arbitrary_function_optional_inputs/proto.json
+++ b/schema/testdata/proto/arbitrary_function_optional_inputs/proto.json
@@ -1,0 +1,598 @@
+{
+  "models": [
+    {
+      "name": "People",
+      "fields": [
+        {
+          "modelName": "People",
+          "name": "name",
+          "type": {
+            "type": "TYPE_STRING"
+          }
+        },
+        {
+          "modelName": "People",
+          "name": "id",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "primaryKey": true,
+          "defaultValue": {
+            "useZeroValue": true
+          }
+        },
+        {
+          "modelName": "People",
+          "name": "createdAt",
+          "type": {
+            "type": "TYPE_DATETIME"
+          },
+          "defaultValue": {
+            "useZeroValue": true
+          }
+        },
+        {
+          "modelName": "People",
+          "name": "updatedAt",
+          "type": {
+            "type": "TYPE_DATETIME"
+          },
+          "defaultValue": {
+            "useZeroValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "Groups",
+      "fields": [
+        {
+          "modelName": "Groups",
+          "name": "people",
+          "type": {
+            "type": "TYPE_MODEL",
+            "modelName": "People"
+          },
+          "optional": true,
+          "foreignKeyFieldName": "peopleId"
+        },
+        {
+          "modelName": "Groups",
+          "name": "name",
+          "type": {
+            "type": "TYPE_STRING"
+          }
+        },
+        {
+          "modelName": "Groups",
+          "name": "nullText",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Groups",
+          "name": "id",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "primaryKey": true,
+          "defaultValue": {
+            "useZeroValue": true
+          }
+        },
+        {
+          "modelName": "Groups",
+          "name": "createdAt",
+          "type": {
+            "type": "TYPE_DATETIME"
+          },
+          "defaultValue": {
+            "useZeroValue": true
+          }
+        },
+        {
+          "modelName": "Groups",
+          "name": "updatedAt",
+          "type": {
+            "type": "TYPE_DATETIME"
+          },
+          "defaultValue": {
+            "useZeroValue": true
+          }
+        },
+        {
+          "modelName": "Groups",
+          "name": "peopleId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "optional": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "People",
+            "relatedModelField": "id"
+          }
+        }
+      ],
+      "actions": [
+        {
+          "modelName": "Groups",
+          "name": "testAction",
+          "type": "ACTION_TYPE_WRITE",
+          "implementation": "ACTION_IMPLEMENTATION_CUSTOM",
+          "inputMessageName": "TestActionInput",
+          "responseMessageName": "UpdateGroupResponse"
+        },
+        {
+          "modelName": "Groups",
+          "name": "testUpdateAction",
+          "type": "ACTION_TYPE_UPDATE",
+          "implementation": "ACTION_IMPLEMENTATION_AUTO",
+          "inputMessageName": "TestUpdateActionInput"
+        }
+      ]
+    },
+    {
+      "name": "Identity",
+      "fields": [
+        {
+          "modelName": "Identity",
+          "name": "email",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true,
+          "uniqueWith": [
+            "issuer"
+          ]
+        },
+        {
+          "modelName": "Identity",
+          "name": "emailVerified",
+          "type": {
+            "type": "TYPE_BOOL"
+          },
+          "defaultValue": {
+            "expression": {
+              "source": "false"
+            }
+          }
+        },
+        {
+          "modelName": "Identity",
+          "name": "password",
+          "type": {
+            "type": "TYPE_PASSWORD"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Identity",
+          "name": "externalId",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Identity",
+          "name": "issuer",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true,
+          "uniqueWith": [
+            "email"
+          ]
+        },
+        {
+          "modelName": "Identity",
+          "name": "name",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Identity",
+          "name": "givenName",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Identity",
+          "name": "familyName",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Identity",
+          "name": "middleName",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Identity",
+          "name": "nickName",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Identity",
+          "name": "profile",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Identity",
+          "name": "picture",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Identity",
+          "name": "website",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Identity",
+          "name": "gender",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Identity",
+          "name": "zoneInfo",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Identity",
+          "name": "locale",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Identity",
+          "name": "id",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "primaryKey": true,
+          "defaultValue": {
+            "useZeroValue": true
+          }
+        },
+        {
+          "modelName": "Identity",
+          "name": "createdAt",
+          "type": {
+            "type": "TYPE_DATETIME"
+          },
+          "defaultValue": {
+            "useZeroValue": true
+          }
+        },
+        {
+          "modelName": "Identity",
+          "name": "updatedAt",
+          "type": {
+            "type": "TYPE_DATETIME"
+          },
+          "defaultValue": {
+            "useZeroValue": true
+          }
+        }
+      ],
+      "actions": [
+        {
+          "modelName": "Identity",
+          "name": "requestPasswordReset",
+          "type": "ACTION_TYPE_WRITE",
+          "implementation": "ACTION_IMPLEMENTATION_RUNTIME",
+          "inputMessageName": "RequestPasswordResetInput",
+          "responseMessageName": "RequestPasswordResetResponse"
+        },
+        {
+          "modelName": "Identity",
+          "name": "resetPassword",
+          "type": "ACTION_TYPE_WRITE",
+          "implementation": "ACTION_IMPLEMENTATION_RUNTIME",
+          "inputMessageName": "ResetPasswordInput",
+          "responseMessageName": "ResetPasswordResponse"
+        }
+      ]
+    }
+  ],
+  "apis": [
+    {
+      "name": "Api",
+      "apiModels": [
+        {
+          "modelName": "People"
+        },
+        {
+          "modelName": "Groups",
+          "modelActions": [
+            {
+              "actionName": "testAction"
+            },
+            {
+              "actionName": "testUpdateAction"
+            }
+          ]
+        },
+        {
+          "modelName": "Identity",
+          "modelActions": [
+            {
+              "actionName": "requestPasswordReset"
+            },
+            {
+              "actionName": "resetPassword"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "messages": [
+    {
+      "name": "Any"
+    },
+    {
+      "name": "UpdateGroupResponse",
+      "fields": [
+        {
+          "messageName": "UpdateGroupResponse",
+          "name": "status",
+          "type": {
+            "type": "TYPE_STRING"
+          }
+        }
+      ]
+    },
+    {
+      "name": "RequestPasswordResetInput",
+      "fields": [
+        {
+          "messageName": "RequestPasswordResetInput",
+          "name": "email",
+          "type": {
+            "type": "TYPE_STRING"
+          }
+        },
+        {
+          "messageName": "RequestPasswordResetInput",
+          "name": "redirectUrl",
+          "type": {
+            "type": "TYPE_STRING"
+          }
+        }
+      ]
+    },
+    {
+      "name": "RequestPasswordResetResponse"
+    },
+    {
+      "name": "ResetPasswordInput",
+      "fields": [
+        {
+          "messageName": "ResetPasswordInput",
+          "name": "token",
+          "type": {
+            "type": "TYPE_STRING"
+          }
+        },
+        {
+          "messageName": "ResetPasswordInput",
+          "name": "password",
+          "type": {
+            "type": "TYPE_STRING"
+          }
+        }
+      ]
+    },
+    {
+      "name": "ResetPasswordResponse"
+    },
+    {
+      "name": "TestActionInput",
+      "fields": [
+        {
+          "messageName": "TestActionInput",
+          "name": "id",
+          "type": {
+            "type": "TYPE_ID",
+            "modelName": "Groups",
+            "fieldName": "id"
+          },
+          "target": [
+            "id"
+          ]
+        },
+        {
+          "messageName": "TestActionInput",
+          "name": "name",
+          "type": {
+            "type": "TYPE_STRING",
+            "modelName": "Groups",
+            "fieldName": "name"
+          },
+          "optional": true,
+          "target": [
+            "name"
+          ]
+        },
+        {
+          "messageName": "TestActionInput",
+          "name": "nullText",
+          "type": {
+            "type": "TYPE_STRING",
+            "modelName": "Groups",
+            "fieldName": "nullText"
+          },
+          "optional": true,
+          "nullable": true,
+          "target": [
+            "nullText"
+          ]
+        },
+        {
+          "messageName": "TestActionInput",
+          "name": "people",
+          "type": {
+            "type": "TYPE_MESSAGE",
+            "messageName": "TestActionPeopleInput"
+          },
+          "optional": true,
+          "nullable": true
+        }
+      ]
+    },
+    {
+      "name": "TestActionPeopleInput",
+      "fields": [
+        {
+          "messageName": "TestActionPeopleInput",
+          "name": "id",
+          "type": {
+            "type": "TYPE_ID",
+            "modelName": "People",
+            "fieldName": "id"
+          },
+          "optional": true,
+          "target": [
+            "people",
+            "id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "TestUpdateActionWhere",
+      "fields": [
+        {
+          "messageName": "TestUpdateActionWhere",
+          "name": "id",
+          "type": {
+            "type": "TYPE_ID",
+            "modelName": "Groups",
+            "fieldName": "id"
+          },
+          "target": [
+            "id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "TestUpdateActionValues",
+      "fields": [
+        {
+          "messageName": "TestUpdateActionValues",
+          "name": "name",
+          "type": {
+            "type": "TYPE_STRING",
+            "modelName": "Groups",
+            "fieldName": "name"
+          },
+          "optional": true,
+          "target": [
+            "name"
+          ]
+        },
+        {
+          "messageName": "TestUpdateActionValues",
+          "name": "nullText",
+          "type": {
+            "type": "TYPE_STRING",
+            "modelName": "Groups",
+            "fieldName": "nullText"
+          },
+          "optional": true,
+          "nullable": true,
+          "target": [
+            "nullText"
+          ]
+        },
+        {
+          "messageName": "TestUpdateActionValues",
+          "name": "people",
+          "type": {
+            "type": "TYPE_MESSAGE",
+            "messageName": "TestUpdateActionPeopleInput"
+          },
+          "optional": true,
+          "nullable": true
+        }
+      ]
+    },
+    {
+      "name": "TestUpdateActionPeopleInput",
+      "fields": [
+        {
+          "messageName": "TestUpdateActionPeopleInput",
+          "name": "id",
+          "type": {
+            "type": "TYPE_ID",
+            "modelName": "People",
+            "fieldName": "id"
+          },
+          "optional": true,
+          "target": [
+            "people",
+            "id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "TestUpdateActionInput",
+      "fields": [
+        {
+          "messageName": "TestUpdateActionInput",
+          "name": "where",
+          "type": {
+            "type": "TYPE_MESSAGE",
+            "messageName": "TestUpdateActionWhere"
+          }
+        },
+        {
+          "messageName": "TestUpdateActionInput",
+          "name": "values",
+          "type": {
+            "type": "TYPE_MESSAGE",
+            "messageName": "TestUpdateActionValues"
+          },
+          "optional": true
+        }
+      ]
+    }
+  ]
+}

--- a/schema/testdata/proto/arbitrary_function_optional_inputs/schema.keel
+++ b/schema/testdata/proto/arbitrary_function_optional_inputs/schema.keel
@@ -1,0 +1,24 @@
+model People {
+    fields {
+        name Text
+    }
+}
+
+model Groups {
+    fields {
+        people People?
+        name Text
+        nullText Text?
+    }
+
+    actions {
+        write testAction(id, name?, nullText?, people.id?) returns (
+            UpdateGroupResponse
+        )
+        update testUpdateAction(id) with (name?, nullText?, people.id?)
+    }
+}
+
+message UpdateGroupResponse {
+    status Text
+}


### PR DESCRIPTION
When creating write messages with inline fields; e.g.:
```
// keel schema
write testAction(id, name?, relation.id?) returns (SomeResponse)
```
 we should create hierarchical input messages for any models field (`relation.id`) e.g.:
 
 ```
// json schema
 {
  "type": "object",
  "properties": {
    "id": { "type": "string" },
    "name": { "type": "string" },
    "relation": { "$ref": "#/components/schemas/TestActionRelationInput" }
  },
"components": {
    "schemas": {
      "TestActionRelationInput": {
        "type": ["object", "null"],
        "properties": { "id": { "type": "string" } },
        "additionalProperties": false
      }
    }
  }
```
 
 