### PR TITLE
fix: sort direction type resolution

### DIFF
--- a/node/codegen.go
+++ b/node/codegen.go
@@ -440,7 +440,7 @@ func writeFindManyParamsInterface(w *codegen.Writer, model *proto.Model) {
 	})
 
 	for i, f := range relevantFields {
-		w.Writef("%s?: SortDirection", f.Name)
+		w.Writef("%s?: runtime.SortDirection", f.Name)
 
 		if i < len(relevantFields)-1 {
 			w.Write(",")
@@ -1721,11 +1721,7 @@ func toTypeScriptType(t *proto.TypeInfo, includeCompatibleTypes bool, isTestingP
 			ret = t.ModelName.Value
 		}
 	case proto.Type_TYPE_SORT_DIRECTION:
-		if isTestingPackage {
-			ret = "sdk.SortDirection"
-		} else {
-			ret = "SortDirection"
-		}
+		ret = "runtime.SortDirection"
 	case proto.Type_TYPE_UNION:
 		// Retrieve all the types that can satisfy this union field.
 		messageNames := lo.Map(t.UnionNames, func(s *wrapperspb.StringValue, _ int) string {

--- a/node/codegen.go
+++ b/node/codegen.go
@@ -1721,7 +1721,11 @@ func toTypeScriptType(t *proto.TypeInfo, includeCompatibleTypes bool, isTestingP
 			ret = t.ModelName.Value
 		}
 	case proto.Type_TYPE_SORT_DIRECTION:
-		ret = "runtime.SortDirection"
+		if isClientPackage {
+			ret = "SortDirection"
+		} else {
+			ret = "runtime.SortDirection"
+		}
 	case proto.Type_TYPE_UNION:
 		// Retrieve all the types that can satisfy this union field.
 		messageNames := lo.Map(t.UnionNames, func(s *wrapperspb.StringValue, _ int) string {

--- a/node/codegen_test.go
+++ b/node/codegen_test.go
@@ -309,15 +309,15 @@ func TestModelAPIFindManyDeclaration(t *testing.T) {
 	t.Parallel()
 	expected := `
 export type PersonOrderBy = {
-	firstName?: SortDirection,
-	lastName?: SortDirection,
-	age?: SortDirection,
-	dateOfBirth?: SortDirection,
-	gender?: SortDirection,
-	hasChildren?: SortDirection,
-	id?: SortDirection,
-	createdAt?: SortDirection,
-	updatedAt?: SortDirection
+	firstName?: runtime.SortDirection,
+	lastName?: runtime.SortDirection,
+	age?: runtime.SortDirection,
+	dateOfBirth?: runtime.SortDirection,
+	gender?: runtime.SortDirection,
+	hasChildren?: runtime.SortDirection,
+	id?: runtime.SortDirection,
+	createdAt?: runtime.SortDirection,
+	updatedAt?: runtime.SortDirection
 }
 
 export interface PersonFindManyParams {
@@ -1272,10 +1272,10 @@ export interface ListPeopleWhere {
 	favouriteSport: SportQueryInput;
 }
 export interface ListPeopleOrderByName {
-	name: SortDirection;
+	name: runtime.SortDirection;
 }
 export interface ListPeopleOrderByFavouriteSport {
-	favouriteSport: SortDirection;
+	favouriteSport: runtime.SortDirection;
 }
 export interface ListPeopleInput {
 	where: ListPeopleWhere;


### PR DESCRIPTION
The `SortDirection` type from the functions runtime was not being referenced correctly.