### PR TITLE
fix: updates to left join on relationships

### DIFF
--- a/runtime/actions/query.go
+++ b/runtime/actions/query.go
@@ -969,12 +969,7 @@ func (query *QueryBuilder) UpdateStatement(ctx context.Context) *Statement {
 	//var from string
 	if len(query.joins) > 0 {
 		for _, j := range query.joins {
-			//if i == 0 {
-			//	from = fmt.Sprintf("FROM %s AS %s", j.table, j.alias)
-			//	queryFilters = append([]string{j.condition, "AND"}, queryFilters...)
-			//} else {
 			joins += fmt.Sprintf("%s JOIN %s AS %s ON %s ", query.joinType, j.table, j.alias, j.condition)
-			//}
 		}
 	}
 

--- a/runtime/actions/query.go
+++ b/runtime/actions/query.go
@@ -966,7 +966,6 @@ func (query *QueryBuilder) UpdateStatement(ctx context.Context) *Statement {
 
 	args = append(args, query.args...)
 
-	//var from string
 	if len(query.joins) > 0 {
 		for _, j := range query.joins {
 			joins += fmt.Sprintf("%s JOIN %s AS %s ON %s ", query.joinType, j.table, j.alias, j.condition)

--- a/runtime/actions/query.go
+++ b/runtime/actions/query.go
@@ -966,15 +966,15 @@ func (query *QueryBuilder) UpdateStatement(ctx context.Context) *Statement {
 
 	args = append(args, query.args...)
 
-	var from string
+	//var from string
 	if len(query.joins) > 0 {
-		for i, j := range query.joins {
-			if i == 0 {
-				from = fmt.Sprintf("FROM %s AS %s", j.table, j.alias)
-				queryFilters = append([]string{j.condition, "AND"}, queryFilters...)
-			} else {
-				joins += fmt.Sprintf("%s JOIN %s AS %s ON %s ", query.joinType, j.table, j.alias, j.condition)
-			}
+		for _, j := range query.joins {
+			//if i == 0 {
+			//	from = fmt.Sprintf("FROM %s AS %s", j.table, j.alias)
+			//	queryFilters = append([]string{j.condition, "AND"}, queryFilters...)
+			//} else {
+			joins += fmt.Sprintf("%s JOIN %s AS %s ON %s ", query.joinType, j.table, j.alias, j.condition)
+			//}
 		}
 	}
 
@@ -1004,14 +1004,25 @@ func (query *QueryBuilder) UpdateStatement(ctx context.Context) *Statement {
 		commonTableExpressions = fmt.Sprintf("WITH %s", strings.Join(ctes, ", "))
 	}
 
-	template := fmt.Sprintf("%s UPDATE %s SET %s %s %s %s %s",
-		commonTableExpressions,
-		sqlQuote(query.table),
-		strings.Join(sets, ", "),
-		from,
-		joins,
-		filters,
-		returning)
+	var template string
+	if len(query.joins) == 0 {
+		template = fmt.Sprintf("%s UPDATE %s SET %s %s %s",
+			commonTableExpressions,
+			sqlQuote(query.table),
+			strings.Join(sets, ", "),
+			filters,
+			returning)
+	} else {
+		template = fmt.Sprintf("%s UPDATE %s SET %s WHERE \"id\" = (SELECT %s.\"id\" FROM %s %s %s) %s",
+			commonTableExpressions,
+			sqlQuote(query.table),
+			strings.Join(sets, ", "),
+			sqlQuote(query.table),
+			sqlQuote(query.table),
+			joins,
+			filters,
+			returning)
+	}
 
 	return &Statement{
 		template: template,

--- a/runtime/actions/query_test.go
+++ b/runtime/actions/query_test.go
@@ -2561,11 +2561,11 @@ var testCases = []testCase{
 		expectedTemplate: `
 			UPDATE "product"
 			SET is_active = ?
-			FROM "brand" AS "product$brand"
-			WHERE
-				"product$brand"."id" = "product"."brand_id" AND
-				"product"."product_code" IS NOT DISTINCT FROM ? AND
-				"product$brand"."code" IS NOT DISTINCT FROM ?
+			WHERE "id" = (
+				SELECT "product"."id" 
+				FROM "product" 
+				LEFT JOIN "brand" AS "product$brand" ON "product$brand"."id" = "product"."brand_id" 
+				WHERE "product"."product_code" IS NOT DISTINCT FROM ? AND "product$brand"."code" IS NOT DISTINCT FROM ?) 
 			RETURNING "product".*`,
 		expectedArgs: []any{false, "prodcode", "brand"},
 	},
@@ -2611,14 +2611,16 @@ var testCases = []testCase{
 		expectedTemplate: `
 			UPDATE "product"
 			SET is_active = ?
-			FROM "brand" AS "product$brand"
-			LEFT JOIN "supplier" AS "product$supplier" ON "product$supplier"."id" = "product"."supplier_id"
-			WHERE
-				"product$brand"."id" = "product"."brand_id" AND
-				"product"."product_code" IS NOT DISTINCT FROM ? AND
-				"product$brand"."code" IS NOT DISTINCT FROM ? AND
-				"product"."is_active" IS NOT DISTINCT FROM ? AND
-				"product$supplier"."is_registered" IS NOT DISTINCT FROM ?
+			WHERE "id" = (
+				SELECT "product"."id" 
+				FROM "product" 
+				LEFT JOIN "brand" AS "product$brand" ON "product$brand"."id" = "product"."brand_id" 
+				LEFT JOIN "supplier" AS "product$supplier" ON "product$supplier"."id" = "product"."supplier_id" 
+				WHERE 
+					"product"."product_code" IS NOT DISTINCT FROM ? AND 
+					"product$brand"."code" IS NOT DISTINCT FROM ? AND 
+					"product"."is_active" IS NOT DISTINCT FROM ? AND 
+					"product$supplier"."is_registered" IS NOT DISTINCT FROM ?)
 			RETURNING "product".*`,
 		expectedArgs: []any{false, "prodcode", "brand", true, true},
 	},


### PR DESCRIPTION
When performing an `update` which requires checking conditions on related tables, we need to ensure that we are left joining on those tables.  The reason for this is because if there is no relationship present, then we don't want the row to be omitted.

However, we have been using `FROM` in our update statements.  When relationships are involved, will are now using sub-queries.  This is cleared to understand and fixes the issue.  

Except from Postgres docs: 

> When a FROM clause is present, what essentially happens is that the target table is joined to the tables mentioned in the from_item list, and each output row of the join represents an update operation for the target table. When using FROM you should ensure that the join produces at most one output row for each row to be modified. In other words, a target row shouldn’t join to more than one row from the other table(s). If it does, then only one of the join rows will be used to update the target row, but which one will be used is not readily predictable.
> Because of this indeterminacy, referencing other tables only within sub-selects is safer, though often harder to read and slower than using a join.