### PR TITLE
fix: functions database connection limit and retries

### DIFF
--- a/packages/functions-runtime/src/database.js
+++ b/packages/functions-runtime/src/database.js
@@ -186,8 +186,6 @@ function getDialect() {
       const pool = new InstrumentedNeonServerlessPool({
         connectionString: mustEnv("KEEL_DB_CONN"),
         max: 1, // Limit to 1 connection per Lambda instance
-        retryInterval: 1000, // Retry every second
-        maxRetries: 3, // Maximum number of retries
       });
 
       pool.on("connect", (client) => {

--- a/packages/functions-runtime/src/database.js
+++ b/packages/functions-runtime/src/database.js
@@ -185,6 +185,9 @@ function getDialect() {
 
       const pool = new InstrumentedNeonServerlessPool({
         connectionString: mustEnv("KEEL_DB_CONN"),
+        max: 1, // Limit to 1 connection per Lambda instance
+        retryInterval: 1000, // Retry every second
+        maxRetries: 3, // Maximum number of retries
       });
 
       pool.on("connect", (client) => {


### PR DESCRIPTION
Limiting the number of connections in the functions runtime to 1.  Furthermore, configuring 3 retries with an interval of 1s.