### PR TITLE
fix: files url in jsonschema, removed public field from graphql, minor refactoring

### DIFF
--- a/integration/testdata/files/tests.test.ts
+++ b/integration/testdata/files/tests.test.ts
@@ -15,7 +15,7 @@ beforeEach(resetDatabase);
 
 test("files - create action with file input", async () => {
   const fileContents = "hello";
-  const dataUrl = `data:application/text;name=my-file.txt;base64,${Buffer.from(
+  const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
     fileContents
   ).toString("base64")}`;
 
@@ -23,7 +23,7 @@ test("files - create action with file input", async () => {
     file: InlineFile.fromDataURL(dataUrl),
   });
 
-  expect(result.file?.contentType).toEqual("application/text");
+  expect(result.file?.contentType).toEqual("text/plain");
   expect(result.file?.filename).toEqual("my-file.txt");
   expect(result.file?.size).toEqual(5);
 
@@ -49,376 +49,376 @@ test("files - create action with file input", async () => {
   expect(contents).toEqual("hello");
 });
 
-test("files - update action with file input", async () => {
-  const fileContents = "hello";
-  const dataUrl = `data:application/text;name=my-file.txt;base64,${Buffer.from(
-    fileContents
-  ).toString("base64")}`;
-
-  const result = await actions.createFile({
-    file: InlineFile.fromDataURL(dataUrl),
-  });
-
-  const fileContents2 = "hello again";
-  const dataUrl2 = `data:application/text;name=my-second-file.txt;base64,${Buffer.from(
-    fileContents2
-  ).toString("base64")}`;
-
-  const updated = await actions.updateFile({
-    where: {
-      id: result.id,
-    },
-    values: {
-      file: InlineFile.fromDataURL(dataUrl2),
-    },
-  });
-
-  expect(updated.file?.contentType).toEqual("application/text");
-  expect(updated.file?.filename).toEqual("my-second-file.txt");
-  expect(updated.file?.size).toEqual(11);
-
-  const contents1 = await updated.file?.read();
-  expect(contents1?.toString("utf-8")).toEqual("hello again");
-
-  const myfiles = await useDatabase()
-    .selectFrom("my_file")
-    .selectAll()
-    .execute();
-
-  const files =
-    await sql<DbFile>`SELECT * FROM keel_storage ORDER BY created_at DESC`.execute(
-      useDatabase()
-    );
-
-  expect(myfiles.length).toEqual(1);
-  expect(files.rows.length).toEqual(2);
-  expect(files.rows[0].id).toEqual(myfiles[0].file?.key);
-  expect(files.rows[0].filename).toEqual(myfiles[0].file?.filename);
-  expect(files.rows[0].contentType).toEqual(myfiles[0].file?.contentType);
-
-  const contents = files.rows[0].data.toString("utf-8");
-  expect(contents).toEqual("hello again");
-});
-
-test("files - update action with file input and empty hooks", async () => {
-  const fileContents = "hello";
-  const dataUrl = `data:application/text;name=my-file.txt;base64,${Buffer.from(
-    fileContents
-  ).toString("base64")}`;
-
-  const result = await actions.createFile({
-    file: InlineFile.fromDataURL(dataUrl),
-  });
-
-  const fileContents2 = "hello again";
-  const dataUrl2 = `data:application/text;name=my-second-file.txt;base64,${Buffer.from(
-    fileContents2
-  ).toString("base64")}`;
-
-  const updated = await actions.updateFileEmptyHooks({
-    where: {
-      id: result.id,
-    },
-    values: {
-      file: InlineFile.fromDataURL(dataUrl2),
-    },
-  });
-
-  expect(updated.file?.contentType).toEqual("application/text");
-  expect(updated.file?.filename).toEqual("my-second-file.txt");
-  expect(updated.file?.size).toEqual(11);
-
-  const contents1 = await updated.file?.read();
-  expect(contents1?.toString("utf-8")).toEqual("hello again");
-
-  const myfiles = await useDatabase()
-    .selectFrom("my_file")
-    .selectAll()
-    .execute();
-
-  const files =
-    await sql<DbFile>`SELECT * FROM keel_storage ORDER BY created_at DESC`.execute(
-      useDatabase()
-    );
-
-  expect(myfiles.length).toEqual(1);
-  expect(files.rows.length).toEqual(2);
-  expect(files.rows[0].id).toEqual(myfiles[0].file?.key);
-  expect(files.rows[0].filename).toEqual(myfiles[0].file?.filename);
-  expect(files.rows[0].contentType).toEqual(myfiles[0].file?.contentType);
-
-  const contents = files.rows[0].data.toString("utf-8");
-  expect(contents).toEqual("hello again");
-});
-
-test("files - get action", async () => {
-  const fileContents = "hello";
-  const dataUrl = `data:application/text;name=my-file.txt;base64,${Buffer.from(
-    fileContents
-  ).toString("base64")}`;
-
-  const created = await actions.createFile({
-    file: InlineFile.fromDataURL(dataUrl),
-  });
-
-  const result = await actions.getFile({
-    id: created.id,
-  });
-
-  expect(result?.file?.contentType).toEqual("application/text");
-  expect(result?.file?.filename).toEqual("my-file.txt");
-  expect(result?.file?.size).toEqual(5);
-
-  const contents1 = await result?.file?.read();
-  expect(contents1?.toString("utf-8")).toEqual("hello");
-});
-
-test("files - list action", async () => {
-  const fileContents = "hello";
-  const dataUrl = `data:application/text;name=my-file.txt;base64,${Buffer.from(
-    fileContents
-  ).toString("base64")}`;
-
-  await actions.createFile({
-    file: InlineFile.fromDataURL(dataUrl),
-  });
-
-  const fileContents2 = "hello again";
-  const dataUrl2 = `data:application/text;name=my-file.txt;base64,${Buffer.from(
-    fileContents2
-  ).toString("base64")}`;
-
-  await actions.createFile({
-    file: InlineFile.fromDataURL(dataUrl2),
-  });
-
-  const result = await actions.listFiles({});
-
-  expect(result.results[0].file?.contentType).toEqual("application/text");
-  expect(result.results[0].file?.filename).toEqual("my-file.txt");
-  expect(result.results[0].file?.size).toEqual(5);
-
-  const contents1 = await result.results[0].file?.read();
-  expect(contents1?.toString("utf-8")).toEqual("hello");
-
-  expect(result.results[1].file?.contentType).toEqual("application/text");
-  expect(result.results[1].file?.filename).toEqual("my-file.txt");
-  expect(result.results[1].file?.size).toEqual(11);
-
-  const contents2 = await result.results[1].file?.read();
-  expect(contents2?.toString("utf-8")).toEqual("hello again");
-});
-
-test("files - get action empty hooks", async () => {
-  const fileContents = "hello";
-  const dataUrl = `data:application/text;name=my-file.txt;base64,${Buffer.from(
-    fileContents
-  ).toString("base64")}`;
-
-  const created = await actions.createFile({
-    file: InlineFile.fromDataURL(dataUrl),
-  });
-
-  const result = await actions.getFileEmptyHooks({
-    id: created.id,
-  });
-
-  expect(result?.file?.contentType).toEqual("application/text");
-  expect(result?.file?.filename).toEqual("my-file.txt");
-  expect(result?.file?.size).toEqual(5);
-
-  const contents1 = await result?.file?.read();
-  expect(contents1?.toString("utf-8")).toEqual("hello");
-});
-
-test("files - list action empty hooks", async () => {
-  const fileContents = "hello";
-  const dataUrl = `data:application/text;name=my-file.txt;base64,${Buffer.from(
-    fileContents
-  ).toString("base64")}`;
-
-  await actions.createFile({
-    file: InlineFile.fromDataURL(dataUrl),
-  });
-
-  const result = await actions.listFilesEmptyHooks({});
-
-  expect(result.results[0].file?.contentType).toEqual("application/text");
-  expect(result.results[0].file?.filename).toEqual("my-file.txt");
-  expect(result.results[0].file?.size).toEqual(5);
-
-  const contents = await result.results[0].file?.read();
-  expect(contents?.toString("utf-8")).toEqual("hello");
-});
-
-test("files - create file in hook", async () => {
-  await actions.createFileInHook({});
-
-  const myfiles = await useDatabase()
-    .selectFrom("my_file")
-    .selectAll()
-    .execute();
-
-  const files =
-    await sql<DbFile>`SELECT * FROM keel_storage ORDER BY created_at DESC`.execute(
-      useDatabase()
-    );
-
-  expect(myfiles.length).toEqual(1);
-  expect(files.rows.length).toEqual(1);
-  expect(files.rows[0].id).toEqual(myfiles[0].file?.key);
-  expect(files.rows[0].filename).toEqual(myfiles[0].file?.filename);
-  expect(files.rows[0].contentType).toEqual(myfiles[0].file?.contentType);
-
-  const contents = files.rows[0].data.toString("utf-8");
-  expect(contents).toEqual("created in hook!");
-});
-
-test("files - create and store file in hook", async () => {
-  await actions.createFileAndStoreInHook({});
-
-  const myfiles = await useDatabase()
-    .selectFrom("my_file")
-    .selectAll()
-    .execute();
-
-  const files =
-    await sql<DbFile>`SELECT * FROM keel_storage ORDER BY created_at DESC`.execute(
-      useDatabase()
-    );
-
-  expect(myfiles.length).toEqual(1);
-  expect(files.rows.length).toEqual(1);
-  expect(files.rows[0].id).toEqual(myfiles[0].file?.key);
-  expect(files.rows[0].filename).toEqual(myfiles[0].file?.filename);
-  expect(files.rows[0].contentType).toEqual(myfiles[0].file?.contentType);
-
-  const contents = files.rows[0].data.toString("utf-8");
-  expect(contents).toEqual("created and stored in hook!");
-});
-
-test("files - read and store in query hook", async () => {
-  const fileContents = "1";
-  const dataUrl = `data:application/text;name=my-file.txt;base64,${Buffer.from(
-    fileContents
-  ).toString("base64")}`;
-
-  const result = await actions.createFile({
-    file: InlineFile.fromDataURL(dataUrl),
-  });
-
-  await actions.getFileNumerateContents({ id: result.id });
-  await actions.getFileNumerateContents({ id: result.id });
-  await actions.getFileNumerateContents({ id: result.id });
-
-  const myfiles = await useDatabase()
-    .selectFrom("my_file")
-    .selectAll()
-    .execute();
-
-  const files =
-    await sql<DbFile>`SELECT * FROM keel_storage ORDER BY created_at DESC`.execute(
-      useDatabase()
-    );
-
-  expect(myfiles.length).toEqual(1);
-  expect(files.rows.length).toEqual(1);
-  expect(files.rows[0].id).toEqual(myfiles[0].file?.key);
-  expect(files.rows[0].filename).toEqual(myfiles[0].file?.filename);
-  expect(files.rows[0].contentType).toEqual(myfiles[0].file?.contentType);
-
-  const contents = files.rows[0].data.toString("utf-8");
-  expect(contents).toEqual("4");
-});
-
-test("files - write many, store many", async () => {
-  const fileContents = "hello";
-  const dataUrl = `data:application/text;name=my-file.txt;base64,${Buffer.from(
-    fileContents
-  ).toString("base64")}`;
-
-  const result = await actions.writeMany({
-    msg: { file: InlineFile.fromDataURL(dataUrl) },
-  });
-
-  expect(result.msg.file.contentType).toEqual("application/text");
-  expect(result.msg.file.size).toEqual(5);
-  expect(result.msg.file.filename).toEqual("my-file.txt");
-
-  const contents = await result.msg.file.read();
-  expect(contents.toString("utf-8")).toEqual("hello");
-
-  const myfiles = await models.myFile.findMany({
-    orderBy: { createdAt: "desc" },
-  });
-
-  const keys = myfiles.map((a) => a.file!.key);
-  keys.push((result.msg.file as File).key);
-
-  const files =
-    await sql<DbFile>`SELECT * FROM keel_storage ORDER BY created_at DESC`.execute(
-      useDatabase()
-    );
-
-  const fileIds = files.rows.map((a) => a.id);
-
-  expect(myfiles.length).toEqual(3);
-  expect(files.rows.length).toEqual(4);
-  expect(keys.sort()).toEqual(fileIds.sort());
-});
-
-test("files - store once, write many", async () => {
-  const fileContents = "hello";
-  const dataUrl = `data:application/text;name=my-file.txt;base64,${Buffer.from(
-    fileContents
-  ).toString("base64")}`;
-
-  const result = await actions.storeAndWriteMany({
-    file: InlineFile.fromDataURL(dataUrl),
-  });
-
-  expect(result.msg.file.contentType).toEqual("application/text");
-  expect(result.msg.file.size).toEqual(5);
-  expect(result.msg.file.filename).toEqual("my-file.txt");
-
-  const contents = await result.msg.file.read();
-  expect(contents.toString("utf-8")).toEqual("hello");
-
-  const myfiles = await useDatabase()
-    .selectFrom("my_file")
-    .selectAll()
-    .execute();
-
-  const files =
-    await sql<DbFile>`SELECT * FROM keel_storage ORDER BY created_at DESC`.execute(
-      useDatabase()
-    );
-
-  expect(myfiles.length).toEqual(3);
-  expect(files.rows.length).toEqual(1);
-  expect(myfiles[0].file?.key).toEqual(files.rows[0].id);
-  expect(myfiles[1].file?.key).toEqual(files.rows[0].id);
-  expect(myfiles[2].file?.key).toEqual(files.rows[0].id);
-  expect((result.msg.file as File).key).toEqual(files.rows[0].id);
-});
-
-test("files - model API file tests", async () => {
-  await expect(actions.modelApiTests({})).not.toHaveError({});
-});
-
-test("files - kysely file tests", async () => {
-  await expect(actions.kyselyTests({})).not.toHaveError({});
-});
-
-test("files - presigned url", async () => {
-  const fileContents = "hello";
-  const dataUrl = `data:application/text;name=my-file.txt;base64,${Buffer.from(
-    fileContents
-  ).toString("base64")}`;
-
-  const result = await actions.presignedUrl({
-    file: InlineFile.fromDataURL(dataUrl),
-  });
-
-  expect(result).toEqual(dataUrl);
-});
+// test("files - update action with file input", async () => {
+//   const fileContents = "hello";
+//   const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
+//     fileContents
+//   ).toString("base64")}`;
+
+//   const result = await actions.createFile({
+//     file: InlineFile.fromDataURL(dataUrl),
+//   });
+
+//   const fileContents2 = "hello again";
+//   const dataUrl2 = `data:text/plain;name=my-second-file.txt;base64,${Buffer.from(
+//     fileContents2
+//   ).toString("base64")}`;
+
+//   const updated = await actions.updateFile({
+//     where: {
+//       id: result.id,
+//     },
+//     values: {
+//       file: InlineFile.fromDataURL(dataUrl2),
+//     },
+//   });
+
+//   expect(updated.file?.contentType).toEqual("text/plain");
+//   expect(updated.file?.filename).toEqual("my-second-file.txt");
+//   expect(updated.file?.size).toEqual(11);
+
+//   const contents1 = await updated.file?.read();
+//   expect(contents1?.toString("utf-8")).toEqual("hello again");
+
+//   const myfiles = await useDatabase()
+//     .selectFrom("my_file")
+//     .selectAll()
+//     .execute();
+
+//   const files =
+//     await sql<DbFile>`SELECT * FROM keel_storage ORDER BY created_at DESC`.execute(
+//       useDatabase()
+//     );
+
+//   expect(myfiles.length).toEqual(1);
+//   expect(files.rows.length).toEqual(2);
+//   expect(files.rows[0].id).toEqual(myfiles[0].file?.key);
+//   expect(files.rows[0].filename).toEqual(myfiles[0].file?.filename);
+//   expect(files.rows[0].contentType).toEqual(myfiles[0].file?.contentType);
+
+//   const contents = files.rows[0].data.toString("utf-8");
+//   expect(contents).toEqual("hello again");
+// });
+
+// test("files - update action with file input and empty hooks", async () => {
+//   const fileContents = "hello";
+//   const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
+//     fileContents
+//   ).toString("base64")}`;
+
+//   const result = await actions.createFile({
+//     file: InlineFile.fromDataURL(dataUrl),
+//   });
+
+//   const fileContents2 = "hello again";
+//   const dataUrl2 = `data:text/plain;name=my-second-file.txt;base64,${Buffer.from(
+//     fileContents2
+//   ).toString("base64")}`;
+
+//   const updated = await actions.updateFileEmptyHooks({
+//     where: {
+//       id: result.id,
+//     },
+//     values: {
+//       file: InlineFile.fromDataURL(dataUrl2),
+//     },
+//   });
+
+//   expect(updated.file?.contentType).toEqual("text/plain");
+//   expect(updated.file?.filename).toEqual("my-second-file.txt");
+//   expect(updated.file?.size).toEqual(11);
+
+//   const contents1 = await updated.file?.read();
+//   expect(contents1?.toString("utf-8")).toEqual("hello again");
+
+//   const myfiles = await useDatabase()
+//     .selectFrom("my_file")
+//     .selectAll()
+//     .execute();
+
+//   const files =
+//     await sql<DbFile>`SELECT * FROM keel_storage ORDER BY created_at DESC`.execute(
+//       useDatabase()
+//     );
+
+//   expect(myfiles.length).toEqual(1);
+//   expect(files.rows.length).toEqual(2);
+//   expect(files.rows[0].id).toEqual(myfiles[0].file?.key);
+//   expect(files.rows[0].filename).toEqual(myfiles[0].file?.filename);
+//   expect(files.rows[0].contentType).toEqual(myfiles[0].file?.contentType);
+
+//   const contents = files.rows[0].data.toString("utf-8");
+//   expect(contents).toEqual("hello again");
+// });
+
+// test("files - get action", async () => {
+//   const fileContents = "hello";
+//   const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
+//     fileContents
+//   ).toString("base64")}`;
+
+//   const created = await actions.createFile({
+//     file: InlineFile.fromDataURL(dataUrl),
+//   });
+
+//   const result = await actions.getFile({
+//     id: created.id,
+//   });
+
+//   expect(result?.file?.contentType).toEqual("text/plain");
+//   expect(result?.file?.filename).toEqual("my-file.txt");
+//   expect(result?.file?.size).toEqual(5);
+
+//   const contents1 = await result?.file?.read();
+//   expect(contents1?.toString("utf-8")).toEqual("hello");
+// });
+
+// test("files - list action", async () => {
+//   const fileContents = "hello";
+//   const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
+//     fileContents
+//   ).toString("base64")}`;
+
+//   await actions.createFile({
+//     file: InlineFile.fromDataURL(dataUrl),
+//   });
+
+//   const fileContents2 = "hello again";
+//   const dataUrl2 = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
+//     fileContents2
+//   ).toString("base64")}`;
+
+//   await actions.createFile({
+//     file: InlineFile.fromDataURL(dataUrl2),
+//   });
+
+//   const result = await actions.listFiles({});
+
+//   expect(result.results[0].file?.contentType).toEqual("text/plain");
+//   expect(result.results[0].file?.filename).toEqual("my-file.txt");
+//   expect(result.results[0].file?.size).toEqual(5);
+
+//   const contents1 = await result.results[0].file?.read();
+//   expect(contents1?.toString("utf-8")).toEqual("hello");
+
+//   expect(result.results[1].file?.contentType).toEqual("text/plain");
+//   expect(result.results[1].file?.filename).toEqual("my-file.txt");
+//   expect(result.results[1].file?.size).toEqual(11);
+
+//   const contents2 = await result.results[1].file?.read();
+//   expect(contents2?.toString("utf-8")).toEqual("hello again");
+// });
+
+// test("files - get action empty hooks", async () => {
+//   const fileContents = "hello";
+//   const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
+//     fileContents
+//   ).toString("base64")}`;
+
+//   const created = await actions.createFile({
+//     file: InlineFile.fromDataURL(dataUrl),
+//   });
+
+//   const result = await actions.getFileEmptyHooks({
+//     id: created.id,
+//   });
+
+//   expect(result?.file?.contentType).toEqual("text/plain");
+//   expect(result?.file?.filename).toEqual("my-file.txt");
+//   expect(result?.file?.size).toEqual(5);
+
+//   const contents1 = await result?.file?.read();
+//   expect(contents1?.toString("utf-8")).toEqual("hello");
+// });
+
+// test("files - list action empty hooks", async () => {
+//   const fileContents = "hello";
+//   const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
+//     fileContents
+//   ).toString("base64")}`;
+
+//   await actions.createFile({
+//     file: InlineFile.fromDataURL(dataUrl),
+//   });
+
+//   const result = await actions.listFilesEmptyHooks({});
+
+//   expect(result.results[0].file?.contentType).toEqual("text/plain");
+//   expect(result.results[0].file?.filename).toEqual("my-file.txt");
+//   expect(result.results[0].file?.size).toEqual(5);
+
+//   const contents = await result.results[0].file?.read();
+//   expect(contents?.toString("utf-8")).toEqual("hello");
+// });
+
+// test("files - create file in hook", async () => {
+//   await actions.createFileInHook({});
+
+//   const myfiles = await useDatabase()
+//     .selectFrom("my_file")
+//     .selectAll()
+//     .execute();
+
+//   const files =
+//     await sql<DbFile>`SELECT * FROM keel_storage ORDER BY created_at DESC`.execute(
+//       useDatabase()
+//     );
+
+//   expect(myfiles.length).toEqual(1);
+//   expect(files.rows.length).toEqual(1);
+//   expect(files.rows[0].id).toEqual(myfiles[0].file?.key);
+//   expect(files.rows[0].filename).toEqual(myfiles[0].file?.filename);
+//   expect(files.rows[0].contentType).toEqual(myfiles[0].file?.contentType);
+
+//   const contents = files.rows[0].data.toString("utf-8");
+//   expect(contents).toEqual("created in hook!");
+// });
+
+// test("files - create and store file in hook", async () => {
+//   await actions.createFileAndStoreInHook({});
+
+//   const myfiles = await useDatabase()
+//     .selectFrom("my_file")
+//     .selectAll()
+//     .execute();
+
+//   const files =
+//     await sql<DbFile>`SELECT * FROM keel_storage ORDER BY created_at DESC`.execute(
+//       useDatabase()
+//     );
+
+//   expect(myfiles.length).toEqual(1);
+//   expect(files.rows.length).toEqual(1);
+//   expect(files.rows[0].id).toEqual(myfiles[0].file?.key);
+//   expect(files.rows[0].filename).toEqual(myfiles[0].file?.filename);
+//   expect(files.rows[0].contentType).toEqual(myfiles[0].file?.contentType);
+
+//   const contents = files.rows[0].data.toString("utf-8");
+//   expect(contents).toEqual("created and stored in hook!");
+// });
+
+// test("files - read and store in query hook", async () => {
+//   const fileContents = "1";
+//   const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
+//     fileContents
+//   ).toString("base64")}`;
+
+//   const result = await actions.createFile({
+//     file: InlineFile.fromDataURL(dataUrl),
+//   });
+
+//   await actions.getFileNumerateContents({ id: result.id });
+//   await actions.getFileNumerateContents({ id: result.id });
+//   await actions.getFileNumerateContents({ id: result.id });
+
+//   const myfiles = await useDatabase()
+//     .selectFrom("my_file")
+//     .selectAll()
+//     .execute();
+
+//   const files =
+//     await sql<DbFile>`SELECT * FROM keel_storage ORDER BY created_at DESC`.execute(
+//       useDatabase()
+//     );
+
+//   expect(myfiles.length).toEqual(1);
+//   expect(files.rows.length).toEqual(1);
+//   expect(files.rows[0].id).toEqual(myfiles[0].file?.key);
+//   expect(files.rows[0].filename).toEqual(myfiles[0].file?.filename);
+//   expect(files.rows[0].contentType).toEqual(myfiles[0].file?.contentType);
+
+//   const contents = files.rows[0].data.toString("utf-8");
+//   expect(contents).toEqual("4");
+// });
+
+// test("files - write many, store many", async () => {
+//   const fileContents = "hello";
+//   const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
+//     fileContents
+//   ).toString("base64")}`;
+
+//   const result = await actions.writeMany({
+//     msg: { file: InlineFile.fromDataURL(dataUrl) },
+//   });
+
+//   expect(result.msg.file.contentType).toEqual("text/plain");
+//   expect(result.msg.file.size).toEqual(5);
+//   expect(result.msg.file.filename).toEqual("my-file.txt");
+
+//   const contents = await result.msg.file.read();
+//   expect(contents.toString("utf-8")).toEqual("hello");
+
+//   const myfiles = await models.myFile.findMany({
+//     orderBy: { createdAt: "desc" },
+//   });
+
+//   const keys = myfiles.map((a) => a.file!.key);
+//   keys.push((result.msg.file as File).key);
+
+//   const files =
+//     await sql<DbFile>`SELECT * FROM keel_storage ORDER BY created_at DESC`.execute(
+//       useDatabase()
+//     );
+
+//   const fileIds = files.rows.map((a) => a.id);
+
+//   expect(myfiles.length).toEqual(3);
+//   expect(files.rows.length).toEqual(4);
+//   expect(keys.sort()).toEqual(fileIds.sort());
+// });
+
+// test("files - store once, write many", async () => {
+//   const fileContents = "hello";
+//   const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
+//     fileContents
+//   ).toString("base64")}`;
+
+//   const result = await actions.storeAndWriteMany({
+//     file: InlineFile.fromDataURL(dataUrl),
+//   });
+
+//   expect(result.msg.file.contentType).toEqual("text/plain");
+//   expect(result.msg.file.size).toEqual(5);
+//   expect(result.msg.file.filename).toEqual("my-file.txt");
+
+//   const contents = await result.msg.file.read();
+//   expect(contents.toString("utf-8")).toEqual("hello");
+
+//   const myfiles = await useDatabase()
+//     .selectFrom("my_file")
+//     .selectAll()
+//     .execute();
+
+//   const files =
+//     await sql<DbFile>`SELECT * FROM keel_storage ORDER BY created_at DESC`.execute(
+//       useDatabase()
+//     );
+
+//   expect(myfiles.length).toEqual(3);
+//   expect(files.rows.length).toEqual(1);
+//   expect(myfiles[0].file?.key).toEqual(files.rows[0].id);
+//   expect(myfiles[1].file?.key).toEqual(files.rows[0].id);
+//   expect(myfiles[2].file?.key).toEqual(files.rows[0].id);
+//   expect((result.msg.file as File).key).toEqual(files.rows[0].id);
+// });
+
+// test("files - model API file tests", async () => {
+//   await expect(actions.modelApiTests({})).not.toHaveError({});
+// });
+
+// test("files - kysely file tests", async () => {
+//   await expect(actions.kyselyTests({})).not.toHaveError({});
+// });
+
+// test("files - presigned url", async () => {
+//   const fileContents = "hello";
+//   const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
+//     fileContents
+//   ).toString("base64")}`;
+
+//   const result = await actions.presignedUrl({
+//     file: InlineFile.fromDataURL(dataUrl),
+//   });
+
+//   expect(result).toEqual(dataUrl);
+// });

--- a/integration/testdata/files/tests.test.ts
+++ b/integration/testdata/files/tests.test.ts
@@ -49,376 +49,376 @@ test("files - create action with file input", async () => {
   expect(contents).toEqual("hello");
 });
 
-// test("files - update action with file input", async () => {
-//   const fileContents = "hello";
-//   const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
-//     fileContents
-//   ).toString("base64")}`;
-
-//   const result = await actions.createFile({
-//     file: InlineFile.fromDataURL(dataUrl),
-//   });
-
-//   const fileContents2 = "hello again";
-//   const dataUrl2 = `data:text/plain;name=my-second-file.txt;base64,${Buffer.from(
-//     fileContents2
-//   ).toString("base64")}`;
-
-//   const updated = await actions.updateFile({
-//     where: {
-//       id: result.id,
-//     },
-//     values: {
-//       file: InlineFile.fromDataURL(dataUrl2),
-//     },
-//   });
-
-//   expect(updated.file?.contentType).toEqual("text/plain");
-//   expect(updated.file?.filename).toEqual("my-second-file.txt");
-//   expect(updated.file?.size).toEqual(11);
-
-//   const contents1 = await updated.file?.read();
-//   expect(contents1?.toString("utf-8")).toEqual("hello again");
-
-//   const myfiles = await useDatabase()
-//     .selectFrom("my_file")
-//     .selectAll()
-//     .execute();
-
-//   const files =
-//     await sql<DbFile>`SELECT * FROM keel_storage ORDER BY created_at DESC`.execute(
-//       useDatabase()
-//     );
-
-//   expect(myfiles.length).toEqual(1);
-//   expect(files.rows.length).toEqual(2);
-//   expect(files.rows[0].id).toEqual(myfiles[0].file?.key);
-//   expect(files.rows[0].filename).toEqual(myfiles[0].file?.filename);
-//   expect(files.rows[0].contentType).toEqual(myfiles[0].file?.contentType);
-
-//   const contents = files.rows[0].data.toString("utf-8");
-//   expect(contents).toEqual("hello again");
-// });
-
-// test("files - update action with file input and empty hooks", async () => {
-//   const fileContents = "hello";
-//   const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
-//     fileContents
-//   ).toString("base64")}`;
-
-//   const result = await actions.createFile({
-//     file: InlineFile.fromDataURL(dataUrl),
-//   });
-
-//   const fileContents2 = "hello again";
-//   const dataUrl2 = `data:text/plain;name=my-second-file.txt;base64,${Buffer.from(
-//     fileContents2
-//   ).toString("base64")}`;
-
-//   const updated = await actions.updateFileEmptyHooks({
-//     where: {
-//       id: result.id,
-//     },
-//     values: {
-//       file: InlineFile.fromDataURL(dataUrl2),
-//     },
-//   });
-
-//   expect(updated.file?.contentType).toEqual("text/plain");
-//   expect(updated.file?.filename).toEqual("my-second-file.txt");
-//   expect(updated.file?.size).toEqual(11);
-
-//   const contents1 = await updated.file?.read();
-//   expect(contents1?.toString("utf-8")).toEqual("hello again");
-
-//   const myfiles = await useDatabase()
-//     .selectFrom("my_file")
-//     .selectAll()
-//     .execute();
-
-//   const files =
-//     await sql<DbFile>`SELECT * FROM keel_storage ORDER BY created_at DESC`.execute(
-//       useDatabase()
-//     );
-
-//   expect(myfiles.length).toEqual(1);
-//   expect(files.rows.length).toEqual(2);
-//   expect(files.rows[0].id).toEqual(myfiles[0].file?.key);
-//   expect(files.rows[0].filename).toEqual(myfiles[0].file?.filename);
-//   expect(files.rows[0].contentType).toEqual(myfiles[0].file?.contentType);
-
-//   const contents = files.rows[0].data.toString("utf-8");
-//   expect(contents).toEqual("hello again");
-// });
-
-// test("files - get action", async () => {
-//   const fileContents = "hello";
-//   const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
-//     fileContents
-//   ).toString("base64")}`;
-
-//   const created = await actions.createFile({
-//     file: InlineFile.fromDataURL(dataUrl),
-//   });
-
-//   const result = await actions.getFile({
-//     id: created.id,
-//   });
-
-//   expect(result?.file?.contentType).toEqual("text/plain");
-//   expect(result?.file?.filename).toEqual("my-file.txt");
-//   expect(result?.file?.size).toEqual(5);
-
-//   const contents1 = await result?.file?.read();
-//   expect(contents1?.toString("utf-8")).toEqual("hello");
-// });
-
-// test("files - list action", async () => {
-//   const fileContents = "hello";
-//   const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
-//     fileContents
-//   ).toString("base64")}`;
-
-//   await actions.createFile({
-//     file: InlineFile.fromDataURL(dataUrl),
-//   });
-
-//   const fileContents2 = "hello again";
-//   const dataUrl2 = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
-//     fileContents2
-//   ).toString("base64")}`;
-
-//   await actions.createFile({
-//     file: InlineFile.fromDataURL(dataUrl2),
-//   });
-
-//   const result = await actions.listFiles({});
-
-//   expect(result.results[0].file?.contentType).toEqual("text/plain");
-//   expect(result.results[0].file?.filename).toEqual("my-file.txt");
-//   expect(result.results[0].file?.size).toEqual(5);
-
-//   const contents1 = await result.results[0].file?.read();
-//   expect(contents1?.toString("utf-8")).toEqual("hello");
-
-//   expect(result.results[1].file?.contentType).toEqual("text/plain");
-//   expect(result.results[1].file?.filename).toEqual("my-file.txt");
-//   expect(result.results[1].file?.size).toEqual(11);
-
-//   const contents2 = await result.results[1].file?.read();
-//   expect(contents2?.toString("utf-8")).toEqual("hello again");
-// });
-
-// test("files - get action empty hooks", async () => {
-//   const fileContents = "hello";
-//   const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
-//     fileContents
-//   ).toString("base64")}`;
-
-//   const created = await actions.createFile({
-//     file: InlineFile.fromDataURL(dataUrl),
-//   });
-
-//   const result = await actions.getFileEmptyHooks({
-//     id: created.id,
-//   });
-
-//   expect(result?.file?.contentType).toEqual("text/plain");
-//   expect(result?.file?.filename).toEqual("my-file.txt");
-//   expect(result?.file?.size).toEqual(5);
-
-//   const contents1 = await result?.file?.read();
-//   expect(contents1?.toString("utf-8")).toEqual("hello");
-// });
-
-// test("files - list action empty hooks", async () => {
-//   const fileContents = "hello";
-//   const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
-//     fileContents
-//   ).toString("base64")}`;
-
-//   await actions.createFile({
-//     file: InlineFile.fromDataURL(dataUrl),
-//   });
-
-//   const result = await actions.listFilesEmptyHooks({});
-
-//   expect(result.results[0].file?.contentType).toEqual("text/plain");
-//   expect(result.results[0].file?.filename).toEqual("my-file.txt");
-//   expect(result.results[0].file?.size).toEqual(5);
-
-//   const contents = await result.results[0].file?.read();
-//   expect(contents?.toString("utf-8")).toEqual("hello");
-// });
-
-// test("files - create file in hook", async () => {
-//   await actions.createFileInHook({});
-
-//   const myfiles = await useDatabase()
-//     .selectFrom("my_file")
-//     .selectAll()
-//     .execute();
-
-//   const files =
-//     await sql<DbFile>`SELECT * FROM keel_storage ORDER BY created_at DESC`.execute(
-//       useDatabase()
-//     );
-
-//   expect(myfiles.length).toEqual(1);
-//   expect(files.rows.length).toEqual(1);
-//   expect(files.rows[0].id).toEqual(myfiles[0].file?.key);
-//   expect(files.rows[0].filename).toEqual(myfiles[0].file?.filename);
-//   expect(files.rows[0].contentType).toEqual(myfiles[0].file?.contentType);
-
-//   const contents = files.rows[0].data.toString("utf-8");
-//   expect(contents).toEqual("created in hook!");
-// });
-
-// test("files - create and store file in hook", async () => {
-//   await actions.createFileAndStoreInHook({});
-
-//   const myfiles = await useDatabase()
-//     .selectFrom("my_file")
-//     .selectAll()
-//     .execute();
-
-//   const files =
-//     await sql<DbFile>`SELECT * FROM keel_storage ORDER BY created_at DESC`.execute(
-//       useDatabase()
-//     );
-
-//   expect(myfiles.length).toEqual(1);
-//   expect(files.rows.length).toEqual(1);
-//   expect(files.rows[0].id).toEqual(myfiles[0].file?.key);
-//   expect(files.rows[0].filename).toEqual(myfiles[0].file?.filename);
-//   expect(files.rows[0].contentType).toEqual(myfiles[0].file?.contentType);
-
-//   const contents = files.rows[0].data.toString("utf-8");
-//   expect(contents).toEqual("created and stored in hook!");
-// });
-
-// test("files - read and store in query hook", async () => {
-//   const fileContents = "1";
-//   const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
-//     fileContents
-//   ).toString("base64")}`;
-
-//   const result = await actions.createFile({
-//     file: InlineFile.fromDataURL(dataUrl),
-//   });
-
-//   await actions.getFileNumerateContents({ id: result.id });
-//   await actions.getFileNumerateContents({ id: result.id });
-//   await actions.getFileNumerateContents({ id: result.id });
-
-//   const myfiles = await useDatabase()
-//     .selectFrom("my_file")
-//     .selectAll()
-//     .execute();
-
-//   const files =
-//     await sql<DbFile>`SELECT * FROM keel_storage ORDER BY created_at DESC`.execute(
-//       useDatabase()
-//     );
-
-//   expect(myfiles.length).toEqual(1);
-//   expect(files.rows.length).toEqual(1);
-//   expect(files.rows[0].id).toEqual(myfiles[0].file?.key);
-//   expect(files.rows[0].filename).toEqual(myfiles[0].file?.filename);
-//   expect(files.rows[0].contentType).toEqual(myfiles[0].file?.contentType);
-
-//   const contents = files.rows[0].data.toString("utf-8");
-//   expect(contents).toEqual("4");
-// });
-
-// test("files - write many, store many", async () => {
-//   const fileContents = "hello";
-//   const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
-//     fileContents
-//   ).toString("base64")}`;
-
-//   const result = await actions.writeMany({
-//     msg: { file: InlineFile.fromDataURL(dataUrl) },
-//   });
-
-//   expect(result.msg.file.contentType).toEqual("text/plain");
-//   expect(result.msg.file.size).toEqual(5);
-//   expect(result.msg.file.filename).toEqual("my-file.txt");
-
-//   const contents = await result.msg.file.read();
-//   expect(contents.toString("utf-8")).toEqual("hello");
-
-//   const myfiles = await models.myFile.findMany({
-//     orderBy: { createdAt: "desc" },
-//   });
-
-//   const keys = myfiles.map((a) => a.file!.key);
-//   keys.push((result.msg.file as File).key);
-
-//   const files =
-//     await sql<DbFile>`SELECT * FROM keel_storage ORDER BY created_at DESC`.execute(
-//       useDatabase()
-//     );
-
-//   const fileIds = files.rows.map((a) => a.id);
-
-//   expect(myfiles.length).toEqual(3);
-//   expect(files.rows.length).toEqual(4);
-//   expect(keys.sort()).toEqual(fileIds.sort());
-// });
-
-// test("files - store once, write many", async () => {
-//   const fileContents = "hello";
-//   const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
-//     fileContents
-//   ).toString("base64")}`;
-
-//   const result = await actions.storeAndWriteMany({
-//     file: InlineFile.fromDataURL(dataUrl),
-//   });
-
-//   expect(result.msg.file.contentType).toEqual("text/plain");
-//   expect(result.msg.file.size).toEqual(5);
-//   expect(result.msg.file.filename).toEqual("my-file.txt");
-
-//   const contents = await result.msg.file.read();
-//   expect(contents.toString("utf-8")).toEqual("hello");
-
-//   const myfiles = await useDatabase()
-//     .selectFrom("my_file")
-//     .selectAll()
-//     .execute();
-
-//   const files =
-//     await sql<DbFile>`SELECT * FROM keel_storage ORDER BY created_at DESC`.execute(
-//       useDatabase()
-//     );
-
-//   expect(myfiles.length).toEqual(3);
-//   expect(files.rows.length).toEqual(1);
-//   expect(myfiles[0].file?.key).toEqual(files.rows[0].id);
-//   expect(myfiles[1].file?.key).toEqual(files.rows[0].id);
-//   expect(myfiles[2].file?.key).toEqual(files.rows[0].id);
-//   expect((result.msg.file as File).key).toEqual(files.rows[0].id);
-// });
-
-// test("files - model API file tests", async () => {
-//   await expect(actions.modelApiTests({})).not.toHaveError({});
-// });
-
-// test("files - kysely file tests", async () => {
-//   await expect(actions.kyselyTests({})).not.toHaveError({});
-// });
-
-// test("files - presigned url", async () => {
-//   const fileContents = "hello";
-//   const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
-//     fileContents
-//   ).toString("base64")}`;
-
-//   const result = await actions.presignedUrl({
-//     file: InlineFile.fromDataURL(dataUrl),
-//   });
-
-//   expect(result).toEqual(dataUrl);
-// });
+test("files - update action with file input", async () => {
+  const fileContents = "hello";
+  const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
+    fileContents
+  ).toString("base64")}`;
+
+  const result = await actions.createFile({
+    file: InlineFile.fromDataURL(dataUrl),
+  });
+
+  const fileContents2 = "hello again";
+  const dataUrl2 = `data:text/plain;name=my-second-file.txt;base64,${Buffer.from(
+    fileContents2
+  ).toString("base64")}`;
+
+  const updated = await actions.updateFile({
+    where: {
+      id: result.id,
+    },
+    values: {
+      file: InlineFile.fromDataURL(dataUrl2),
+    },
+  });
+
+  expect(updated.file?.contentType).toEqual("text/plain");
+  expect(updated.file?.filename).toEqual("my-second-file.txt");
+  expect(updated.file?.size).toEqual(11);
+
+  const contents1 = await updated.file?.read();
+  expect(contents1?.toString("utf-8")).toEqual("hello again");
+
+  const myfiles = await useDatabase()
+    .selectFrom("my_file")
+    .selectAll()
+    .execute();
+
+  const files =
+    await sql<DbFile>`SELECT * FROM keel_storage ORDER BY created_at DESC`.execute(
+      useDatabase()
+    );
+
+  expect(myfiles.length).toEqual(1);
+  expect(files.rows.length).toEqual(2);
+  expect(files.rows[0].id).toEqual(myfiles[0].file?.key);
+  expect(files.rows[0].filename).toEqual(myfiles[0].file?.filename);
+  expect(files.rows[0].contentType).toEqual(myfiles[0].file?.contentType);
+
+  const contents = files.rows[0].data.toString("utf-8");
+  expect(contents).toEqual("hello again");
+});
+
+test("files - update action with file input and empty hooks", async () => {
+  const fileContents = "hello";
+  const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
+    fileContents
+  ).toString("base64")}`;
+
+  const result = await actions.createFile({
+    file: InlineFile.fromDataURL(dataUrl),
+  });
+
+  const fileContents2 = "hello again";
+  const dataUrl2 = `data:text/plain;name=my-second-file.txt;base64,${Buffer.from(
+    fileContents2
+  ).toString("base64")}`;
+
+  const updated = await actions.updateFileEmptyHooks({
+    where: {
+      id: result.id,
+    },
+    values: {
+      file: InlineFile.fromDataURL(dataUrl2),
+    },
+  });
+
+  expect(updated.file?.contentType).toEqual("text/plain");
+  expect(updated.file?.filename).toEqual("my-second-file.txt");
+  expect(updated.file?.size).toEqual(11);
+
+  const contents1 = await updated.file?.read();
+  expect(contents1?.toString("utf-8")).toEqual("hello again");
+
+  const myfiles = await useDatabase()
+    .selectFrom("my_file")
+    .selectAll()
+    .execute();
+
+  const files =
+    await sql<DbFile>`SELECT * FROM keel_storage ORDER BY created_at DESC`.execute(
+      useDatabase()
+    );
+
+  expect(myfiles.length).toEqual(1);
+  expect(files.rows.length).toEqual(2);
+  expect(files.rows[0].id).toEqual(myfiles[0].file?.key);
+  expect(files.rows[0].filename).toEqual(myfiles[0].file?.filename);
+  expect(files.rows[0].contentType).toEqual(myfiles[0].file?.contentType);
+
+  const contents = files.rows[0].data.toString("utf-8");
+  expect(contents).toEqual("hello again");
+});
+
+test("files - get action", async () => {
+  const fileContents = "hello";
+  const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
+    fileContents
+  ).toString("base64")}`;
+
+  const created = await actions.createFile({
+    file: InlineFile.fromDataURL(dataUrl),
+  });
+
+  const result = await actions.getFile({
+    id: created.id,
+  });
+
+  expect(result?.file?.contentType).toEqual("text/plain");
+  expect(result?.file?.filename).toEqual("my-file.txt");
+  expect(result?.file?.size).toEqual(5);
+
+  const contents1 = await result?.file?.read();
+  expect(contents1?.toString("utf-8")).toEqual("hello");
+});
+
+test("files - list action", async () => {
+  const fileContents = "hello";
+  const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
+    fileContents
+  ).toString("base64")}`;
+
+  await actions.createFile({
+    file: InlineFile.fromDataURL(dataUrl),
+  });
+
+  const fileContents2 = "hello again";
+  const dataUrl2 = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
+    fileContents2
+  ).toString("base64")}`;
+
+  await actions.createFile({
+    file: InlineFile.fromDataURL(dataUrl2),
+  });
+
+  const result = await actions.listFiles({});
+
+  expect(result.results[0].file?.contentType).toEqual("text/plain");
+  expect(result.results[0].file?.filename).toEqual("my-file.txt");
+  expect(result.results[0].file?.size).toEqual(5);
+
+  const contents1 = await result.results[0].file?.read();
+  expect(contents1?.toString("utf-8")).toEqual("hello");
+
+  expect(result.results[1].file?.contentType).toEqual("text/plain");
+  expect(result.results[1].file?.filename).toEqual("my-file.txt");
+  expect(result.results[1].file?.size).toEqual(11);
+
+  const contents2 = await result.results[1].file?.read();
+  expect(contents2?.toString("utf-8")).toEqual("hello again");
+});
+
+test("files - get action empty hooks", async () => {
+  const fileContents = "hello";
+  const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
+    fileContents
+  ).toString("base64")}`;
+
+  const created = await actions.createFile({
+    file: InlineFile.fromDataURL(dataUrl),
+  });
+
+  const result = await actions.getFileEmptyHooks({
+    id: created.id,
+  });
+
+  expect(result?.file?.contentType).toEqual("text/plain");
+  expect(result?.file?.filename).toEqual("my-file.txt");
+  expect(result?.file?.size).toEqual(5);
+
+  const contents1 = await result?.file?.read();
+  expect(contents1?.toString("utf-8")).toEqual("hello");
+});
+
+test("files - list action empty hooks", async () => {
+  const fileContents = "hello";
+  const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
+    fileContents
+  ).toString("base64")}`;
+
+  await actions.createFile({
+    file: InlineFile.fromDataURL(dataUrl),
+  });
+
+  const result = await actions.listFilesEmptyHooks({});
+
+  expect(result.results[0].file?.contentType).toEqual("text/plain");
+  expect(result.results[0].file?.filename).toEqual("my-file.txt");
+  expect(result.results[0].file?.size).toEqual(5);
+
+  const contents = await result.results[0].file?.read();
+  expect(contents?.toString("utf-8")).toEqual("hello");
+});
+
+test("files - create file in hook", async () => {
+  await actions.createFileInHook({});
+
+  const myfiles = await useDatabase()
+    .selectFrom("my_file")
+    .selectAll()
+    .execute();
+
+  const files =
+    await sql<DbFile>`SELECT * FROM keel_storage ORDER BY created_at DESC`.execute(
+      useDatabase()
+    );
+
+  expect(myfiles.length).toEqual(1);
+  expect(files.rows.length).toEqual(1);
+  expect(files.rows[0].id).toEqual(myfiles[0].file?.key);
+  expect(files.rows[0].filename).toEqual(myfiles[0].file?.filename);
+  expect(files.rows[0].contentType).toEqual(myfiles[0].file?.contentType);
+
+  const contents = files.rows[0].data.toString("utf-8");
+  expect(contents).toEqual("created in hook!");
+});
+
+test("files - create and store file in hook", async () => {
+  await actions.createFileAndStoreInHook({});
+
+  const myfiles = await useDatabase()
+    .selectFrom("my_file")
+    .selectAll()
+    .execute();
+
+  const files =
+    await sql<DbFile>`SELECT * FROM keel_storage ORDER BY created_at DESC`.execute(
+      useDatabase()
+    );
+
+  expect(myfiles.length).toEqual(1);
+  expect(files.rows.length).toEqual(1);
+  expect(files.rows[0].id).toEqual(myfiles[0].file?.key);
+  expect(files.rows[0].filename).toEqual(myfiles[0].file?.filename);
+  expect(files.rows[0].contentType).toEqual(myfiles[0].file?.contentType);
+
+  const contents = files.rows[0].data.toString("utf-8");
+  expect(contents).toEqual("created and stored in hook!");
+});
+
+test("files - read and store in query hook", async () => {
+  const fileContents = "1";
+  const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
+    fileContents
+  ).toString("base64")}`;
+
+  const result = await actions.createFile({
+    file: InlineFile.fromDataURL(dataUrl),
+  });
+
+  await actions.getFileNumerateContents({ id: result.id });
+  await actions.getFileNumerateContents({ id: result.id });
+  await actions.getFileNumerateContents({ id: result.id });
+
+  const myfiles = await useDatabase()
+    .selectFrom("my_file")
+    .selectAll()
+    .execute();
+
+  const files =
+    await sql<DbFile>`SELECT * FROM keel_storage ORDER BY created_at DESC`.execute(
+      useDatabase()
+    );
+
+  expect(myfiles.length).toEqual(1);
+  expect(files.rows.length).toEqual(1);
+  expect(files.rows[0].id).toEqual(myfiles[0].file?.key);
+  expect(files.rows[0].filename).toEqual(myfiles[0].file?.filename);
+  expect(files.rows[0].contentType).toEqual(myfiles[0].file?.contentType);
+
+  const contents = files.rows[0].data.toString("utf-8");
+  expect(contents).toEqual("4");
+});
+
+test("files - write many, store many", async () => {
+  const fileContents = "hello";
+  const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
+    fileContents
+  ).toString("base64")}`;
+
+  const result = await actions.writeMany({
+    msg: { file: InlineFile.fromDataURL(dataUrl) },
+  });
+
+  expect(result.msg.file.contentType).toEqual("text/plain");
+  expect(result.msg.file.size).toEqual(5);
+  expect(result.msg.file.filename).toEqual("my-file.txt");
+
+  const contents = await result.msg.file.read();
+  expect(contents.toString("utf-8")).toEqual("hello");
+
+  const myfiles = await models.myFile.findMany({
+    orderBy: { createdAt: "desc" },
+  });
+
+  const keys = myfiles.map((a) => a.file!.key);
+  keys.push((result.msg.file as File).key);
+
+  const files =
+    await sql<DbFile>`SELECT * FROM keel_storage ORDER BY created_at DESC`.execute(
+      useDatabase()
+    );
+
+  const fileIds = files.rows.map((a) => a.id);
+
+  expect(myfiles.length).toEqual(3);
+  expect(files.rows.length).toEqual(4);
+  expect(keys.sort()).toEqual(fileIds.sort());
+});
+
+test("files - store once, write many", async () => {
+  const fileContents = "hello";
+  const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
+    fileContents
+  ).toString("base64")}`;
+
+  const result = await actions.storeAndWriteMany({
+    file: InlineFile.fromDataURL(dataUrl),
+  });
+
+  expect(result.msg.file.contentType).toEqual("text/plain");
+  expect(result.msg.file.size).toEqual(5);
+  expect(result.msg.file.filename).toEqual("my-file.txt");
+
+  const contents = await result.msg.file.read();
+  expect(contents.toString("utf-8")).toEqual("hello");
+
+  const myfiles = await useDatabase()
+    .selectFrom("my_file")
+    .selectAll()
+    .execute();
+
+  const files =
+    await sql<DbFile>`SELECT * FROM keel_storage ORDER BY created_at DESC`.execute(
+      useDatabase()
+    );
+
+  expect(myfiles.length).toEqual(3);
+  expect(files.rows.length).toEqual(1);
+  expect(myfiles[0].file?.key).toEqual(files.rows[0].id);
+  expect(myfiles[1].file?.key).toEqual(files.rows[0].id);
+  expect(myfiles[2].file?.key).toEqual(files.rows[0].id);
+  expect((result.msg.file as File).key).toEqual(files.rows[0].id);
+});
+
+test("files - model API file tests", async () => {
+  await expect(actions.modelApiTests({})).not.toHaveError({});
+});
+
+test("files - kysely file tests", async () => {
+  await expect(actions.kyselyTests({})).not.toHaveError({});
+});
+
+test("files - presigned url", async () => {
+  const fileContents = "hello";
+  const dataUrl = `data:text/plain;name=my-file.txt;base64,${Buffer.from(
+    fileContents
+  ).toString("base64")}`;
+
+  const result = await actions.presignedUrl({
+    file: InlineFile.fromDataURL(dataUrl),
+  });
+
+  expect(result).toEqual(dataUrl);
+});

--- a/runtime/actions/create.go
+++ b/runtime/actions/create.go
@@ -66,6 +66,9 @@ func Create(scope *Scope, input map[string]any) (res map[string]any, err error) 
 			return nil
 		})
 	}
+	if err != nil {
+		return nil, err
+	}
 
 	// if we have any files in our results we need to transform them to the object structure required
 	if scope.Model.HasFiles() {

--- a/runtime/actions/files.go
+++ b/runtime/actions/files.go
@@ -49,7 +49,12 @@ func handleFileUploads(scope *Scope, inputs map[string]any) (map[string]any, err
 					return inputs, fmt.Errorf("storing file: %w", err)
 				}
 
-				inputs[field.Name] = fi
+				// ... and then change the input with the file data that should be saved in the db
+				fileInfo, err := fi.ToDbRecord()
+				if err != nil {
+					return inputs, err
+				}
+				inputs[field.Name] = fileInfo
 			}
 		}
 	}

--- a/runtime/apis/graphql/types.go
+++ b/runtime/apis/graphql/types.go
@@ -179,6 +179,10 @@ var pageInfoType = graphql.NewObject(graphql.ObjectConfig{
 var fileType = graphql.NewObject(graphql.ObjectConfig{
 	Name: "File",
 	Fields: graphql.Fields{
+		"key": &graphql.Field{
+			Type:        graphql.NewNonNull(graphql.String),
+			Description: "Unique reference for this file.",
+		},
 		"contentType": &graphql.Field{
 			Type:        graphql.NewNonNull(graphql.String),
 			Description: "MIME type for the file.",

--- a/runtime/apis/graphql/types.go
+++ b/runtime/apis/graphql/types.go
@@ -187,14 +187,6 @@ var fileType = graphql.NewObject(graphql.ObjectConfig{
 			Type:        graphql.NewNonNull(graphql.String),
 			Description: "The name of the file when it was uploaded.",
 		},
-		"key": &graphql.Field{
-			Type:        graphql.NewNonNull(graphql.String),
-			Description: "Unique reference for this file.",
-		},
-		"public": &graphql.Field{
-			Type:        graphql.NewNonNull(graphql.Boolean),
-			Description: "If the file is public or private.",
-		},
 		"size": &graphql.Field{
 			Type:        graphql.NewNonNull(graphql.Int),
 			Description: "Size of the file in bytes.",

--- a/runtime/jsonschema/jsonschema.go
+++ b/runtime/jsonschema/jsonschema.go
@@ -558,12 +558,13 @@ func jsonSchemaForField(ctx context.Context, schema *proto.Schema, action *proto
 			// if the field is as part of a response, then the action is nil and we want to return an object
 			prop.Type = "object"
 			prop.Properties = map[string]JSONSchema{
+				"key":         {Type: "string"},
 				"filename":    {Type: "string"},
 				"contentType": {Type: "string"},
 				"size":        {Type: "number"},
 				"url":         {Type: "string"},
 			}
-			prop.Required = []string{"filename", "contentType", "size", "url"}
+			prop.Required = []string{"key", "filename", "contentType", "size", "url"}
 		}
 	}
 

--- a/runtime/jsonschema/jsonschema.go
+++ b/runtime/jsonschema/jsonschema.go
@@ -561,10 +561,9 @@ func jsonSchemaForField(ctx context.Context, schema *proto.Schema, action *proto
 				"filename":    {Type: "string"},
 				"contentType": {Type: "string"},
 				"size":        {Type: "number"},
-				"key":         {Type: "string"},
 				"url":         {Type: "string"},
 			}
-			prop.Required = []string{"filename", "contentType", "size", "key"}
+			prop.Required = []string{"filename", "contentType", "size", "url"}
 		}
 	}
 

--- a/runtime/openapi/testdata/basic.json
+++ b/runtime/openapi/testdata/basic.json
@@ -281,12 +281,13 @@
           "picture": {
             "type": "object",
             "properties": {
+              "key": { "type": "string" },
               "contentType": { "type": "string" },
               "filename": { "type": "string" },
               "size": { "type": "number" },
               "url": { "type": "string" }
             },
-            "required": ["filename", "contentType", "size", "url"]
+            "required": ["key", "filename", "contentType", "size", "url"]
           },
           "updatedAt": { "type": "string", "format": "date-time" },
           "weight": { "type": "number", "format": "float" }

--- a/runtime/openapi/testdata/basic.json
+++ b/runtime/openapi/testdata/basic.json
@@ -283,11 +283,10 @@
             "properties": {
               "contentType": { "type": "string" },
               "filename": { "type": "string" },
-              "key": { "type": "string" },
               "size": { "type": "number" },
               "url": { "type": "string" }
             },
-            "required": ["filename", "contentType", "size", "key"]
+            "required": ["filename", "contentType", "size", "url"]
           },
           "updatedAt": { "type": "string", "format": "date-time" },
           "weight": { "type": "number", "format": "float" }

--- a/runtime/openapi/testdata/files.json
+++ b/runtime/openapi/testdata/files.json
@@ -272,11 +272,10 @@
                       "properties": {
                         "contentType": { "type": "string" },
                         "filename": { "type": "string" },
-                        "key": { "type": "string" },
                         "size": { "type": "number" },
                         "url": { "type": "string" }
                       },
-                      "required": ["filename", "contentType", "size", "key"]
+                      "required": ["filename", "contentType", "size", "url"]
                     }
                   },
                   "additionalProperties": false,
@@ -325,11 +324,10 @@
             "properties": {
               "contentType": { "type": "string" },
               "filename": { "type": "string" },
-              "key": { "type": "string" },
               "size": { "type": "number" },
               "url": { "type": "string" }
             },
-            "required": ["filename", "contentType", "size", "key"]
+            "required": ["filename", "contentType", "size", "url"]
           },
           "updatedAt": { "type": "string", "format": "date-time" }
         },

--- a/runtime/openapi/testdata/files.json
+++ b/runtime/openapi/testdata/files.json
@@ -272,10 +272,17 @@
                       "properties": {
                         "contentType": { "type": "string" },
                         "filename": { "type": "string" },
+                        "key": { "type": "string" },
                         "size": { "type": "number" },
                         "url": { "type": "string" }
                       },
-                      "required": ["filename", "contentType", "size", "url"]
+                      "required": [
+                        "key",
+                        "filename",
+                        "contentType",
+                        "size",
+                        "url"
+                      ]
                     }
                   },
                   "additionalProperties": false,
@@ -322,13 +329,13 @@
           "photo": {
             "type": "object",
             "properties": {
-              "key": { "type": "string" },
               "contentType": { "type": "string" },
               "filename": { "type": "string" },
+              "key": { "type": "string" },
               "size": { "type": "number" },
               "url": { "type": "string" }
             },
-            "required": [ "key", "filename", "contentType", "size", "url"]
+            "required": ["key", "filename", "contentType", "size", "url"]
           },
           "updatedAt": { "type": "string", "format": "date-time" }
         },

--- a/runtime/openapi/testdata/files.json
+++ b/runtime/openapi/testdata/files.json
@@ -322,12 +322,13 @@
           "photo": {
             "type": "object",
             "properties": {
+              "key": { "type": "string" },
               "contentType": { "type": "string" },
               "filename": { "type": "string" },
               "size": { "type": "number" },
               "url": { "type": "string" }
             },
-            "required": ["filename", "contentType", "size", "url"]
+            "required": [ "key", "filename", "contentType", "size", "url"]
           },
           "updatedAt": { "type": "string", "format": "date-time" }
         },

--- a/schema/testdata/proto/message_file_field/proto.json
+++ b/schema/testdata/proto/message_file_field/proto.json
@@ -1,0 +1,343 @@
+{
+  "models": [
+    {
+      "name": "Person",
+      "fields": [
+        {
+          "modelName": "Person",
+          "name": "id",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "primaryKey": true,
+          "defaultValue": {
+            "useZeroValue": true
+          }
+        },
+        {
+          "modelName": "Person",
+          "name": "createdAt",
+          "type": {
+            "type": "TYPE_DATETIME"
+          },
+          "defaultValue": {
+            "useZeroValue": true
+          }
+        },
+        {
+          "modelName": "Person",
+          "name": "updatedAt",
+          "type": {
+            "type": "TYPE_DATETIME"
+          },
+          "defaultValue": {
+            "useZeroValue": true
+          }
+        }
+      ],
+      "actions": [
+        {
+          "modelName": "Person",
+          "name": "writeFile",
+          "type": "ACTION_TYPE_WRITE",
+          "implementation": "ACTION_IMPLEMENTATION_CUSTOM",
+          "inputMessageName": "Input",
+          "responseMessageName": "Response"
+        }
+      ]
+    },
+    {
+      "name": "Identity",
+      "fields": [
+        {
+          "modelName": "Identity",
+          "name": "email",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true,
+          "uniqueWith": [
+            "issuer"
+          ]
+        },
+        {
+          "modelName": "Identity",
+          "name": "emailVerified",
+          "type": {
+            "type": "TYPE_BOOL"
+          },
+          "defaultValue": {
+            "expression": {
+              "source": "false"
+            }
+          }
+        },
+        {
+          "modelName": "Identity",
+          "name": "password",
+          "type": {
+            "type": "TYPE_PASSWORD"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Identity",
+          "name": "externalId",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Identity",
+          "name": "issuer",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true,
+          "uniqueWith": [
+            "email"
+          ]
+        },
+        {
+          "modelName": "Identity",
+          "name": "name",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Identity",
+          "name": "givenName",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Identity",
+          "name": "familyName",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Identity",
+          "name": "middleName",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Identity",
+          "name": "nickName",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Identity",
+          "name": "profile",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Identity",
+          "name": "picture",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Identity",
+          "name": "website",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Identity",
+          "name": "gender",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Identity",
+          "name": "zoneInfo",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Identity",
+          "name": "locale",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "modelName": "Identity",
+          "name": "id",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "primaryKey": true,
+          "defaultValue": {
+            "useZeroValue": true
+          }
+        },
+        {
+          "modelName": "Identity",
+          "name": "createdAt",
+          "type": {
+            "type": "TYPE_DATETIME"
+          },
+          "defaultValue": {
+            "useZeroValue": true
+          }
+        },
+        {
+          "modelName": "Identity",
+          "name": "updatedAt",
+          "type": {
+            "type": "TYPE_DATETIME"
+          },
+          "defaultValue": {
+            "useZeroValue": true
+          }
+        }
+      ],
+      "actions": [
+        {
+          "modelName": "Identity",
+          "name": "requestPasswordReset",
+          "type": "ACTION_TYPE_WRITE",
+          "implementation": "ACTION_IMPLEMENTATION_RUNTIME",
+          "inputMessageName": "RequestPasswordResetInput",
+          "responseMessageName": "RequestPasswordResetResponse"
+        },
+        {
+          "modelName": "Identity",
+          "name": "resetPassword",
+          "type": "ACTION_TYPE_WRITE",
+          "implementation": "ACTION_IMPLEMENTATION_RUNTIME",
+          "inputMessageName": "ResetPasswordInput",
+          "responseMessageName": "ResetPasswordResponse"
+        }
+      ]
+    }
+  ],
+  "apis": [
+    {
+      "name": "Api",
+      "apiModels": [
+        {
+          "modelName": "Person",
+          "modelActions": [
+            {
+              "actionName": "writeFile"
+            }
+          ]
+        },
+        {
+          "modelName": "Identity",
+          "modelActions": [
+            {
+              "actionName": "requestPasswordReset"
+            },
+            {
+              "actionName": "resetPassword"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "messages": [
+    {
+      "name": "Any"
+    },
+    {
+      "name": "Input",
+      "fields": [
+        {
+          "messageName": "Input",
+          "name": "data",
+          "type": {
+            "type": "TYPE_FILE"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Response",
+      "fields": [
+        {
+          "messageName": "Response",
+          "name": "data",
+          "type": {
+            "type": "TYPE_FILE"
+          }
+        }
+      ]
+    },
+    {
+      "name": "RequestPasswordResetInput",
+      "fields": [
+        {
+          "messageName": "RequestPasswordResetInput",
+          "name": "email",
+          "type": {
+            "type": "TYPE_STRING"
+          }
+        },
+        {
+          "messageName": "RequestPasswordResetInput",
+          "name": "redirectUrl",
+          "type": {
+            "type": "TYPE_STRING"
+          }
+        }
+      ]
+    },
+    {
+      "name": "RequestPasswordResetResponse"
+    },
+    {
+      "name": "ResetPasswordInput",
+      "fields": [
+        {
+          "messageName": "ResetPasswordInput",
+          "name": "token",
+          "type": {
+            "type": "TYPE_STRING"
+          }
+        },
+        {
+          "messageName": "ResetPasswordInput",
+          "name": "password",
+          "type": {
+            "type": "TYPE_STRING"
+          }
+        }
+      ]
+    },
+    {
+      "name": "ResetPasswordResponse"
+    }
+  ]
+}

--- a/schema/testdata/proto/message_file_field/proto.json
+++ b/schema/testdata/proto/message_file_field/proto.json
@@ -57,9 +57,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -96,9 +94,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/message_file_field/schema.keel
+++ b/schema/testdata/proto/message_file_field/schema.keel
@@ -1,0 +1,13 @@
+message Input {
+	data File
+}
+
+message Response {
+	data File
+}
+
+model Person {
+    actions {
+        write writeFile(Input) returns (Response)
+    }
+}

--- a/storage/database_storer.go
+++ b/storage/database_storer.go
@@ -135,6 +135,7 @@ func (s *DbStore) GenerateFileResponse(fi *FileInfo) (FileResponse, error) {
 	dataURL := encodeDataURL(fd)
 
 	return FileResponse{
+		Key:         fi.Key,
 		Filename:    fi.Filename,
 		ContentType: fi.ContentType,
 		Size:        fi.Size,

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -33,6 +33,7 @@ type FileInfo struct {
 
 // FileResponse is what is returned from our APIs
 type FileResponse struct {
+	Key         string `json:"key"`
 	Filename    string `json:"filename"`
 	ContentType string `json:"contentType"`
 	Size        int    `json:"size"`
@@ -44,5 +45,14 @@ func (fi *FileInfo) ToJSON() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("marshalling to json: %w", err)
 	}
+	return string(json), nil
+}
+
+func (fi *FileInfo) ToDbRecord() (string, error) {
+	json, err := json.Marshal(fi)
+	if err != nil {
+		return "", fmt.Errorf("marshalling to json: %w", err)
+	}
+
 	return string(json), nil
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -7,59 +7,40 @@ import (
 
 // Storer represents the interface for a file storing service that is used by the Keel runtime
 type Storer interface {
-	// Store will save the given file and return a FileData struct for it
+	// Store will save the given file and return a FileInfo struct for it
 	//
 	// The input should be a well formed dataURL https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs
 	// The name of the file can also be passed as a parameter of the mediaType segment; e.g.
 	// data:application/pdf;name=MyUploadedFile.pdf;base64,xxxxxx[...]
-	Store(dataURL string) (FileResponse, error)
+	Store(dataURL string) (FileInfo, error)
 
-	// GetFileInfo will return the file information for the given unique file key.
-	//
-	// The File info returned can contain a URL where the file can be downloaded from, if applicable; i.e. for database
-	// storage, at the moment files cannot be retrieved via URLs.
-	GetFileInfo(key string) (FileResponse, error)
+	// GetFileInfo will return the file information for the given unique file key as stored in the database.
+	GetFileInfo(key string) (FileInfo, error)
 
-	// HydrateFileInfo will take the given file info and hydrate it with the most up to date information.
+	// GenerateFileResponse will take the given file info and generate a response to be returned from an API.
 	//
 	// The use of this function is to generate any signed URLs for file downloads.
-	HydrateFileInfo(fi *FileResponse) (FileResponse, error)
+	GenerateFileResponse(fi *FileInfo) (FileResponse, error)
 }
 
-// FileResponse is what is returned from our APIs
-type FileResponse struct {
-	Key         string  `json:"key"`
-	Filename    string  `json:"filename"`
-	ContentType string  `json:"contentType"`
-	Size        int     `json:"size"`
-	URL         *string `json:"url,omitempty"`
-}
-
-// FileDbRecord is what is stored in the database
-type FileDbRecord struct {
+// FileInfo contains important data for the File type as stored in the database
+type FileInfo struct {
 	Key         string `json:"key"`
 	Filename    string `json:"filename"`
 	ContentType string `json:"contentType"`
 	Size        int    `json:"size"`
 }
 
-func (fi *FileResponse) ToJSON() (string, error) {
-	json, err := json.Marshal(fi)
-	if err != nil {
-		return "", fmt.Errorf("marshalling to json: %w", err)
-	}
-	return string(json), nil
+// FileResponse is what is returned from our APIs
+type FileResponse struct {
+	Filename    string `json:"filename"`
+	ContentType string `json:"contentType"`
+	Size        int    `json:"size"`
+	URL         string `json:"url"`
 }
 
-func (fi *FileResponse) ToDbRecord() (string, error) {
-	dbRec := &FileDbRecord{
-		Key:         fi.Key,
-		Filename:    fi.Filename,
-		ContentType: fi.ContentType,
-		Size:        fi.Size,
-	}
-
-	json, err := json.Marshal(dbRec)
+func (fi *FileInfo) ToJSON() (string, error) {
+	json, err := json.Marshal(fi)
 	if err != nil {
 		return "", fmt.Errorf("marshalling to json: %w", err)
 	}


### PR DESCRIPTION
File's `url` response field now required in jsonschema.  Removed `public` field from the GraphQL schema.