### PR TITLE
fix: preserve order of foreign keys generated in proto

### DIFF
--- a/integration/testdata/set_backlinks/tests.test.ts
+++ b/integration/testdata/set_backlinks/tests.test.ts
@@ -112,7 +112,7 @@ test("create - @set with backlinks and no authenticated identity", async () => {
 
   await expect(actions.createRecord({ name: "Tax Records" })).toHaveError({
     code: "ERR_INVALID_INPUT",
-    message: "field 'isActive' cannot be null",
+    message: "field 'ownerId' cannot be null",
   });
 });
 
@@ -123,7 +123,7 @@ test("create - @set with backlinks and no user backlink", async () => {
     actions.withIdentity(identity).createRecord({ name: "Tax Records" })
   ).toHaveError({
     code: "ERR_INVALID_INPUT",
-    message: "field 'isActive' cannot be null",
+    message: "field 'ownerId' cannot be null",
   });
 });
 
@@ -193,7 +193,7 @@ test("update - @set with backlinks and no authenticated identity", async () => {
     })
   ).toHaveError({
     code: "ERR_INVALID_INPUT",
-    message: "field 'isActive' cannot be null",
+    message: "field 'ownerId' cannot be null",
   });
 });
 
@@ -221,7 +221,7 @@ test("update - @set with backlinks and no user backlink", async () => {
     })
   ).toHaveError({
     code: "ERR_INVALID_INPUT",
-    message: "field 'isActive' cannot be null",
+    message: "field 'ownerId' cannot be null",
   });
 });
 

--- a/migrations/testdata/model_added.txt
+++ b/migrations/testdata/model_added.txt
@@ -23,10 +23,10 @@ model Animal {
 
 CREATE TABLE "animal" (
 "name" TEXT NOT NULL,
+"human_friend_id" TEXT NOT NULL,
 "id" TEXT NOT NULL DEFAULT ksuid(),
 "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
-"updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
-"human_friend_id" TEXT NOT NULL
+"updated_at" TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 ALTER TABLE "animal" ADD CONSTRAINT animal_id_pkey PRIMARY KEY ("id");
 ALTER TABLE "animal" ADD FOREIGN KEY ("human_friend_id") REFERENCES "person"("id") ON DELETE CASCADE;

--- a/node/codegen_test.go
+++ b/node/codegen_test.go
@@ -81,12 +81,11 @@ model Account {
 
 	expected := `
 export interface Account {
+	identityId: string
 	id: string
 	createdAt: Date
 	updatedAt: Date
-	identityId: string
-}
-`
+}`
 	runWriterTest(t, schema, expected, func(s *proto.Schema, w *codegen.Writer) {
 		m := s.FindModel("Account")
 		writeModelInterface(w, m, false)
@@ -1427,10 +1426,10 @@ model Person {
 		updatedAt: Date
 	}
 	birthplace: City
+	countryId: string
 	id: string
 	createdAt: Date
 	updatedAt: Date
-	countryId: string
 }`
 
 	runWriterTest(t, schema, expected, func(s *proto.Schema, w *codegen.Writer) {

--- a/runtime/openapi/testdata/basic.json
+++ b/runtime/openapi/testdata/basic.json
@@ -295,13 +295,13 @@
         "required": [
           "name",
           "dateOfBirth",
+          "addressId",
           "details",
           "weight",
           "picture",
           "id",
           "createdAt",
-          "updatedAt",
-          "addressId"
+          "updatedAt"
         ]
       },
       "CustomersWhere": {

--- a/runtime/openapi/testdata/embedded_data.json
+++ b/runtime/openapi/testdata/embedded_data.json
@@ -729,16 +729,6 @@
   },
   "components": {
     "schemas": {
-      "User": {
-        "properties": {
-          "createdAt": { "type": "string", "format": "date-time" },
-          "firstName": { "type": "string" },
-          "id": { "type": "string" },
-          "surname": { "type": "string" },
-          "updatedAt": { "type": "string", "format": "date-time" }
-        },
-        "required": ["firstName", "surname", "id", "createdAt", "updatedAt"]
-      },
       "Book": {
         "properties": {
           "authorId": { "type": "string" },
@@ -747,17 +737,17 @@
           "title": { "type": "string" },
           "updatedAt": { "type": "string", "format": "date-time" }
         },
-        "required": ["title", "id", "createdAt", "updatedAt", "authorId"]
+        "required": ["title", "authorId", "id", "createdAt", "updatedAt"]
       },
       "Code": {
         "properties": {
+          "bookId": { "type": "string" },
+          "code": { "type": "string" },
           "createdAt": { "type": "string", "format": "date-time" },
           "id": { "type": "string" },
-          "code": { "type": "string" },
-          "bookId": { "type": "string" },
           "updatedAt": { "type": "string", "format": "date-time" }
         },
-        "required": ["code", "id", "createdAt", "updatedAt", "bookId"]
+        "required": ["code", "bookId", "id", "createdAt", "updatedAt"]
       },
       "CreateBookAuthorInput": {
         "type": "object",
@@ -839,7 +829,17 @@
           "id": { "type": "string" },
           "updatedAt": { "type": "string", "format": "date-time" }
         },
-        "required": ["content", "id", "createdAt", "updatedAt", "bookId"]
+        "required": ["content", "bookId", "id", "createdAt", "updatedAt"]
+      },
+      "User": {
+        "properties": {
+          "createdAt": { "type": "string", "format": "date-time" },
+          "firstName": { "type": "string" },
+          "id": { "type": "string" },
+          "surname": { "type": "string" },
+          "updatedAt": { "type": "string", "format": "date-time" }
+        },
+        "required": ["firstName", "surname", "id", "createdAt", "updatedAt"]
       }
     }
   }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -345,7 +345,6 @@ func (scm *Builder) insertForeignKeyFields(asts []*parser.AST) *errorhandling.Er
 				fkField.Attributes = append(fkField.Attributes, &attr)
 			}
 
-			//fkFieldsToAdd = append(fkFieldsToAdd, fkField)
 			fkFieldsToAdd[i] = fkField
 		}
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/alecthomas/participle/v2/lexer"
+	"github.com/samber/lo"
 	"github.com/teamkeel/keel/casing"
 	"github.com/teamkeel/keel/proto"
 	"golang.org/x/exp/slices"
@@ -350,10 +351,12 @@ func (scm *Builder) insertForeignKeyFields(asts []*parser.AST) *errorhandling.Er
 
 		// Add the new FK fields to the existing model's fields section at the same location as the model fields.
 		offset := 1
+		keys := lo.Keys(fkFieldsToAdd)
+		slices.Sort(keys)
 		for _, section := range mdl.Sections {
 			if section.Fields != nil {
-				for k, v := range fkFieldsToAdd {
-					section.Fields = slices.Insert(section.Fields, k+offset, v)
+				for _, v := range keys {
+					section.Fields = slices.Insert(section.Fields, v+offset, fkFieldsToAdd[v])
 					offset++
 				}
 			}

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -54,7 +54,9 @@ func TestProto(t *testing.T) {
 				return
 			}
 
+			fmt.Println(testCase.Name())
 			fmt.Println(string(actual))
+			fmt.Println()
 
 			assert.Fail(t, "actual proto JSON does not match expected", explanation)
 		})

--- a/schema/testdata/generate_testdata.go
+++ b/schema/testdata/generate_testdata.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -109,9 +108,10 @@ func main() {
 
 			// protojson does some slightly weird things with whitespace so we run
 			// the output through go's default indenter to fix this
-			var dest bytes.Buffer
-			_ = json.Indent(&dest, b, "", "  ")
-			outputContents = dest.Bytes()
+
+			//var dest bytes.Buffer
+			//_ = json.Indent(&dest, b, "", "  ")
+			outputContents = b //dest.Bytes()
 
 			outputFileName = filepath.Join(testdataDir, subDir.Name(), "proto.json")
 		}

--- a/schema/testdata/generate_testdata.go
+++ b/schema/testdata/generate_testdata.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -109,9 +110,9 @@ func main() {
 			// protojson does some slightly weird things with whitespace so we run
 			// the output through go's default indenter to fix this
 
-			//var dest bytes.Buffer
-			//_ = json.Indent(&dest, b, "", "  ")
-			outputContents = b //dest.Bytes()
+			var dest bytes.Buffer
+			_ = json.Indent(&dest, b, "", "  ")
+			outputContents = dest.Bytes()
 
 			outputFileName = filepath.Join(testdataDir, subDir.Name(), "proto.json")
 		}

--- a/schema/testdata/proto/action_inputs_in_both_query_and_with/proto.json
+++ b/schema/testdata/proto/action_inputs_in_both_query_and_with/proto.json
@@ -45,6 +45,18 @@
         },
         {
           "modelName": "Account",
+          "name": "identityId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Identity",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Account",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -73,18 +85,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "Account",
-          "name": "identityId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Identity",
-            "relatedModelField": "id"
           }
         }
       ],
@@ -136,7 +136,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -173,7 +175,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -423,7 +427,9 @@
             "modelName": "Account",
             "fieldName": "username"
           },
-          "target": ["username"]
+          "target": [
+            "username"
+          ]
         }
       ]
     },
@@ -438,7 +444,9 @@
             "modelName": "Account",
             "fieldName": "name"
           },
-          "target": ["name"]
+          "target": [
+            "name"
+          ]
         },
         {
           "messageName": "UpdateAccountValues",
@@ -448,7 +456,9 @@
             "modelName": "Account",
             "fieldName": "username"
           },
-          "target": ["username"]
+          "target": [
+            "username"
+          ]
         },
         {
           "messageName": "UpdateAccountValues",
@@ -458,7 +468,9 @@
             "modelName": "Account",
             "fieldName": "isActive"
           },
-          "target": ["isActive"]
+          "target": [
+            "isActive"
+          ]
         }
       ]
     },
@@ -494,7 +506,9 @@
             "modelName": "Account",
             "fieldName": "username"
           },
-          "target": ["username"]
+          "target": [
+            "username"
+          ]
         },
         {
           "messageName": "UpdateAccount2Where",
@@ -504,7 +518,9 @@
             "modelName": "Account",
             "fieldName": "isActive"
           },
-          "target": ["isActive"]
+          "target": [
+            "isActive"
+          ]
         }
       ]
     },
@@ -519,7 +535,9 @@
             "modelName": "Account",
             "fieldName": "name"
           },
-          "target": ["name"]
+          "target": [
+            "name"
+          ]
         },
         {
           "messageName": "UpdateAccount2Values",
@@ -529,7 +547,9 @@
             "modelName": "Account",
             "fieldName": "username"
           },
-          "target": ["username"]
+          "target": [
+            "username"
+          ]
         },
         {
           "messageName": "UpdateAccount2Values",
@@ -539,7 +559,9 @@
             "modelName": "Account",
             "fieldName": "isActive"
           },
-          "target": ["isActive"]
+          "target": [
+            "isActive"
+          ]
         }
       ]
     },
@@ -575,7 +597,10 @@
             "modelName": "Identity",
             "fieldName": "id"
           },
-          "target": ["identity", "id"]
+          "target": [
+            "identity",
+            "id"
+          ]
         }
       ]
     },
@@ -603,7 +628,10 @@
             "modelName": "Identity",
             "fieldName": "id"
           },
-          "target": ["identity", "id"]
+          "target": [
+            "identity",
+            "id"
+          ]
         }
       ]
     },
@@ -640,7 +668,10 @@
             "fieldName": "email"
           },
           "nullable": true,
-          "target": ["identity", "email"]
+          "target": [
+            "identity",
+            "email"
+          ]
         },
         {
           "messageName": "UpdateAccount4Where",
@@ -651,7 +682,10 @@
             "fieldName": "issuer"
           },
           "nullable": true,
-          "target": ["identity", "issuer"]
+          "target": [
+            "identity",
+            "issuer"
+          ]
         }
       ]
     },
@@ -666,7 +700,9 @@
             "modelName": "Account",
             "fieldName": "email"
           },
-          "target": ["email"]
+          "target": [
+            "email"
+          ]
         }
       ]
     },
@@ -703,7 +739,10 @@
             "fieldName": "email"
           },
           "nullable": true,
-          "target": ["identity", "email"]
+          "target": [
+            "identity",
+            "email"
+          ]
         },
         {
           "messageName": "UpdateAccount5Where",
@@ -714,7 +753,10 @@
             "fieldName": "issuer"
           },
           "nullable": true,
-          "target": ["identity", "issuer"]
+          "target": [
+            "identity",
+            "issuer"
+          ]
         }
       ]
     },
@@ -743,7 +785,10 @@
             "fieldName": "email"
           },
           "nullable": true,
-          "target": ["identity", "email"]
+          "target": [
+            "identity",
+            "email"
+          ]
         }
       ]
     },

--- a/schema/testdata/proto/action_inputs_in_both_query_and_with/proto.json
+++ b/schema/testdata/proto/action_inputs_in_both_query_and_with/proto.json
@@ -136,9 +136,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -175,9 +173,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -427,9 +423,7 @@
             "modelName": "Account",
             "fieldName": "username"
           },
-          "target": [
-            "username"
-          ]
+          "target": ["username"]
         }
       ]
     },
@@ -444,9 +438,7 @@
             "modelName": "Account",
             "fieldName": "name"
           },
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         },
         {
           "messageName": "UpdateAccountValues",
@@ -456,9 +448,7 @@
             "modelName": "Account",
             "fieldName": "username"
           },
-          "target": [
-            "username"
-          ]
+          "target": ["username"]
         },
         {
           "messageName": "UpdateAccountValues",
@@ -468,9 +458,7 @@
             "modelName": "Account",
             "fieldName": "isActive"
           },
-          "target": [
-            "isActive"
-          ]
+          "target": ["isActive"]
         }
       ]
     },
@@ -506,9 +494,7 @@
             "modelName": "Account",
             "fieldName": "username"
           },
-          "target": [
-            "username"
-          ]
+          "target": ["username"]
         },
         {
           "messageName": "UpdateAccount2Where",
@@ -518,9 +504,7 @@
             "modelName": "Account",
             "fieldName": "isActive"
           },
-          "target": [
-            "isActive"
-          ]
+          "target": ["isActive"]
         }
       ]
     },
@@ -535,9 +519,7 @@
             "modelName": "Account",
             "fieldName": "name"
           },
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         },
         {
           "messageName": "UpdateAccount2Values",
@@ -547,9 +529,7 @@
             "modelName": "Account",
             "fieldName": "username"
           },
-          "target": [
-            "username"
-          ]
+          "target": ["username"]
         },
         {
           "messageName": "UpdateAccount2Values",
@@ -559,9 +539,7 @@
             "modelName": "Account",
             "fieldName": "isActive"
           },
-          "target": [
-            "isActive"
-          ]
+          "target": ["isActive"]
         }
       ]
     },
@@ -597,10 +575,7 @@
             "modelName": "Identity",
             "fieldName": "id"
           },
-          "target": [
-            "identity",
-            "id"
-          ]
+          "target": ["identity", "id"]
         }
       ]
     },
@@ -628,10 +603,7 @@
             "modelName": "Identity",
             "fieldName": "id"
           },
-          "target": [
-            "identity",
-            "id"
-          ]
+          "target": ["identity", "id"]
         }
       ]
     },
@@ -668,10 +640,7 @@
             "fieldName": "email"
           },
           "nullable": true,
-          "target": [
-            "identity",
-            "email"
-          ]
+          "target": ["identity", "email"]
         },
         {
           "messageName": "UpdateAccount4Where",
@@ -682,10 +651,7 @@
             "fieldName": "issuer"
           },
           "nullable": true,
-          "target": [
-            "identity",
-            "issuer"
-          ]
+          "target": ["identity", "issuer"]
         }
       ]
     },
@@ -700,9 +666,7 @@
             "modelName": "Account",
             "fieldName": "email"
           },
-          "target": [
-            "email"
-          ]
+          "target": ["email"]
         }
       ]
     },
@@ -739,10 +703,7 @@
             "fieldName": "email"
           },
           "nullable": true,
-          "target": [
-            "identity",
-            "email"
-          ]
+          "target": ["identity", "email"]
         },
         {
           "messageName": "UpdateAccount5Where",
@@ -753,10 +714,7 @@
             "fieldName": "issuer"
           },
           "nullable": true,
-          "target": [
-            "identity",
-            "issuer"
-          ]
+          "target": ["identity", "issuer"]
         }
       ]
     },
@@ -785,10 +743,7 @@
             "fieldName": "email"
           },
           "nullable": true,
-          "target": [
-            "identity",
-            "email"
-          ]
+          "target": ["identity", "email"]
         }
       ]
     },

--- a/schema/testdata/proto/attribute_embed/proto.json
+++ b/schema/testdata/proto/attribute_embed/proto.json
@@ -115,6 +115,17 @@
         },
         {
           "modelName": "Review",
+          "name": "bookId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Book",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Review",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -144,17 +155,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Review",
-          "name": "bookId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Book",
-            "relatedModelField": "id"
-          }
         }
       ],
       "actions": [
@@ -178,7 +178,9 @@
           "type": "ACTION_TYPE_GET",
           "implementation": "ACTION_IMPLEMENTATION_AUTO",
           "inputMessageName": "GetReviewInput",
-          "responseEmbeds": ["book"]
+          "responseEmbeds": [
+            "book"
+          ]
         }
       ],
       "permissions": [
@@ -216,6 +218,17 @@
           },
           "foreignKeyFieldName": "authorId",
           "inverseFieldName": "books"
+        },
+        {
+          "modelName": "Book",
+          "name": "authorId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Author",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Book",
@@ -268,17 +281,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Book",
-          "name": "authorId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Author",
-            "relatedModelField": "id"
-          }
         }
       ],
       "actions": [
@@ -288,7 +290,9 @@
           "type": "ACTION_TYPE_LIST",
           "implementation": "ACTION_IMPLEMENTATION_AUTO",
           "inputMessageName": "ListBooksInput",
-          "responseEmbeds": ["author"]
+          "responseEmbeds": [
+            "author"
+          ]
         },
         {
           "modelName": "Book",
@@ -303,7 +307,10 @@
           "type": "ACTION_TYPE_GET",
           "implementation": "ACTION_IMPLEMENTATION_AUTO",
           "inputMessageName": "GetBookInput",
-          "responseEmbeds": ["code", "author"]
+          "responseEmbeds": [
+            "code",
+            "author"
+          ]
         },
         {
           "modelName": "Book",
@@ -352,6 +359,18 @@
         },
         {
           "modelName": "Code",
+          "name": "bookId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Book",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Code",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -381,18 +400,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Code",
-          "name": "bookId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Book",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -406,7 +413,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -443,7 +452,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -708,7 +719,9 @@
             "modelName": "Author",
             "fieldName": "firstName"
           },
-          "target": ["firstName"]
+          "target": [
+            "firstName"
+          ]
         },
         {
           "messageName": "CreateAuthorInput",
@@ -718,7 +731,9 @@
             "modelName": "Author",
             "fieldName": "surname"
           },
-          "target": ["surname"]
+          "target": [
+            "surname"
+          ]
         }
       ]
     },
@@ -819,7 +834,9 @@
             "modelName": "Review",
             "fieldName": "content"
           },
-          "target": ["content"]
+          "target": [
+            "content"
+          ]
         },
         {
           "messageName": "CreateReviewInput",
@@ -842,7 +859,10 @@
             "modelName": "Book",
             "fieldName": "id"
           },
-          "target": ["book", "id"]
+          "target": [
+            "book",
+            "id"
+          ]
         }
       ]
     },
@@ -857,7 +877,10 @@
             "messageName": "IdQueryInput"
           },
           "optional": true,
-          "target": ["book", "id"]
+          "target": [
+            "book",
+            "id"
+          ]
         }
       ]
     },
@@ -967,7 +990,9 @@
             "modelName": "Review",
             "fieldName": "id"
           },
-          "target": ["id"]
+          "target": [
+            "id"
+          ]
         }
       ]
     },
@@ -1031,7 +1056,9 @@
             "modelName": "Book",
             "fieldName": "title"
           },
-          "target": ["title"]
+          "target": [
+            "title"
+          ]
         },
         {
           "messageName": "CreateBookInput",
@@ -1054,7 +1081,10 @@
             "modelName": "Author",
             "fieldName": "id"
           },
-          "target": ["author", "id"]
+          "target": [
+            "author",
+            "id"
+          ]
         }
       ]
     },
@@ -1069,7 +1099,9 @@
             "modelName": "Book",
             "fieldName": "id"
           },
-          "target": ["id"]
+          "target": [
+            "id"
+          ]
         }
       ]
     },
@@ -1084,7 +1116,9 @@
             "modelName": "Book",
             "fieldName": "id"
           },
-          "target": ["id"]
+          "target": [
+            "id"
+          ]
         }
       ]
     }

--- a/schema/testdata/proto/attribute_embed/proto.json
+++ b/schema/testdata/proto/attribute_embed/proto.json
@@ -178,9 +178,7 @@
           "type": "ACTION_TYPE_GET",
           "implementation": "ACTION_IMPLEMENTATION_AUTO",
           "inputMessageName": "GetReviewInput",
-          "responseEmbeds": [
-            "book"
-          ]
+          "responseEmbeds": ["book"]
         }
       ],
       "permissions": [
@@ -290,9 +288,7 @@
           "type": "ACTION_TYPE_LIST",
           "implementation": "ACTION_IMPLEMENTATION_AUTO",
           "inputMessageName": "ListBooksInput",
-          "responseEmbeds": [
-            "author"
-          ]
+          "responseEmbeds": ["author"]
         },
         {
           "modelName": "Book",
@@ -307,10 +303,7 @@
           "type": "ACTION_TYPE_GET",
           "implementation": "ACTION_IMPLEMENTATION_AUTO",
           "inputMessageName": "GetBookInput",
-          "responseEmbeds": [
-            "code",
-            "author"
-          ]
+          "responseEmbeds": ["code", "author"]
         },
         {
           "modelName": "Book",
@@ -413,9 +406,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -452,9 +443,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -719,9 +708,7 @@
             "modelName": "Author",
             "fieldName": "firstName"
           },
-          "target": [
-            "firstName"
-          ]
+          "target": ["firstName"]
         },
         {
           "messageName": "CreateAuthorInput",
@@ -731,9 +718,7 @@
             "modelName": "Author",
             "fieldName": "surname"
           },
-          "target": [
-            "surname"
-          ]
+          "target": ["surname"]
         }
       ]
     },
@@ -834,9 +819,7 @@
             "modelName": "Review",
             "fieldName": "content"
           },
-          "target": [
-            "content"
-          ]
+          "target": ["content"]
         },
         {
           "messageName": "CreateReviewInput",
@@ -859,10 +842,7 @@
             "modelName": "Book",
             "fieldName": "id"
           },
-          "target": [
-            "book",
-            "id"
-          ]
+          "target": ["book", "id"]
         }
       ]
     },
@@ -877,10 +857,7 @@
             "messageName": "IdQueryInput"
           },
           "optional": true,
-          "target": [
-            "book",
-            "id"
-          ]
+          "target": ["book", "id"]
         }
       ]
     },
@@ -990,9 +967,7 @@
             "modelName": "Review",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -1056,9 +1031,7 @@
             "modelName": "Book",
             "fieldName": "title"
           },
-          "target": [
-            "title"
-          ]
+          "target": ["title"]
         },
         {
           "messageName": "CreateBookInput",
@@ -1081,10 +1054,7 @@
             "modelName": "Author",
             "fieldName": "id"
           },
-          "target": [
-            "author",
-            "id"
-          ]
+          "target": ["author", "id"]
         }
       ]
     },
@@ -1099,9 +1069,7 @@
             "modelName": "Book",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -1116,9 +1084,7 @@
             "modelName": "Book",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     }

--- a/schema/testdata/proto/create_inputs_missing_reln_valid/proto.json
+++ b/schema/testdata/proto/create_inputs_missing_reln_valid/proto.json
@@ -139,9 +139,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -178,9 +176,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -414,9 +410,7 @@
             "modelName": "Post",
             "fieldName": "content"
           },
-          "target": [
-            "content"
-          ]
+          "target": ["content"]
         },
         {
           "messageName": "CreatePostBInput",
@@ -439,10 +433,7 @@
             "modelName": "Author",
             "fieldName": "id"
           },
-          "target": [
-            "author",
-            "id"
-          ]
+          "target": ["author", "id"]
         }
       ]
     },
@@ -457,9 +448,7 @@
             "modelName": "Post",
             "fieldName": "content"
           },
-          "target": [
-            "content"
-          ]
+          "target": ["content"]
         },
         {
           "messageName": "CreatePostCInput",

--- a/schema/testdata/proto/create_inputs_missing_reln_valid/proto.json
+++ b/schema/testdata/proto/create_inputs_missing_reln_valid/proto.json
@@ -65,6 +65,17 @@
         },
         {
           "modelName": "Post",
+          "name": "authorId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Author",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Post",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -93,17 +104,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "Post",
-          "name": "authorId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Author",
-            "relatedModelField": "id"
           }
         }
       ],
@@ -139,7 +139,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -176,7 +178,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -410,7 +414,9 @@
             "modelName": "Post",
             "fieldName": "content"
           },
-          "target": ["content"]
+          "target": [
+            "content"
+          ]
         },
         {
           "messageName": "CreatePostBInput",
@@ -433,7 +439,10 @@
             "modelName": "Author",
             "fieldName": "id"
           },
-          "target": ["author", "id"]
+          "target": [
+            "author",
+            "id"
+          ]
         }
       ]
     },
@@ -448,7 +457,9 @@
             "modelName": "Post",
             "fieldName": "content"
           },
-          "target": ["content"]
+          "target": [
+            "content"
+          ]
         },
         {
           "messageName": "CreatePostCInput",

--- a/schema/testdata/proto/expression_identity_field_comparison/proto.json
+++ b/schema/testdata/proto/expression_identity_field_comparison/proto.json
@@ -230,9 +230,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -269,9 +267,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -505,9 +501,7 @@
             "modelName": "Post",
             "fieldName": "title"
           },
-          "target": [
-            "title"
-          ]
+          "target": ["title"]
         },
         {
           "messageName": "CreatePostInput",
@@ -540,10 +534,7 @@
             "modelName": "Publisher",
             "fieldName": "id"
           },
-          "target": [
-            "publisher",
-            "id"
-          ]
+          "target": ["publisher", "id"]
         }
       ]
     },
@@ -558,10 +549,7 @@
             "modelName": "Author",
             "fieldName": "id"
           },
-          "target": [
-            "owner",
-            "id"
-          ]
+          "target": ["owner", "id"]
         }
       ]
     }

--- a/schema/testdata/proto/expression_identity_field_comparison/proto.json
+++ b/schema/testdata/proto/expression_identity_field_comparison/proto.json
@@ -14,6 +14,17 @@
         },
         {
           "modelName": "Author",
+          "name": "identityId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Identity",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Author",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -42,17 +53,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "Author",
-          "name": "identityId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Identity",
-            "relatedModelField": "id"
           }
         }
       ]
@@ -71,6 +71,17 @@
         },
         {
           "modelName": "Publisher",
+          "name": "identityId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Identity",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Publisher",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -99,17 +110,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "Publisher",
-          "name": "identityId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Identity",
-            "relatedModelField": "id"
           }
         }
       ]
@@ -136,6 +136,18 @@
         },
         {
           "modelName": "Post",
+          "name": "ownerId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "optional": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Author",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Post",
           "name": "publisher",
           "type": {
             "type": "TYPE_MODEL",
@@ -143,6 +155,18 @@
           },
           "optional": true,
           "foreignKeyFieldName": "publisherId"
+        },
+        {
+          "modelName": "Post",
+          "name": "publisherId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "optional": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Publisher",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Post",
@@ -174,30 +198,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "Post",
-          "name": "ownerId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "optional": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Author",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Post",
-          "name": "publisherId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "optional": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Publisher",
-            "relatedModelField": "id"
           }
         }
       ],
@@ -230,7 +230,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -267,7 +269,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -501,7 +505,9 @@
             "modelName": "Post",
             "fieldName": "title"
           },
-          "target": ["title"]
+          "target": [
+            "title"
+          ]
         },
         {
           "messageName": "CreatePostInput",
@@ -534,7 +540,10 @@
             "modelName": "Publisher",
             "fieldName": "id"
           },
-          "target": ["publisher", "id"]
+          "target": [
+            "publisher",
+            "id"
+          ]
         }
       ]
     },
@@ -549,7 +558,10 @@
             "modelName": "Author",
             "fieldName": "id"
           },
-          "target": ["owner", "id"]
+          "target": [
+            "owner",
+            "id"
+          ]
         }
       ]
     }

--- a/schema/testdata/proto/expression_nullish_optional_comparison/proto.json
+++ b/schema/testdata/proto/expression_nullish_optional_comparison/proto.json
@@ -92,9 +92,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -131,9 +129,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/expression_nullish_optional_comparison/proto.json
+++ b/schema/testdata/proto/expression_nullish_optional_comparison/proto.json
@@ -15,6 +15,18 @@
         },
         {
           "modelName": "Post",
+          "name": "identityId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "optional": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Identity",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Post",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -43,18 +55,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "Post",
-          "name": "identityId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "optional": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Identity",
-            "relatedModelField": "id"
           }
         }
       ],
@@ -92,7 +92,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -129,7 +131,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/expressions/proto.json
+++ b/schema/testdata/proto/expressions/proto.json
@@ -36,6 +36,17 @@
         },
         {
           "modelName": "Person",
+          "name": "identityId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Identity",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Person",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -64,17 +75,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "Person",
-          "name": "identityId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Identity",
-            "relatedModelField": "id"
           }
         }
       ],
@@ -139,7 +139,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -176,7 +178,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -465,7 +469,9 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": ["name"]
+          "target": [
+            "name"
+          ]
         }
       ]
     },
@@ -525,7 +531,9 @@
             "modelName": "Person",
             "fieldName": "name"
           },
-          "target": ["name"]
+          "target": [
+            "name"
+          ]
         }
       ]
     },
@@ -540,7 +548,9 @@
             "modelName": "Person",
             "fieldName": "id"
           },
-          "target": ["id"]
+          "target": [
+            "id"
+          ]
         }
       ]
     },

--- a/schema/testdata/proto/expressions/proto.json
+++ b/schema/testdata/proto/expressions/proto.json
@@ -139,9 +139,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -178,9 +176,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -469,9 +465,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         }
       ]
     },
@@ -531,9 +525,7 @@
             "modelName": "Person",
             "fieldName": "name"
           },
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         }
       ]
     },
@@ -548,9 +540,7 @@
             "modelName": "Person",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },

--- a/schema/testdata/proto/expressions_compare_model_operand/proto.json
+++ b/schema/testdata/proto/expressions_compare_model_operand/proto.json
@@ -148,9 +148,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -187,9 +185,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -440,9 +436,7 @@
             "modelName": "BankAccount",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     }

--- a/schema/testdata/proto/expressions_compare_model_operand/proto.json
+++ b/schema/testdata/proto/expressions_compare_model_operand/proto.json
@@ -16,6 +16,18 @@
         },
         {
           "modelName": "User",
+          "name": "identityId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Identity",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "User",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -44,18 +56,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "User",
-          "name": "identityId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Identity",
-            "relatedModelField": "id"
           }
         }
       ]
@@ -76,6 +76,18 @@
         },
         {
           "modelName": "BankAccount",
+          "name": "identityId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Identity",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "BankAccount",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -104,18 +116,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "BankAccount",
-          "name": "identityId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Identity",
-            "relatedModelField": "id"
           }
         }
       ],
@@ -148,7 +148,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -185,7 +187,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -436,7 +440,9 @@
             "modelName": "BankAccount",
             "fieldName": "id"
           },
-          "target": ["id"]
+          "target": [
+            "id"
+          ]
         }
       ]
     }

--- a/schema/testdata/proto/field_optional_of_same_model_type/proto.json
+++ b/schema/testdata/proto/field_optional_of_same_model_type/proto.json
@@ -16,6 +16,18 @@
         },
         {
           "modelName": "Person",
+          "name": "motherId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "optional": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Person",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Person",
           "name": "children",
           "type": {
             "type": "TYPE_MODEL",
@@ -55,18 +67,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Person",
-          "name": "motherId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "optional": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Person",
-            "relatedModelField": "id"
-          }
         }
       ],
       "actions": [
@@ -89,7 +89,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -126,7 +128,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/field_optional_of_same_model_type/proto.json
+++ b/schema/testdata/proto/field_optional_of_same_model_type/proto.json
@@ -89,9 +89,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -128,9 +126,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/fields_attributes/proto.json
+++ b/schema/testdata/proto/fields_attributes/proto.json
@@ -95,9 +95,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -134,9 +132,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/fields_attributes/proto.json
+++ b/schema/testdata/proto/fields_attributes/proto.json
@@ -41,6 +41,18 @@
         },
         {
           "modelName": "Foo",
+          "name": "identityId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "optional": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Identity",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Foo",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -70,18 +82,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Foo",
-          "name": "identityId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "optional": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Identity",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -95,7 +95,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -132,7 +134,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/fields_types/proto.json
+++ b/schema/testdata/proto/fields_types/proto.json
@@ -124,9 +124,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -163,9 +161,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/fields_types/proto.json
+++ b/schema/testdata/proto/fields_types/proto.json
@@ -14,6 +14,17 @@
         },
         {
           "modelName": "Foo",
+          "name": "aId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Identity",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Foo",
           "name": "b",
           "type": {
             "type": "TYPE_STRING"
@@ -100,17 +111,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Foo",
-          "name": "aId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Identity",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -124,7 +124,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -161,7 +163,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/identity_backlinks/proto.json
+++ b/schema/testdata/proto/identity_backlinks/proto.json
@@ -16,6 +16,18 @@
         },
         {
           "modelName": "CompanyEmployee",
+          "name": "pIdentityId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Identity",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "CompanyEmployee",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -45,18 +57,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "CompanyEmployee",
-          "name": "pIdentityId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Identity",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -70,7 +70,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -107,7 +109,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/identity_backlinks/proto.json
+++ b/schema/testdata/proto/identity_backlinks/proto.json
@@ -70,9 +70,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -109,9 +107,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/identity_backlinks_relation_attribute/proto.json
+++ b/schema/testdata/proto/identity_backlinks_relation_attribute/proto.json
@@ -16,6 +16,18 @@
         },
         {
           "modelName": "CompanyEmployee",
+          "name": "abcIdentityId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Identity",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "CompanyEmployee",
           "name": "xyzIdentity",
           "type": {
             "type": "TYPE_MODEL",
@@ -24,6 +36,18 @@
           "unique": true,
           "foreignKeyFieldName": "xyzIdentityId",
           "inverseFieldName": "xyzEmployee"
+        },
+        {
+          "modelName": "CompanyEmployee",
+          "name": "xyzIdentityId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Identity",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "CompanyEmployee",
@@ -56,30 +80,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "CompanyEmployee",
-          "name": "abcIdentityId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Identity",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "CompanyEmployee",
-          "name": "xyzIdentityId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Identity",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -93,7 +93,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -130,7 +132,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/identity_backlinks_relation_attribute/proto.json
+++ b/schema/testdata/proto/identity_backlinks_relation_attribute/proto.json
@@ -93,9 +93,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -132,9 +130,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/operations_create_relationships/proto.json
+++ b/schema/testdata/proto/operations_create_relationships/proto.json
@@ -225,9 +225,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -264,9 +262,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -511,9 +507,7 @@
             "modelName": "Sale",
             "fieldName": "date"
           },
-          "target": [
-            "date"
-          ]
+          "target": ["date"]
         },
         {
           "messageName": "CreateSaleAndItemsInput",
@@ -545,10 +539,7 @@
             "modelName": "SaleItem",
             "fieldName": "quantity"
           },
-          "target": [
-            "items",
-            "quantity"
-          ]
+          "target": ["items", "quantity"]
         }
       ]
     },
@@ -563,11 +554,7 @@
             "modelName": "Product",
             "fieldName": "id"
           },
-          "target": [
-            "items",
-            "product",
-            "id"
-          ]
+          "target": ["items", "product", "id"]
         }
       ]
     },
@@ -582,9 +569,7 @@
             "modelName": "Sale",
             "fieldName": "date"
           },
-          "target": [
-            "date"
-          ]
+          "target": ["date"]
         },
         {
           "messageName": "CreateSaleAndProductInput",
@@ -616,10 +601,7 @@
             "modelName": "SaleItem",
             "fieldName": "quantity"
           },
-          "target": [
-            "items",
-            "quantity"
-          ]
+          "target": ["items", "quantity"]
         }
       ]
     },
@@ -634,11 +616,7 @@
             "modelName": "Product",
             "fieldName": "name"
           },
-          "target": [
-            "items",
-            "product",
-            "name"
-          ]
+          "target": ["items", "product", "name"]
         }
       ]
     },
@@ -669,9 +647,7 @@
             "modelName": "SaleItem",
             "fieldName": "quantity"
           },
-          "target": [
-            "quantity"
-          ]
+          "target": ["quantity"]
         }
       ]
     },
@@ -686,10 +662,7 @@
             "modelName": "Sale",
             "fieldName": "id"
           },
-          "target": [
-            "sale",
-            "id"
-          ]
+          "target": ["sale", "id"]
         }
       ]
     },
@@ -704,10 +677,7 @@
             "modelName": "Product",
             "fieldName": "id"
           },
-          "target": [
-            "product",
-            "id"
-          ]
+          "target": ["product", "id"]
         }
       ]
     },
@@ -738,9 +708,7 @@
             "modelName": "SaleItem",
             "fieldName": "quantity"
           },
-          "target": [
-            "quantity"
-          ]
+          "target": ["quantity"]
         }
       ]
     },
@@ -755,10 +723,7 @@
             "modelName": "Sale",
             "fieldName": "id"
           },
-          "target": [
-            "sale",
-            "id"
-          ]
+          "target": ["sale", "id"]
         }
       ]
     },
@@ -773,10 +738,7 @@
             "modelName": "Product",
             "fieldName": "name"
           },
-          "target": [
-            "product",
-            "name"
-          ]
+          "target": ["product", "name"]
         }
       ]
     }

--- a/schema/testdata/proto/operations_create_relationships/proto.json
+++ b/schema/testdata/proto/operations_create_relationships/proto.json
@@ -85,12 +85,34 @@
         },
         {
           "modelName": "SaleItem",
+          "name": "saleId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Sale",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "SaleItem",
           "name": "product",
           "type": {
             "type": "TYPE_MODEL",
             "modelName": "Product"
           },
           "foreignKeyFieldName": "productId"
+        },
+        {
+          "modelName": "SaleItem",
+          "name": "productId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Product",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "SaleItem",
@@ -129,28 +151,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "SaleItem",
-          "name": "saleId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Sale",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "SaleItem",
-          "name": "productId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Product",
-            "relatedModelField": "id"
           }
         }
       ],
@@ -225,7 +225,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -262,7 +264,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -507,7 +511,9 @@
             "modelName": "Sale",
             "fieldName": "date"
           },
-          "target": ["date"]
+          "target": [
+            "date"
+          ]
         },
         {
           "messageName": "CreateSaleAndItemsInput",
@@ -539,7 +545,10 @@
             "modelName": "SaleItem",
             "fieldName": "quantity"
           },
-          "target": ["items", "quantity"]
+          "target": [
+            "items",
+            "quantity"
+          ]
         }
       ]
     },
@@ -554,7 +563,11 @@
             "modelName": "Product",
             "fieldName": "id"
           },
-          "target": ["items", "product", "id"]
+          "target": [
+            "items",
+            "product",
+            "id"
+          ]
         }
       ]
     },
@@ -569,7 +582,9 @@
             "modelName": "Sale",
             "fieldName": "date"
           },
-          "target": ["date"]
+          "target": [
+            "date"
+          ]
         },
         {
           "messageName": "CreateSaleAndProductInput",
@@ -601,7 +616,10 @@
             "modelName": "SaleItem",
             "fieldName": "quantity"
           },
-          "target": ["items", "quantity"]
+          "target": [
+            "items",
+            "quantity"
+          ]
         }
       ]
     },
@@ -616,7 +634,11 @@
             "modelName": "Product",
             "fieldName": "name"
           },
-          "target": ["items", "product", "name"]
+          "target": [
+            "items",
+            "product",
+            "name"
+          ]
         }
       ]
     },
@@ -647,7 +669,9 @@
             "modelName": "SaleItem",
             "fieldName": "quantity"
           },
-          "target": ["quantity"]
+          "target": [
+            "quantity"
+          ]
         }
       ]
     },
@@ -662,7 +686,10 @@
             "modelName": "Sale",
             "fieldName": "id"
           },
-          "target": ["sale", "id"]
+          "target": [
+            "sale",
+            "id"
+          ]
         }
       ]
     },
@@ -677,7 +704,10 @@
             "modelName": "Product",
             "fieldName": "id"
           },
-          "target": ["product", "id"]
+          "target": [
+            "product",
+            "id"
+          ]
         }
       ]
     },
@@ -708,7 +738,9 @@
             "modelName": "SaleItem",
             "fieldName": "quantity"
           },
-          "target": ["quantity"]
+          "target": [
+            "quantity"
+          ]
         }
       ]
     },
@@ -723,7 +755,10 @@
             "modelName": "Sale",
             "fieldName": "id"
           },
-          "target": ["sale", "id"]
+          "target": [
+            "sale",
+            "id"
+          ]
         }
       ]
     },
@@ -738,7 +773,10 @@
             "modelName": "Product",
             "fieldName": "name"
           },
-          "target": ["product", "name"]
+          "target": [
+            "product",
+            "name"
+          ]
         }
       ]
     }

--- a/schema/testdata/proto/operations_list_nested_input_optional_model/proto.json
+++ b/schema/testdata/proto/operations_list_nested_input_optional_model/proto.json
@@ -201,9 +201,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -240,9 +238,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -488,11 +484,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": [
-            "author",
-            "publisher",
-            "name"
-          ]
+          "target": ["author", "publisher", "name"]
         }
       ]
     },

--- a/schema/testdata/proto/operations_list_nested_input_optional_model/proto.json
+++ b/schema/testdata/proto/operations_list_nested_input_optional_model/proto.json
@@ -70,6 +70,18 @@
         },
         {
           "modelName": "Author",
+          "name": "publisherId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "optional": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Publisher",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Author",
           "name": "books",
           "type": {
             "type": "TYPE_MODEL",
@@ -109,18 +121,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Author",
-          "name": "publisherId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "optional": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Publisher",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -136,6 +136,17 @@
           },
           "foreignKeyFieldName": "authorId",
           "inverseFieldName": "books"
+        },
+        {
+          "modelName": "Book",
+          "name": "authorId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Author",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Book",
@@ -168,17 +179,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Book",
-          "name": "authorId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Author",
-            "relatedModelField": "id"
-          }
         }
       ],
       "actions": [
@@ -201,7 +201,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -238,7 +240,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -484,7 +488,11 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": ["author", "publisher", "name"]
+          "target": [
+            "author",
+            "publisher",
+            "name"
+          ]
         }
       ]
     },

--- a/schema/testdata/proto/operations_nested_model_input/proto.json
+++ b/schema/testdata/proto/operations_nested_model_input/proto.json
@@ -283,9 +283,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -322,9 +320,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -591,12 +587,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": [
-            "theFi",
-            "theFo",
-            "theFum",
-            "theName"
-          ]
+          "target": ["theFi", "theFo", "theFum", "theName"]
         }
       ]
     },
@@ -750,12 +741,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": [
-            "theFos",
-            "theFis",
-            "theFees",
-            "theName"
-          ]
+          "target": ["theFos", "theFis", "theFees", "theName"]
         }
       ]
     },

--- a/schema/testdata/proto/operations_nested_model_input/proto.json
+++ b/schema/testdata/proto/operations_nested_model_input/proto.json
@@ -15,6 +15,17 @@
         },
         {
           "modelName": "Fee",
+          "name": "theFiId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Fi",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Fee",
           "name": "theName",
           "type": {
             "type": "TYPE_STRING"
@@ -51,17 +62,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Fee",
-          "name": "theFiId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Fi",
-            "relatedModelField": "id"
-          }
         }
       ],
       "actions": [
@@ -86,6 +86,17 @@
           },
           "foreignKeyFieldName": "theFoId",
           "inverseFieldName": "theFis"
+        },
+        {
+          "modelName": "Fi",
+          "name": "theFoId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Fo",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Fi",
@@ -128,17 +139,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Fi",
-          "name": "theFoId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Fo",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -154,6 +154,17 @@
           },
           "foreignKeyFieldName": "theFumId",
           "inverseFieldName": "theFos"
+        },
+        {
+          "modelName": "Fo",
+          "name": "theFumId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Fum",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Fo",
@@ -195,17 +206,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "Fo",
-          "name": "theFumId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Fum",
-            "relatedModelField": "id"
           }
         }
       ]
@@ -283,7 +283,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -320,7 +322,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -587,7 +591,12 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": ["theFi", "theFo", "theFum", "theName"]
+          "target": [
+            "theFi",
+            "theFo",
+            "theFum",
+            "theName"
+          ]
         }
       ]
     },
@@ -741,7 +750,12 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": ["theFos", "theFis", "theFees", "theName"]
+          "target": [
+            "theFos",
+            "theFis",
+            "theFees",
+            "theName"
+          ]
         }
       ]
     },

--- a/schema/testdata/proto/operations_update_mutate_id/proto.json
+++ b/schema/testdata/proto/operations_update_mutate_id/proto.json
@@ -169,9 +169,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -208,9 +206,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -450,9 +446,7 @@
             "modelName": "Person",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -467,9 +461,7 @@
             "modelName": "Person",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         },
         {
           "messageName": "UpdatePersonValues",
@@ -479,9 +471,7 @@
             "modelName": "Person",
             "fieldName": "name"
           },
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         }
       ]
     },
@@ -517,9 +507,7 @@
             "modelName": "Person",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -567,9 +555,7 @@
             "modelName": "Person",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -597,10 +583,7 @@
             "modelName": "Company",
             "fieldName": "id"
           },
-          "target": [
-            "employer",
-            "id"
-          ]
+          "target": ["employer", "id"]
         }
       ]
     },
@@ -636,9 +619,7 @@
             "modelName": "Person",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },

--- a/schema/testdata/proto/operations_update_mutate_id/proto.json
+++ b/schema/testdata/proto/operations_update_mutate_id/proto.json
@@ -22,6 +22,17 @@
         },
         {
           "modelName": "Person",
+          "name": "employerId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Company",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Person",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -50,17 +61,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "Person",
-          "name": "employerId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Company",
-            "relatedModelField": "id"
           }
         }
       ],
@@ -169,7 +169,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -206,7 +208,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -446,7 +450,9 @@
             "modelName": "Person",
             "fieldName": "id"
           },
-          "target": ["id"]
+          "target": [
+            "id"
+          ]
         }
       ]
     },
@@ -461,7 +467,9 @@
             "modelName": "Person",
             "fieldName": "id"
           },
-          "target": ["id"]
+          "target": [
+            "id"
+          ]
         },
         {
           "messageName": "UpdatePersonValues",
@@ -471,7 +479,9 @@
             "modelName": "Person",
             "fieldName": "name"
           },
-          "target": ["name"]
+          "target": [
+            "name"
+          ]
         }
       ]
     },
@@ -507,7 +517,9 @@
             "modelName": "Person",
             "fieldName": "id"
           },
-          "target": ["id"]
+          "target": [
+            "id"
+          ]
         }
       ]
     },
@@ -555,7 +567,9 @@
             "modelName": "Person",
             "fieldName": "id"
           },
-          "target": ["id"]
+          "target": [
+            "id"
+          ]
         }
       ]
     },
@@ -583,7 +597,10 @@
             "modelName": "Company",
             "fieldName": "id"
           },
-          "target": ["employer", "id"]
+          "target": [
+            "employer",
+            "id"
+          ]
         }
       ]
     },
@@ -619,7 +636,9 @@
             "modelName": "Person",
             "fieldName": "id"
           },
-          "target": ["id"]
+          "target": [
+            "id"
+          ]
         }
       ]
     },

--- a/schema/testdata/proto/optional_nested_input/proto.json
+++ b/schema/testdata/proto/optional_nested_input/proto.json
@@ -21,16 +21,6 @@
         },
         {
           "modelName": "Person",
-          "name": "previousCompany",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "Company"
-          },
-          "optional": true,
-          "foreignKeyFieldName": "previousCompanyId"
-        },
-        {
-          "modelName": "Person",
           "name": "companyId",
           "type": {
             "type": "TYPE_ID"
@@ -39,6 +29,16 @@
             "relatedModelName": "Company",
             "relatedModelField": "id"
           }
+        },
+        {
+          "modelName": "Person",
+          "name": "previousCompany",
+          "type": {
+            "type": "TYPE_MODEL",
+            "modelName": "Company"
+          },
+          "optional": true,
+          "foreignKeyFieldName": "previousCompanyId"
         },
         {
           "modelName": "Person",
@@ -171,7 +171,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -208,7 +210,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -444,7 +448,10 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": ["company", "name"]
+          "target": [
+            "company",
+            "name"
+          ]
         },
         {
           "messageName": "ListByCompanyCompanyInput",
@@ -453,7 +460,10 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": ["company", "tradingAs"]
+          "target": [
+            "company",
+            "tradingAs"
+          ]
         }
       ]
     },
@@ -581,7 +591,10 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": ["previousCompany", "name"]
+          "target": [
+            "previousCompany",
+            "name"
+          ]
         },
         {
           "messageName": "ListByPreviousCompanyPreviousCompanyInput",
@@ -590,7 +603,10 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": ["previousCompany", "tradingAs"]
+          "target": [
+            "previousCompany",
+            "tradingAs"
+          ]
         }
       ]
     },
@@ -663,7 +679,10 @@
             "messageName": "StringQueryInput"
           },
           "optional": true,
-          "target": ["company", "name"]
+          "target": [
+            "company",
+            "name"
+          ]
         },
         {
           "messageName": "ListByCompanyOptionalInputsCompanyInput",
@@ -673,7 +692,10 @@
             "messageName": "StringQueryInput"
           },
           "optional": true,
-          "target": ["company", "tradingAs"]
+          "target": [
+            "company",
+            "tradingAs"
+          ]
         }
       ]
     },

--- a/schema/testdata/proto/optional_nested_input/proto.json
+++ b/schema/testdata/proto/optional_nested_input/proto.json
@@ -171,9 +171,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -210,9 +208,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -448,10 +444,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": [
-            "company",
-            "name"
-          ]
+          "target": ["company", "name"]
         },
         {
           "messageName": "ListByCompanyCompanyInput",
@@ -460,10 +453,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": [
-            "company",
-            "tradingAs"
-          ]
+          "target": ["company", "tradingAs"]
         }
       ]
     },
@@ -591,10 +581,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": [
-            "previousCompany",
-            "name"
-          ]
+          "target": ["previousCompany", "name"]
         },
         {
           "messageName": "ListByPreviousCompanyPreviousCompanyInput",
@@ -603,10 +590,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": [
-            "previousCompany",
-            "tradingAs"
-          ]
+          "target": ["previousCompany", "tradingAs"]
         }
       ]
     },
@@ -679,10 +663,7 @@
             "messageName": "StringQueryInput"
           },
           "optional": true,
-          "target": [
-            "company",
-            "name"
-          ]
+          "target": ["company", "name"]
         },
         {
           "messageName": "ListByCompanyOptionalInputsCompanyInput",
@@ -692,10 +673,7 @@
             "messageName": "StringQueryInput"
           },
           "optional": true,
-          "target": [
-            "company",
-            "tradingAs"
-          ]
+          "target": ["company", "tradingAs"]
         }
       ]
     },

--- a/schema/testdata/proto/optional_nested_input/proto.json
+++ b/schema/testdata/proto/optional_nested_input/proto.json
@@ -21,6 +21,17 @@
         },
         {
           "modelName": "Person",
+          "name": "companyId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Company",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Person",
           "name": "previousCompany",
           "type": {
             "type": "TYPE_MODEL",
@@ -28,6 +39,18 @@
           },
           "optional": true,
           "foreignKeyFieldName": "previousCompanyId"
+        },
+        {
+          "modelName": "Person",
+          "name": "previousCompanyId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "optional": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Company",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Person",
@@ -59,29 +82,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "Person",
-          "name": "companyId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Company",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Person",
-          "name": "previousCompanyId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "optional": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Company",
-            "relatedModelField": "id"
           }
         }
       ],
@@ -171,7 +171,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -208,7 +210,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -444,7 +448,10 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": ["company", "name"]
+          "target": [
+            "company",
+            "name"
+          ]
         },
         {
           "messageName": "ListByCompanyCompanyInput",
@@ -453,7 +460,10 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": ["company", "tradingAs"]
+          "target": [
+            "company",
+            "tradingAs"
+          ]
         }
       ]
     },
@@ -581,7 +591,10 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": ["previousCompany", "name"]
+          "target": [
+            "previousCompany",
+            "name"
+          ]
         },
         {
           "messageName": "ListByPreviousCompanyPreviousCompanyInput",
@@ -590,7 +603,10 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringQueryInput"
           },
-          "target": ["previousCompany", "tradingAs"]
+          "target": [
+            "previousCompany",
+            "tradingAs"
+          ]
         }
       ]
     },
@@ -663,7 +679,10 @@
             "messageName": "StringQueryInput"
           },
           "optional": true,
-          "target": ["company", "name"]
+          "target": [
+            "company",
+            "name"
+          ]
         },
         {
           "messageName": "ListByCompanyOptionalInputsCompanyInput",
@@ -673,7 +692,10 @@
             "messageName": "StringQueryInput"
           },
           "optional": true,
-          "target": ["company", "tradingAs"]
+          "target": [
+            "company",
+            "tradingAs"
+          ]
         }
       ]
     },

--- a/schema/testdata/proto/optional_nested_input/proto.json
+++ b/schema/testdata/proto/optional_nested_input/proto.json
@@ -21,6 +21,16 @@
         },
         {
           "modelName": "Person",
+          "name": "previousCompany",
+          "type": {
+            "type": "TYPE_MODEL",
+            "modelName": "Company"
+          },
+          "optional": true,
+          "foreignKeyFieldName": "previousCompanyId"
+        },
+        {
+          "modelName": "Person",
           "name": "companyId",
           "type": {
             "type": "TYPE_ID"
@@ -29,16 +39,6 @@
             "relatedModelName": "Company",
             "relatedModelField": "id"
           }
-        },
-        {
-          "modelName": "Person",
-          "name": "previousCompany",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "Company"
-          },
-          "optional": true,
-          "foreignKeyFieldName": "previousCompanyId"
         },
         {
           "modelName": "Person",

--- a/schema/testdata/proto/permission_expression_with_identity/proto.json
+++ b/schema/testdata/proto/permission_expression_with_identity/proto.json
@@ -17,6 +17,19 @@
         },
         {
           "modelName": "Account",
+          "name": "identityId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "optional": true,
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Identity",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Account",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -46,19 +59,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Account",
-          "name": "identityId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "optional": true,
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Identity",
-            "relatedModelField": "id"
-          }
         }
       ],
       "actions": [
@@ -81,7 +81,9 @@
           "expression": {
             "source": "account.identity == ctx.identity"
           },
-          "actionTypes": ["ACTION_TYPE_CREATE"]
+          "actionTypes": [
+            "ACTION_TYPE_CREATE"
+          ]
         }
       ]
     },
@@ -95,7 +97,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -132,7 +136,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/permission_expression_with_identity/proto.json
+++ b/schema/testdata/proto/permission_expression_with_identity/proto.json
@@ -81,9 +81,7 @@
           "expression": {
             "source": "account.identity == ctx.identity"
           },
-          "actionTypes": [
-            "ACTION_TYPE_CREATE"
-          ]
+          "actionTypes": ["ACTION_TYPE_CREATE"]
         }
       ]
     },
@@ -97,9 +95,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -136,9 +132,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relations_both_sides/proto.json
+++ b/schema/testdata/proto/relations_both_sides/proto.json
@@ -115,9 +115,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -154,9 +152,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relations_both_sides/proto.json
+++ b/schema/testdata/proto/relations_both_sides/proto.json
@@ -62,6 +62,17 @@
         },
         {
           "modelName": "Post",
+          "name": "authorId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Account",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Post",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -91,17 +102,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Post",
-          "name": "authorId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Account",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -115,7 +115,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -152,7 +154,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relations_multi_uses_reln_attribute/proto.json
+++ b/schema/testdata/proto/relations_multi_uses_reln_attribute/proto.json
@@ -93,6 +93,16 @@
         },
         {
           "modelName": "Post",
+          "name": "favouritedBy",
+          "type": {
+            "type": "TYPE_MODEL",
+            "modelName": "Account",
+            "repeated": true
+          },
+          "inverseFieldName": "favourite"
+        },
+        {
+          "modelName": "Post",
           "name": "reviewerId",
           "type": {
             "type": "TYPE_ID"
@@ -101,16 +111,6 @@
             "relatedModelName": "Account",
             "relatedModelField": "id"
           }
-        },
-        {
-          "modelName": "Post",
-          "name": "favouritedBy",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "Account",
-            "repeated": true
-          },
-          "inverseFieldName": "favourite"
         },
         {
           "modelName": "Post",
@@ -177,7 +177,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -214,7 +216,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relations_multi_uses_reln_attribute/proto.json
+++ b/schema/testdata/proto/relations_multi_uses_reln_attribute/proto.json
@@ -15,6 +15,17 @@
         },
         {
           "modelName": "Account",
+          "name": "favouriteId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Post",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Account",
           "name": "authoredPosts",
           "type": {
             "type": "TYPE_MODEL",
@@ -64,17 +75,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Account",
-          "name": "favouriteId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Post",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -90,6 +90,17 @@
           },
           "foreignKeyFieldName": "reviewerId",
           "inverseFieldName": "reviewedPosts"
+        },
+        {
+          "modelName": "Post",
+          "name": "reviewerId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Account",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Post",
@@ -110,6 +121,17 @@
           },
           "foreignKeyFieldName": "authorId",
           "inverseFieldName": "authoredPosts"
+        },
+        {
+          "modelName": "Post",
+          "name": "authorId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Account",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Post",
@@ -142,28 +164,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Post",
-          "name": "reviewerId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Account",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Post",
-          "name": "authorId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Account",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -177,7 +177,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -214,7 +216,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relations_multi_uses_reln_attribute/proto.json
+++ b/schema/testdata/proto/relations_multi_uses_reln_attribute/proto.json
@@ -93,16 +93,6 @@
         },
         {
           "modelName": "Post",
-          "name": "favouritedBy",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "Account",
-            "repeated": true
-          },
-          "inverseFieldName": "favourite"
-        },
-        {
-          "modelName": "Post",
           "name": "reviewerId",
           "type": {
             "type": "TYPE_ID"
@@ -111,6 +101,16 @@
             "relatedModelName": "Account",
             "relatedModelField": "id"
           }
+        },
+        {
+          "modelName": "Post",
+          "name": "favouritedBy",
+          "type": {
+            "type": "TYPE_MODEL",
+            "modelName": "Account",
+            "repeated": true
+          },
+          "inverseFieldName": "favourite"
         },
         {
           "modelName": "Post",

--- a/schema/testdata/proto/relations_multi_uses_reln_attribute/proto.json
+++ b/schema/testdata/proto/relations_multi_uses_reln_attribute/proto.json
@@ -177,9 +177,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -216,9 +214,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relations_single/1.json
+++ b/schema/testdata/proto/relations_single/1.json
@@ -6,25 +6,25 @@
         {
           "modelName": "ChildModel",
           "name": "isActive",
-          "type": {
-            "type": "TYPE_BOOL"
-          }
+          "type": { "type": "TYPE_BOOL" }
         },
         {
           "modelName": "ChildModel",
           "name": "parent",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "ParentModel"
-          },
+          "type": { "type": "TYPE_MODEL", "modelName": "ParentModel" },
           "foreignKeyFieldName": "parentId"
         },
         {
           "modelName": "ChildModel",
+          "name": "parentOptional",
+          "type": { "type": "TYPE_MODEL", "modelName": "ParentModel" },
+          "optional": true,
+          "foreignKeyFieldName": "parentOptionalId"
+        },
+        {
+          "modelName": "ChildModel",
           "name": "parentId",
-          "type": {
-            "type": "TYPE_ID"
-          },
+          "type": { "type": "TYPE_ID" },
           "foreignKeyInfo": {
             "relatedModelName": "ParentModel",
             "relatedModelField": "id"
@@ -32,20 +32,8 @@
         },
         {
           "modelName": "ChildModel",
-          "name": "parentOptional",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "ParentModel"
-          },
-          "optional": true,
-          "foreignKeyFieldName": "parentOptionalId"
-        },
-        {
-          "modelName": "ChildModel",
           "name": "parentOptionalId",
-          "type": {
-            "type": "TYPE_ID"
-          },
+          "type": { "type": "TYPE_ID" },
           "optional": true,
           "foreignKeyInfo": {
             "relatedModelName": "ParentModel",
@@ -55,34 +43,22 @@
         {
           "modelName": "ChildModel",
           "name": "id",
-          "type": {
-            "type": "TYPE_ID"
-          },
+          "type": { "type": "TYPE_ID" },
           "unique": true,
           "primaryKey": true,
-          "defaultValue": {
-            "useZeroValue": true
-          }
+          "defaultValue": { "useZeroValue": true }
         },
         {
           "modelName": "ChildModel",
           "name": "createdAt",
-          "type": {
-            "type": "TYPE_DATETIME"
-          },
-          "defaultValue": {
-            "useZeroValue": true
-          }
+          "type": { "type": "TYPE_DATETIME" },
+          "defaultValue": { "useZeroValue": true }
         },
         {
           "modelName": "ChildModel",
           "name": "updatedAt",
-          "type": {
-            "type": "TYPE_DATETIME"
-          },
-          "defaultValue": {
-            "useZeroValue": true
-          }
+          "type": { "type": "TYPE_DATETIME" },
+          "defaultValue": { "useZeroValue": true }
         }
       ],
       "actions": [
@@ -91,6 +67,10 @@
           "name": "updateChild1",
           "type": "ACTION_TYPE_UPDATE",
           "implementation": "ACTION_IMPLEMENTATION_AUTO",
+          "setExpressions": [
+            { "source": "childModel.parentId = explicitParentId" },
+            { "source": "childModel.parentOptionalId = explicitParentId" }
+          ],
           "inputMessageName": "UpdateChild1Input"
         },
         {
@@ -98,6 +78,10 @@
           "name": "updateChild2",
           "type": "ACTION_TYPE_UPDATE",
           "implementation": "ACTION_IMPLEMENTATION_AUTO",
+          "setExpressions": [
+            { "source": "childModel.parentId = explicitParentId" },
+            { "source": "childModel.parentOptionalId = childModel.parentId" }
+          ],
           "inputMessageName": "UpdateChild2Input"
         },
         {
@@ -105,14 +89,10 @@
           "name": "updateChild3",
           "type": "ACTION_TYPE_UPDATE",
           "implementation": "ACTION_IMPLEMENTATION_AUTO",
+          "setExpressions": [
+            { "source": "childModel.parentId = explicitParentId" }
+          ],
           "inputMessageName": "UpdateChild3Input"
-        },
-        {
-          "modelName": "ChildModel",
-          "name": "updateChild4",
-          "type": "ACTION_TYPE_UPDATE",
-          "implementation": "ACTION_IMPLEMENTATION_AUTO",
-          "inputMessageName": "UpdateChild4Input"
         }
       ]
     },
@@ -122,41 +102,27 @@
         {
           "modelName": "ParentModel",
           "name": "isActive",
-          "type": {
-            "type": "TYPE_BOOL"
-          }
+          "type": { "type": "TYPE_BOOL" }
         },
         {
           "modelName": "ParentModel",
           "name": "id",
-          "type": {
-            "type": "TYPE_ID"
-          },
+          "type": { "type": "TYPE_ID" },
           "unique": true,
           "primaryKey": true,
-          "defaultValue": {
-            "useZeroValue": true
-          }
+          "defaultValue": { "useZeroValue": true }
         },
         {
           "modelName": "ParentModel",
           "name": "createdAt",
-          "type": {
-            "type": "TYPE_DATETIME"
-          },
-          "defaultValue": {
-            "useZeroValue": true
-          }
+          "type": { "type": "TYPE_DATETIME" },
+          "defaultValue": { "useZeroValue": true }
         },
         {
           "modelName": "ParentModel",
           "name": "updatedAt",
-          "type": {
-            "type": "TYPE_DATETIME"
-          },
-          "defaultValue": {
-            "useZeroValue": true
-          }
+          "type": { "type": "TYPE_DATETIME" },
+          "defaultValue": { "useZeroValue": true }
         }
       ]
     },
@@ -166,168 +132,120 @@
         {
           "modelName": "Identity",
           "name": "email",
-          "type": {
-            "type": "TYPE_STRING"
-          },
+          "type": { "type": "TYPE_STRING" },
           "optional": true,
           "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
           "name": "emailVerified",
-          "type": {
-            "type": "TYPE_BOOL"
-          },
-          "defaultValue": {
-            "expression": {
-              "source": "false"
-            }
-          }
+          "type": { "type": "TYPE_BOOL" },
+          "defaultValue": { "expression": { "source": "false" } }
         },
         {
           "modelName": "Identity",
           "name": "password",
-          "type": {
-            "type": "TYPE_PASSWORD"
-          },
+          "type": { "type": "TYPE_PASSWORD" },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "externalId",
-          "type": {
-            "type": "TYPE_STRING"
-          },
+          "type": { "type": "TYPE_STRING" },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "issuer",
-          "type": {
-            "type": "TYPE_STRING"
-          },
+          "type": { "type": "TYPE_STRING" },
           "optional": true,
           "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
           "name": "name",
-          "type": {
-            "type": "TYPE_STRING"
-          },
+          "type": { "type": "TYPE_STRING" },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "givenName",
-          "type": {
-            "type": "TYPE_STRING"
-          },
+          "type": { "type": "TYPE_STRING" },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "familyName",
-          "type": {
-            "type": "TYPE_STRING"
-          },
+          "type": { "type": "TYPE_STRING" },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "middleName",
-          "type": {
-            "type": "TYPE_STRING"
-          },
+          "type": { "type": "TYPE_STRING" },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "nickName",
-          "type": {
-            "type": "TYPE_STRING"
-          },
+          "type": { "type": "TYPE_STRING" },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "profile",
-          "type": {
-            "type": "TYPE_STRING"
-          },
+          "type": { "type": "TYPE_STRING" },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "picture",
-          "type": {
-            "type": "TYPE_STRING"
-          },
+          "type": { "type": "TYPE_STRING" },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "website",
-          "type": {
-            "type": "TYPE_STRING"
-          },
+          "type": { "type": "TYPE_STRING" },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "gender",
-          "type": {
-            "type": "TYPE_STRING"
-          },
+          "type": { "type": "TYPE_STRING" },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "zoneInfo",
-          "type": {
-            "type": "TYPE_STRING"
-          },
+          "type": { "type": "TYPE_STRING" },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "locale",
-          "type": {
-            "type": "TYPE_STRING"
-          },
+          "type": { "type": "TYPE_STRING" },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "id",
-          "type": {
-            "type": "TYPE_ID"
-          },
+          "type": { "type": "TYPE_ID" },
           "unique": true,
           "primaryKey": true,
-          "defaultValue": {
-            "useZeroValue": true
-          }
+          "defaultValue": { "useZeroValue": true }
         },
         {
           "modelName": "Identity",
           "name": "createdAt",
-          "type": {
-            "type": "TYPE_DATETIME"
-          },
-          "defaultValue": {
-            "useZeroValue": true
-          }
+          "type": { "type": "TYPE_DATETIME" },
+          "defaultValue": { "useZeroValue": true }
         },
         {
           "modelName": "Identity",
           "name": "updatedAt",
-          "type": {
-            "type": "TYPE_DATETIME"
-          },
-          "defaultValue": {
-            "useZeroValue": true
-          }
+          "type": { "type": "TYPE_DATETIME" },
+          "defaultValue": { "useZeroValue": true }
         }
       ],
       "actions": [
@@ -357,85 +275,56 @@
         {
           "modelName": "ChildModel",
           "modelActions": [
-            {
-              "actionName": "updateChild1"
-            },
-            {
-              "actionName": "updateChild2"
-            },
-            {
-              "actionName": "updateChild3"
-            },
-            {
-              "actionName": "updateChild4"
-            }
+            { "actionName": "updateChild1" },
+            { "actionName": "updateChild2" },
+            { "actionName": "updateChild3" }
           ]
         },
-        {
-          "modelName": "ParentModel"
-        },
+        { "modelName": "ParentModel" },
         {
           "modelName": "Identity",
           "modelActions": [
-            {
-              "actionName": "requestPasswordReset"
-            },
-            {
-              "actionName": "resetPassword"
-            }
+            { "actionName": "requestPasswordReset" },
+            { "actionName": "resetPassword" }
           ]
         }
       ]
     }
   ],
   "messages": [
-    {
-      "name": "Any"
-    },
+    { "name": "Any" },
     {
       "name": "RequestPasswordResetInput",
       "fields": [
         {
           "messageName": "RequestPasswordResetInput",
           "name": "email",
-          "type": {
-            "type": "TYPE_STRING"
-          }
+          "type": { "type": "TYPE_STRING" }
         },
         {
           "messageName": "RequestPasswordResetInput",
           "name": "redirectUrl",
-          "type": {
-            "type": "TYPE_STRING"
-          }
+          "type": { "type": "TYPE_STRING" }
         }
       ]
     },
-    {
-      "name": "RequestPasswordResetResponse"
-    },
+    { "name": "RequestPasswordResetResponse" },
     {
       "name": "ResetPasswordInput",
       "fields": [
         {
           "messageName": "ResetPasswordInput",
           "name": "token",
-          "type": {
-            "type": "TYPE_STRING"
-          }
+          "type": { "type": "TYPE_STRING" }
         },
         {
           "messageName": "ResetPasswordInput",
           "name": "password",
-          "type": {
-            "type": "TYPE_STRING"
-          }
+          "type": { "type": "TYPE_STRING" }
         }
       ]
     },
-    {
-      "name": "ResetPasswordResponse"
-    },
+    { "name": "ResetPasswordResponse" },
     {
       "name": "UpdateChild1Where",
       "fields": [
@@ -466,26 +355,8 @@
         },
         {
           "messageName": "UpdateChild1Values",
-          "name": "parent",
-          "type": {
-            "type": "TYPE_MESSAGE",
-            "messageName": "UpdateChild1ParentInput"
-          }
-        }
-      ]
-    },
-    {
-      "name": "UpdateChild1ParentInput",
-      "fields": [
-        {
-          "messageName": "UpdateChild1ParentInput",
-          "name": "id",
-          "type": {
-            "type": "TYPE_ID",
-            "modelName": "ParentModel",
-            "fieldName": "id"
-          },
-          "target": ["parent", "id"]
+          "name": "explicitParentId",
+          "type": { "type": "TYPE_ID" }
         }
       ]
     },
@@ -495,10 +366,7 @@
         {
           "messageName": "UpdateChild1Input",
           "name": "where",
-          "type": {
-            "type": "TYPE_MESSAGE",
-            "messageName": "UpdateChild1Where"
-          }
+          "type": { "type": "TYPE_MESSAGE", "messageName": "UpdateChild1Where" }
         },
         {
           "messageName": "UpdateChild1Input",
@@ -540,13 +408,8 @@
         },
         {
           "messageName": "UpdateChild2Values",
-          "name": "parentId",
-          "type": {
-            "type": "TYPE_ID",
-            "modelName": "ChildModel",
-            "fieldName": "parentId"
-          },
-          "target": ["parentId"]
+          "name": "explicitParentId",
+          "type": { "type": "TYPE_ID" }
         }
       ]
     },
@@ -556,10 +419,7 @@
         {
           "messageName": "UpdateChild2Input",
           "name": "where",
-          "type": {
-            "type": "TYPE_MESSAGE",
-            "messageName": "UpdateChild2Where"
-          }
+          "type": { "type": "TYPE_MESSAGE", "messageName": "UpdateChild2Where" }
         },
         {
           "messageName": "UpdateChild2Input",
@@ -601,50 +461,8 @@
         },
         {
           "messageName": "UpdateChild3Values",
-          "name": "parent",
-          "type": {
-            "type": "TYPE_MESSAGE",
-            "messageName": "UpdateChild3ParentInput"
-          }
-        },
-        {
-          "messageName": "UpdateChild3Values",
-          "name": "parentOptional",
-          "type": {
-            "type": "TYPE_MESSAGE",
-            "messageName": "UpdateChild3ParentOptionalInput"
-          },
-          "nullable": true
-        }
-      ]
-    },
-    {
-      "name": "UpdateChild3ParentInput",
-      "fields": [
-        {
-          "messageName": "UpdateChild3ParentInput",
-          "name": "id",
-          "type": {
-            "type": "TYPE_ID",
-            "modelName": "ParentModel",
-            "fieldName": "id"
-          },
-          "target": ["parent", "id"]
-        }
-      ]
-    },
-    {
-      "name": "UpdateChild3ParentOptionalInput",
-      "fields": [
-        {
-          "messageName": "UpdateChild3ParentOptionalInput",
-          "name": "id",
-          "type": {
-            "type": "TYPE_ID",
-            "modelName": "ParentModel",
-            "fieldName": "id"
-          },
-          "target": ["parentOptional", "id"]
+          "name": "explicitParentId",
+          "type": { "type": "TYPE_ID" }
         }
       ]
     },
@@ -654,10 +472,7 @@
         {
           "messageName": "UpdateChild3Input",
           "name": "where",
-          "type": {
-            "type": "TYPE_MESSAGE",
-            "messageName": "UpdateChild3Where"
-          }
+          "type": { "type": "TYPE_MESSAGE", "messageName": "UpdateChild3Where" }
         },
         {
           "messageName": "UpdateChild3Input",
@@ -665,78 +480,6 @@
           "type": {
             "type": "TYPE_MESSAGE",
             "messageName": "UpdateChild3Values"
-          }
-        }
-      ]
-    },
-    {
-      "name": "UpdateChild4Where",
-      "fields": [
-        {
-          "messageName": "UpdateChild4Where",
-          "name": "id",
-          "type": {
-            "type": "TYPE_ID",
-            "modelName": "ChildModel",
-            "fieldName": "id"
-          },
-          "target": ["id"]
-        }
-      ]
-    },
-    {
-      "name": "UpdateChild4Values",
-      "fields": [
-        {
-          "messageName": "UpdateChild4Values",
-          "name": "isActive",
-          "type": {
-            "type": "TYPE_BOOL",
-            "modelName": "ChildModel",
-            "fieldName": "isActive"
-          },
-          "target": ["isActive"]
-        },
-        {
-          "messageName": "UpdateChild4Values",
-          "name": "parentId",
-          "type": {
-            "type": "TYPE_ID",
-            "modelName": "ChildModel",
-            "fieldName": "parentId"
-          },
-          "target": ["parentId"]
-        },
-        {
-          "messageName": "UpdateChild4Values",
-          "name": "parentOptionalId",
-          "type": {
-            "type": "TYPE_ID",
-            "modelName": "ChildModel",
-            "fieldName": "parentOptionalId"
-          },
-          "nullable": true,
-          "target": ["parentOptionalId"]
-        }
-      ]
-    },
-    {
-      "name": "UpdateChild4Input",
-      "fields": [
-        {
-          "messageName": "UpdateChild4Input",
-          "name": "where",
-          "type": {
-            "type": "TYPE_MESSAGE",
-            "messageName": "UpdateChild4Where"
-          }
-        },
-        {
-          "messageName": "UpdateChild4Input",
-          "name": "values",
-          "type": {
-            "type": "TYPE_MESSAGE",
-            "messageName": "UpdateChild4Values"
           }
         }
       ]

--- a/schema/testdata/proto/relations_single/proto.json
+++ b/schema/testdata/proto/relations_single/proto.json
@@ -104,9 +104,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -143,9 +141,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relations_single/proto.json
+++ b/schema/testdata/proto/relations_single/proto.json
@@ -51,6 +51,17 @@
         },
         {
           "modelName": "Book",
+          "name": "authorId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Person",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Book",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -80,17 +91,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Book",
-          "name": "authorId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Person",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -104,7 +104,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -141,7 +143,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_create_with_explicit_input/proto.json
+++ b/schema/testdata/proto/relationships_create_with_explicit_input/proto.json
@@ -184,9 +184,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -223,9 +221,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -462,9 +458,7 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": [
-            "isActive"
-          ]
+          "target": ["isActive"]
         },
         {
           "messageName": "CreateChild1Input",
@@ -486,9 +480,7 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": [
-            "isActive"
-          ]
+          "target": ["isActive"]
         },
         {
           "messageName": "CreateChild2Input",
@@ -510,9 +502,7 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": [
-            "isActive"
-          ]
+          "target": ["isActive"]
         },
         {
           "messageName": "CreateChild3Input",

--- a/schema/testdata/proto/relationships_create_with_explicit_input/proto.json
+++ b/schema/testdata/proto/relationships_create_with_explicit_input/proto.json
@@ -21,6 +21,17 @@
         },
         {
           "modelName": "ChildModel",
+          "name": "parentId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "ParentModel",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "ChildModel",
           "name": "parentOptional",
           "type": {
             "type": "TYPE_MODEL",
@@ -28,6 +39,18 @@
           },
           "optional": true,
           "foreignKeyFieldName": "parentOptionalId"
+        },
+        {
+          "modelName": "ChildModel",
+          "name": "parentOptionalId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "optional": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "ParentModel",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "ChildModel",
@@ -59,29 +82,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "ChildModel",
-          "name": "parentId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "ParentModel",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "ChildModel",
-          "name": "parentOptionalId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "optional": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "ParentModel",
-            "relatedModelField": "id"
           }
         }
       ],
@@ -184,7 +184,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -221,7 +223,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -458,7 +462,9 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": ["isActive"]
+          "target": [
+            "isActive"
+          ]
         },
         {
           "messageName": "CreateChild1Input",
@@ -480,7 +486,9 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": ["isActive"]
+          "target": [
+            "isActive"
+          ]
         },
         {
           "messageName": "CreateChild2Input",
@@ -502,7 +510,9 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": ["isActive"]
+          "target": [
+            "isActive"
+          ]
         },
         {
           "messageName": "CreateChild3Input",

--- a/schema/testdata/proto/relationships_create_with_implicit_input/proto.json
+++ b/schema/testdata/proto/relationships_create_with_implicit_input/proto.json
@@ -156,9 +156,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -195,9 +193,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -431,9 +427,7 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": [
-            "isActive"
-          ]
+          "target": ["isActive"]
         },
         {
           "messageName": "CreateChild1Input",
@@ -456,10 +450,7 @@
             "modelName": "ParentModel",
             "fieldName": "id"
           },
-          "target": [
-            "parent",
-            "id"
-          ]
+          "target": ["parent", "id"]
         }
       ]
     },
@@ -474,9 +465,7 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": [
-            "isActive"
-          ]
+          "target": ["isActive"]
         },
         {
           "messageName": "CreateChild2Input",
@@ -508,10 +497,7 @@
             "modelName": "ParentModel",
             "fieldName": "id"
           },
-          "target": [
-            "parent",
-            "id"
-          ]
+          "target": ["parent", "id"]
         }
       ]
     },
@@ -526,10 +512,7 @@
             "modelName": "ParentModel",
             "fieldName": "id"
           },
-          "target": [
-            "parentOptional",
-            "id"
-          ]
+          "target": ["parentOptional", "id"]
         }
       ]
     }

--- a/schema/testdata/proto/relationships_create_with_implicit_input/proto.json
+++ b/schema/testdata/proto/relationships_create_with_implicit_input/proto.json
@@ -21,6 +21,17 @@
         },
         {
           "modelName": "ChildModel",
+          "name": "parentId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "ParentModel",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "ChildModel",
           "name": "parentOptional",
           "type": {
             "type": "TYPE_MODEL",
@@ -28,6 +39,18 @@
           },
           "optional": true,
           "foreignKeyFieldName": "parentOptionalId"
+        },
+        {
+          "modelName": "ChildModel",
+          "name": "parentOptionalId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "optional": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "ParentModel",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "ChildModel",
@@ -59,29 +82,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "ChildModel",
-          "name": "parentId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "ParentModel",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "ChildModel",
-          "name": "parentOptionalId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "optional": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "ParentModel",
-            "relatedModelField": "id"
           }
         }
       ],
@@ -156,7 +156,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -193,7 +195,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -427,7 +431,9 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": ["isActive"]
+          "target": [
+            "isActive"
+          ]
         },
         {
           "messageName": "CreateChild1Input",
@@ -450,7 +456,10 @@
             "modelName": "ParentModel",
             "fieldName": "id"
           },
-          "target": ["parent", "id"]
+          "target": [
+            "parent",
+            "id"
+          ]
         }
       ]
     },
@@ -465,7 +474,9 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": ["isActive"]
+          "target": [
+            "isActive"
+          ]
         },
         {
           "messageName": "CreateChild2Input",
@@ -497,7 +508,10 @@
             "modelName": "ParentModel",
             "fieldName": "id"
           },
-          "target": ["parent", "id"]
+          "target": [
+            "parent",
+            "id"
+          ]
         }
       ]
     },
@@ -512,7 +526,10 @@
             "modelName": "ParentModel",
             "fieldName": "id"
           },
-          "target": ["parentOptional", "id"]
+          "target": [
+            "parentOptional",
+            "id"
+          ]
         }
       ]
     }

--- a/schema/testdata/proto/relationships_mixed/proto.json
+++ b/schema/testdata/proto/relationships_mixed/proto.json
@@ -25,6 +25,16 @@
         },
         {
           "modelName": "Author",
+          "name": "starPost",
+          "type": {
+            "type": "TYPE_MODEL",
+            "modelName": "Post"
+          },
+          "unique": true,
+          "foreignKeyFieldName": "starPostId"
+        },
+        {
+          "modelName": "Author",
           "name": "reviewedId",
           "type": {
             "type": "TYPE_ID"
@@ -33,16 +43,6 @@
             "relatedModelName": "Post",
             "relatedModelField": "id"
           }
-        },
-        {
-          "modelName": "Author",
-          "name": "starPost",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "Post"
-          },
-          "unique": true,
-          "foreignKeyFieldName": "starPostId"
         },
         {
           "modelName": "Author",
@@ -168,7 +168,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -205,7 +207,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_mixed/proto.json
+++ b/schema/testdata/proto/relationships_mixed/proto.json
@@ -25,6 +25,17 @@
         },
         {
           "modelName": "Author",
+          "name": "reviewedId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Post",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Author",
           "name": "starPost",
           "type": {
             "type": "TYPE_MODEL",
@@ -32,6 +43,18 @@
           },
           "unique": true,
           "foreignKeyFieldName": "starPostId"
+        },
+        {
+          "modelName": "Author",
+          "name": "starPostId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Post",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Author",
@@ -64,29 +87,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Author",
-          "name": "reviewedId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Post",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Author",
-          "name": "starPostId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Post",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -102,6 +102,17 @@
           },
           "foreignKeyFieldName": "authorId",
           "inverseFieldName": "written"
+        },
+        {
+          "modelName": "Post",
+          "name": "authorId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Author",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Post",
@@ -144,17 +155,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Post",
-          "name": "authorId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Author",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -168,7 +168,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -205,7 +207,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_mixed/proto.json
+++ b/schema/testdata/proto/relationships_mixed/proto.json
@@ -25,16 +25,6 @@
         },
         {
           "modelName": "Author",
-          "name": "starPost",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "Post"
-          },
-          "unique": true,
-          "foreignKeyFieldName": "starPostId"
-        },
-        {
-          "modelName": "Author",
           "name": "reviewedId",
           "type": {
             "type": "TYPE_ID"
@@ -43,6 +33,16 @@
             "relatedModelName": "Post",
             "relatedModelField": "id"
           }
+        },
+        {
+          "modelName": "Author",
+          "name": "starPost",
+          "type": {
+            "type": "TYPE_MODEL",
+            "modelName": "Post"
+          },
+          "unique": true,
+          "foreignKeyFieldName": "starPostId"
         },
         {
           "modelName": "Author",

--- a/schema/testdata/proto/relationships_mixed/proto.json
+++ b/schema/testdata/proto/relationships_mixed/proto.json
@@ -168,9 +168,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -207,9 +205,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_mixed_one_to_many_single_sided/proto.json
+++ b/schema/testdata/proto/relationships_mixed_one_to_many_single_sided/proto.json
@@ -167,9 +167,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -206,9 +204,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_mixed_one_to_many_single_sided/proto.json
+++ b/schema/testdata/proto/relationships_mixed_one_to_many_single_sided/proto.json
@@ -15,6 +15,17 @@
         },
         {
           "modelName": "Author",
+          "name": "writtenId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Post",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Author",
           "name": "coWritten",
           "type": {
             "type": "TYPE_MODEL",
@@ -25,6 +36,17 @@
         },
         {
           "modelName": "Author",
+          "name": "coWrittenId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Post",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Author",
           "name": "reviewed",
           "type": {
             "type": "TYPE_MODEL",
@@ -32,6 +54,17 @@
           },
           "foreignKeyFieldName": "reviewedId",
           "inverseFieldName": "coAuthor"
+        },
+        {
+          "modelName": "Author",
+          "name": "reviewedId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Post",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Author",
@@ -63,39 +96,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "Author",
-          "name": "writtenId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Post",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Author",
-          "name": "coWrittenId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Post",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Author",
-          "name": "reviewedId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Post",
-            "relatedModelField": "id"
           }
         }
       ]
@@ -167,7 +167,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -204,7 +206,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_mixed_one_to_many_single_sided/proto.json
+++ b/schema/testdata/proto/relationships_mixed_one_to_many_single_sided/proto.json
@@ -15,17 +15,6 @@
         },
         {
           "modelName": "Author",
-          "name": "writtenId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Post",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Author",
           "name": "coWritten",
           "type": {
             "type": "TYPE_MODEL",
@@ -37,6 +26,17 @@
         {
           "modelName": "Author",
           "name": "coWrittenId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Post",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Author",
+          "name": "writtenId",
           "type": {
             "type": "TYPE_ID"
           },
@@ -167,7 +167,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -204,7 +206,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_mixed_one_to_many_single_sided/proto.json
+++ b/schema/testdata/proto/relationships_mixed_one_to_many_single_sided/proto.json
@@ -15,6 +15,17 @@
         },
         {
           "modelName": "Author",
+          "name": "writtenId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Post",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Author",
           "name": "coWritten",
           "type": {
             "type": "TYPE_MODEL",
@@ -26,17 +37,6 @@
         {
           "modelName": "Author",
           "name": "coWrittenId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Post",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Author",
-          "name": "writtenId",
           "type": {
             "type": "TYPE_ID"
           },

--- a/schema/testdata/proto/relationships_mixed_one_to_one_single_sided/proto.json
+++ b/schema/testdata/proto/relationships_mixed_one_to_one_single_sided/proto.json
@@ -15,6 +15,17 @@
         },
         {
           "modelName": "Author",
+          "name": "writtenId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Post",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Author",
           "name": "coWritten",
           "type": {
             "type": "TYPE_MODEL",
@@ -25,6 +36,17 @@
         },
         {
           "modelName": "Author",
+          "name": "coWrittenId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Post",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Author",
           "name": "reviewed",
           "type": {
             "type": "TYPE_MODEL",
@@ -32,6 +54,18 @@
           },
           "unique": true,
           "foreignKeyFieldName": "reviewedId"
+        },
+        {
+          "modelName": "Author",
+          "name": "reviewedId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Post",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Author",
@@ -63,40 +97,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "Author",
-          "name": "writtenId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Post",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Author",
-          "name": "coWrittenId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Post",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Author",
-          "name": "reviewedId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Post",
-            "relatedModelField": "id"
           }
         }
       ]
@@ -168,7 +168,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -205,7 +207,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_mixed_one_to_one_single_sided/proto.json
+++ b/schema/testdata/proto/relationships_mixed_one_to_one_single_sided/proto.json
@@ -15,6 +15,17 @@
         },
         {
           "modelName": "Author",
+          "name": "writtenId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Post",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Author",
           "name": "coWritten",
           "type": {
             "type": "TYPE_MODEL",
@@ -25,7 +36,7 @@
         },
         {
           "modelName": "Author",
-          "name": "writtenId",
+          "name": "coWrittenId",
           "type": {
             "type": "TYPE_ID"
           },
@@ -43,17 +54,6 @@
           },
           "unique": true,
           "foreignKeyFieldName": "reviewedId"
-        },
-        {
-          "modelName": "Author",
-          "name": "coWrittenId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Post",
-            "relatedModelField": "id"
-          }
         },
         {
           "modelName": "Author",
@@ -168,9 +168,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -207,9 +205,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_mixed_one_to_one_single_sided/proto.json
+++ b/schema/testdata/proto/relationships_mixed_one_to_one_single_sided/proto.json
@@ -168,9 +168,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -207,9 +205,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_mixed_one_to_one_single_sided/proto.json
+++ b/schema/testdata/proto/relationships_mixed_one_to_one_single_sided/proto.json
@@ -15,17 +15,6 @@
         },
         {
           "modelName": "Author",
-          "name": "writtenId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Post",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Author",
           "name": "coWritten",
           "type": {
             "type": "TYPE_MODEL",
@@ -37,6 +26,17 @@
         {
           "modelName": "Author",
           "name": "coWrittenId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Post",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Author",
+          "name": "writtenId",
           "type": {
             "type": "TYPE_ID"
           },
@@ -168,7 +168,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -205,7 +207,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_mixed_one_to_one_single_sided/proto.json
+++ b/schema/testdata/proto/relationships_mixed_one_to_one_single_sided/proto.json
@@ -25,17 +25,6 @@
         },
         {
           "modelName": "Author",
-          "name": "coWrittenId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Post",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Author",
           "name": "writtenId",
           "type": {
             "type": "TYPE_ID"
@@ -54,6 +43,17 @@
           },
           "unique": true,
           "foreignKeyFieldName": "reviewedId"
+        },
+        {
+          "modelName": "Author",
+          "name": "coWrittenId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Post",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Author",

--- a/schema/testdata/proto/relationships_mixed_one_to_one_single_sided_2/proto.json
+++ b/schema/testdata/proto/relationships_mixed_one_to_one_single_sided_2/proto.json
@@ -15,6 +15,17 @@
         },
         {
           "modelName": "Author",
+          "name": "writtenId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Post",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Author",
           "name": "coWritten",
           "type": {
             "type": "TYPE_MODEL",
@@ -22,6 +33,17 @@
           },
           "foreignKeyFieldName": "coWrittenId",
           "inverseFieldName": "coAuthor"
+        },
+        {
+          "modelName": "Author",
+          "name": "coWrittenId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Post",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Author",
@@ -54,28 +76,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Author",
-          "name": "writtenId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Post",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Author",
-          "name": "coWrittenId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Post",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -91,6 +91,18 @@
           },
           "unique": true,
           "foreignKeyFieldName": "reviewedId"
+        },
+        {
+          "modelName": "Post",
+          "name": "reviewedId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Author",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Post",
@@ -143,18 +155,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Post",
-          "name": "reviewedId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Author",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -168,7 +168,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -205,7 +207,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_mixed_one_to_one_single_sided_2/proto.json
+++ b/schema/testdata/proto/relationships_mixed_one_to_one_single_sided_2/proto.json
@@ -168,9 +168,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -207,9 +205,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_mixed_with_self_relationship/proto.json
+++ b/schema/testdata/proto/relationships_mixed_with_self_relationship/proto.json
@@ -182,9 +182,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -221,9 +219,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_mixed_with_self_relationship/proto.json
+++ b/schema/testdata/proto/relationships_mixed_with_self_relationship/proto.json
@@ -16,6 +16,18 @@
         },
         {
           "modelName": "Company",
+          "name": "ownerId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Person",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Company",
           "name": "employees",
           "type": {
             "type": "TYPE_MODEL",
@@ -35,6 +47,19 @@
           "unique": true,
           "foreignKeyFieldName": "parentCompanyId",
           "inverseFieldName": "childCompany"
+        },
+        {
+          "modelName": "Company",
+          "name": "parentCompanyId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "optional": true,
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Company",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Company",
@@ -77,31 +102,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Company",
-          "name": "ownerId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Person",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Company",
-          "name": "parentCompanyId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "optional": true,
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Company",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -117,6 +117,17 @@
           },
           "foreignKeyFieldName": "employedById",
           "inverseFieldName": "employees"
+        },
+        {
+          "modelName": "Person",
+          "name": "employedById",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Company",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Person",
@@ -158,17 +169,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Person",
-          "name": "employedById",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Company",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -182,7 +182,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -219,7 +221,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_many_multi_one_sided/proto.json
+++ b/schema/testdata/proto/relationships_one_to_many_multi_one_sided/proto.json
@@ -124,9 +124,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -163,9 +161,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_many_multi_one_sided/proto.json
+++ b/schema/testdata/proto/relationships_one_to_many_multi_one_sided/proto.json
@@ -14,6 +14,17 @@
         },
         {
           "modelName": "Post",
+          "name": "authorId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Author",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Post",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -42,17 +53,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "Post",
-          "name": "authorId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Author",
-            "relatedModelField": "id"
           }
         }
       ]
@@ -71,6 +71,17 @@
         },
         {
           "modelName": "Author",
+          "name": "postId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Post",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Author",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -100,17 +111,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Author",
-          "name": "postId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Post",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -124,7 +124,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -161,7 +163,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_many_multi_one_sided_same_side/proto.json
+++ b/schema/testdata/proto/relationships_one_to_many_multi_one_sided_same_side/proto.json
@@ -14,6 +14,15 @@
         },
         {
           "modelName": "Post",
+          "name": "coAuthor",
+          "type": {
+            "type": "TYPE_MODEL",
+            "modelName": "Author"
+          },
+          "foreignKeyFieldName": "coAuthorId"
+        },
+        {
+          "modelName": "Post",
           "name": "authorId",
           "type": {
             "type": "TYPE_ID"
@@ -22,15 +31,6 @@
             "relatedModelName": "Author",
             "relatedModelField": "id"
           }
-        },
-        {
-          "modelName": "Post",
-          "name": "coAuthor",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "Author"
-          },
-          "foreignKeyFieldName": "coAuthorId"
         },
         {
           "modelName": "Post",
@@ -124,7 +124,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -161,7 +163,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_many_multi_one_sided_same_side/proto.json
+++ b/schema/testdata/proto/relationships_one_to_many_multi_one_sided_same_side/proto.json
@@ -124,9 +124,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -163,9 +161,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_many_multi_one_sided_same_side/proto.json
+++ b/schema/testdata/proto/relationships_one_to_many_multi_one_sided_same_side/proto.json
@@ -23,6 +23,28 @@
         },
         {
           "modelName": "Post",
+          "name": "authorId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Author",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Post",
+          "name": "coAuthorId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Author",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Post",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -51,28 +73,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "Post",
-          "name": "authorId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Author",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Post",
-          "name": "coAuthorId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Author",
-            "relatedModelField": "id"
           }
         }
       ]
@@ -124,7 +124,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -161,7 +163,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_many_multi_one_sided_same_side/proto.json
+++ b/schema/testdata/proto/relationships_one_to_many_multi_one_sided_same_side/proto.json
@@ -14,15 +14,6 @@
         },
         {
           "modelName": "Post",
-          "name": "coAuthor",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "Author"
-          },
-          "foreignKeyFieldName": "coAuthorId"
-        },
-        {
-          "modelName": "Post",
           "name": "authorId",
           "type": {
             "type": "TYPE_ID"
@@ -31,6 +22,15 @@
             "relatedModelName": "Author",
             "relatedModelField": "id"
           }
+        },
+        {
+          "modelName": "Post",
+          "name": "coAuthor",
+          "type": {
+            "type": "TYPE_MODEL",
+            "modelName": "Author"
+          },
+          "foreignKeyFieldName": "coAuthorId"
         },
         {
           "modelName": "Post",

--- a/schema/testdata/proto/relationships_one_to_many_single_sided_multiple/proto.json
+++ b/schema/testdata/proto/relationships_one_to_many_single_sided_multiple/proto.json
@@ -91,15 +91,6 @@
         },
         {
           "modelName": "Post",
-          "name": "coAuthoredBy",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "Author"
-          },
-          "foreignKeyFieldName": "coAuthoredById"
-        },
-        {
-          "modelName": "Post",
           "name": "authoredById",
           "type": {
             "type": "TYPE_ID"
@@ -108,6 +99,15 @@
             "relatedModelName": "Author",
             "relatedModelField": "id"
           }
+        },
+        {
+          "modelName": "Post",
+          "name": "coAuthoredBy",
+          "type": {
+            "type": "TYPE_MODEL",
+            "modelName": "Author"
+          },
+          "foreignKeyFieldName": "coAuthoredById"
         },
         {
           "modelName": "Post",
@@ -164,9 +164,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -203,9 +201,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_many_single_sided_multiple/proto.json
+++ b/schema/testdata/proto/relationships_one_to_many_single_sided_multiple/proto.json
@@ -91,6 +91,15 @@
         },
         {
           "modelName": "Post",
+          "name": "coAuthoredBy",
+          "type": {
+            "type": "TYPE_MODEL",
+            "modelName": "Author"
+          },
+          "foreignKeyFieldName": "coAuthoredById"
+        },
+        {
+          "modelName": "Post",
           "name": "authoredById",
           "type": {
             "type": "TYPE_ID"
@@ -99,15 +108,6 @@
             "relatedModelName": "Author",
             "relatedModelField": "id"
           }
-        },
-        {
-          "modelName": "Post",
-          "name": "coAuthoredBy",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "Author"
-          },
-          "foreignKeyFieldName": "coAuthoredById"
         },
         {
           "modelName": "Post",
@@ -164,7 +164,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -201,7 +203,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_many_single_sided_multiple/proto.json
+++ b/schema/testdata/proto/relationships_one_to_many_single_sided_multiple/proto.json
@@ -164,9 +164,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -203,9 +201,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_many_single_sided_multiple/proto.json
+++ b/schema/testdata/proto/relationships_one_to_many_single_sided_multiple/proto.json
@@ -14,12 +14,34 @@
         },
         {
           "modelName": "Author",
+          "name": "topPostId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Post",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Author",
           "name": "worstPost",
           "type": {
             "type": "TYPE_MODEL",
             "modelName": "Post"
           },
           "foreignKeyFieldName": "worstPostId"
+        },
+        {
+          "modelName": "Author",
+          "name": "worstPostId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Post",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Author",
@@ -51,28 +73,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "Author",
-          "name": "topPostId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Post",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Author",
-          "name": "worstPostId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Post",
-            "relatedModelField": "id"
           }
         }
       ]
@@ -91,12 +91,34 @@
         },
         {
           "modelName": "Post",
+          "name": "authoredById",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Author",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Post",
           "name": "coAuthoredBy",
           "type": {
             "type": "TYPE_MODEL",
             "modelName": "Author"
           },
           "foreignKeyFieldName": "coAuthoredById"
+        },
+        {
+          "modelName": "Post",
+          "name": "coAuthoredById",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Author",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Post",
@@ -129,28 +151,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Post",
-          "name": "authoredById",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Author",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Post",
-          "name": "coAuthoredById",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Author",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -164,7 +164,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -201,7 +203,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_one/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one/proto.json
@@ -15,6 +15,18 @@
         },
         {
           "modelName": "Company",
+          "name": "profileId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "CompanyProfile",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Company",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -43,18 +55,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "Company",
-          "name": "profileId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "CompanyProfile",
-            "relatedModelField": "id"
           }
         }
       ],
@@ -122,7 +122,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -159,7 +161,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -403,7 +407,10 @@
             "modelName": "CompanyProfile",
             "fieldName": "employeeCount"
           },
-          "target": ["profile", "employeeCount"]
+          "target": [
+            "profile",
+            "employeeCount"
+          ]
         }
       ]
     }

--- a/schema/testdata/proto/relationships_one_to_one/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one/proto.json
@@ -122,9 +122,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -161,9 +159,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -407,10 +403,7 @@
             "modelName": "CompanyProfile",
             "fieldName": "employeeCount"
           },
-          "target": [
-            "profile",
-            "employeeCount"
-          ]
+          "target": ["profile", "employeeCount"]
         }
       ]
     }

--- a/schema/testdata/proto/relationships_one_to_one_both_directions/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one_both_directions/proto.json
@@ -16,6 +16,18 @@
         },
         {
           "modelName": "User",
+          "name": "studentId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Student",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "User",
           "name": "student2",
           "type": {
             "type": "TYPE_MODEL",
@@ -54,18 +66,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "User",
-          "name": "studentId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Student",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -91,6 +91,18 @@
           "unique": true,
           "foreignKeyFieldName": "user2Id",
           "inverseFieldName": "student2"
+        },
+        {
+          "modelName": "Student",
+          "name": "user2Id",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "User",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Student",
@@ -123,18 +135,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Student",
-          "name": "user2Id",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "User",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -148,7 +148,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -185,7 +187,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_one_both_directions/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one_both_directions/proto.json
@@ -148,9 +148,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -187,9 +185,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_one_both_directions_missing_relation_attribute/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one_both_directions_missing_relation_attribute/proto.json
@@ -16,6 +16,18 @@
         },
         {
           "modelName": "User",
+          "name": "studentId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Student",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "User",
           "name": "student2",
           "type": {
             "type": "TYPE_MODEL",
@@ -54,18 +66,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "User",
-          "name": "studentId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Student",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -91,6 +91,18 @@
           "unique": true,
           "foreignKeyFieldName": "user2Id",
           "inverseFieldName": "student2"
+        },
+        {
+          "modelName": "Student",
+          "name": "user2Id",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "User",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Student",
@@ -123,18 +135,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Student",
-          "name": "user2Id",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "User",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -148,7 +148,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -185,7 +187,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_one_both_directions_missing_relation_attribute/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one_both_directions_missing_relation_attribute/proto.json
@@ -148,9 +148,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -187,9 +185,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_one_both_directions_no_relation_attribute/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one_both_directions_no_relation_attribute/proto.json
@@ -16,6 +16,18 @@
         },
         {
           "modelName": "User",
+          "name": "studentId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Student",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "User",
           "name": "student2",
           "type": {
             "type": "TYPE_MODEL",
@@ -54,18 +66,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "User",
-          "name": "studentId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Student",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -91,6 +91,18 @@
           "unique": true,
           "foreignKeyFieldName": "user2Id",
           "inverseFieldName": "student2"
+        },
+        {
+          "modelName": "Student",
+          "name": "user2Id",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "User",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Student",
@@ -123,18 +135,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Student",
-          "name": "user2Id",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "User",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -148,7 +148,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -185,7 +187,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_one_both_directions_no_relation_attribute/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one_both_directions_no_relation_attribute/proto.json
@@ -148,9 +148,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -187,9 +185,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_one_both_sides/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one_both_sides/proto.json
@@ -16,6 +16,18 @@
         },
         {
           "modelName": "Company",
+          "name": "profileId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "CompanyProfile",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Company",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -44,18 +56,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "Company",
-          "name": "profileId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "CompanyProfile",
-            "relatedModelField": "id"
           }
         }
       ],
@@ -132,7 +132,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -169,7 +171,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -413,7 +417,10 @@
             "modelName": "CompanyProfile",
             "fieldName": "employeeCount"
           },
-          "target": ["profile", "employeeCount"]
+          "target": [
+            "profile",
+            "employeeCount"
+          ]
         }
       ]
     }

--- a/schema/testdata/proto/relationships_one_to_one_both_sides/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one_both_sides/proto.json
@@ -132,9 +132,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -171,9 +169,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -417,10 +413,7 @@
             "modelName": "CompanyProfile",
             "fieldName": "employeeCount"
           },
-          "target": [
-            "profile",
-            "employeeCount"
-          ]
+          "target": ["profile", "employeeCount"]
         }
       ]
     }

--- a/schema/testdata/proto/relationships_one_to_one_missing_reln/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one_missing_reln/proto.json
@@ -16,6 +16,17 @@
         },
         {
           "modelName": "User",
+          "name": "student2",
+          "type": {
+            "type": "TYPE_MODEL",
+            "modelName": "Student"
+          },
+          "unique": true,
+          "foreignKeyFieldName": "student2Id",
+          "inverseFieldName": "user2"
+        },
+        {
+          "modelName": "User",
           "name": "studentId",
           "type": {
             "type": "TYPE_ID"
@@ -25,17 +36,6 @@
             "relatedModelName": "Student",
             "relatedModelField": "id"
           }
-        },
-        {
-          "modelName": "User",
-          "name": "student2",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "Student"
-          },
-          "unique": true,
-          "foreignKeyFieldName": "student2Id",
-          "inverseFieldName": "user2"
         },
         {
           "modelName": "User",

--- a/schema/testdata/proto/relationships_one_to_one_missing_reln/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one_missing_reln/proto.json
@@ -16,17 +16,6 @@
         },
         {
           "modelName": "User",
-          "name": "student2",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "Student"
-          },
-          "unique": true,
-          "foreignKeyFieldName": "student2Id",
-          "inverseFieldName": "user2"
-        },
-        {
-          "modelName": "User",
           "name": "studentId",
           "type": {
             "type": "TYPE_ID"
@@ -36,6 +25,17 @@
             "relatedModelName": "Student",
             "relatedModelField": "id"
           }
+        },
+        {
+          "modelName": "User",
+          "name": "student2",
+          "type": {
+            "type": "TYPE_MODEL",
+            "modelName": "Student"
+          },
+          "unique": true,
+          "foreignKeyFieldName": "student2Id",
+          "inverseFieldName": "user2"
         },
         {
           "modelName": "User",
@@ -148,9 +148,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -187,9 +185,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_one_missing_reln/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one_missing_reln/proto.json
@@ -16,17 +16,6 @@
         },
         {
           "modelName": "User",
-          "name": "student2",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "Student"
-          },
-          "unique": true,
-          "foreignKeyFieldName": "student2Id",
-          "inverseFieldName": "user2"
-        },
-        {
-          "modelName": "User",
           "name": "studentId",
           "type": {
             "type": "TYPE_ID"
@@ -36,6 +25,17 @@
             "relatedModelName": "Student",
             "relatedModelField": "id"
           }
+        },
+        {
+          "modelName": "User",
+          "name": "student2",
+          "type": {
+            "type": "TYPE_MODEL",
+            "modelName": "Student"
+          },
+          "unique": true,
+          "foreignKeyFieldName": "student2Id",
+          "inverseFieldName": "user2"
         },
         {
           "modelName": "User",

--- a/schema/testdata/proto/relationships_one_to_one_missing_reln/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one_missing_reln/proto.json
@@ -148,9 +148,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -187,9 +185,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_one_missing_reln/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one_missing_reln/proto.json
@@ -16,6 +16,17 @@
         },
         {
           "modelName": "User",
+          "name": "student2",
+          "type": {
+            "type": "TYPE_MODEL",
+            "modelName": "Student"
+          },
+          "unique": true,
+          "foreignKeyFieldName": "student2Id",
+          "inverseFieldName": "user2"
+        },
+        {
+          "modelName": "User",
           "name": "studentId",
           "type": {
             "type": "TYPE_ID"
@@ -25,17 +36,6 @@
             "relatedModelName": "Student",
             "relatedModelField": "id"
           }
-        },
-        {
-          "modelName": "User",
-          "name": "student2",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "Student"
-          },
-          "unique": true,
-          "foreignKeyFieldName": "student2Id",
-          "inverseFieldName": "user2"
         },
         {
           "modelName": "User",
@@ -148,7 +148,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -185,7 +187,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_one_missing_reln/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one_missing_reln/proto.json
@@ -16,6 +16,18 @@
         },
         {
           "modelName": "User",
+          "name": "studentId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Student",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "User",
           "name": "student2",
           "type": {
             "type": "TYPE_MODEL",
@@ -24,6 +36,18 @@
           "unique": true,
           "foreignKeyFieldName": "student2Id",
           "inverseFieldName": "user2"
+        },
+        {
+          "modelName": "User",
+          "name": "student2Id",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Student",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "User",
@@ -55,30 +79,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "User",
-          "name": "studentId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Student",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "User",
-          "name": "student2Id",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Student",
-            "relatedModelField": "id"
           }
         }
       ]
@@ -148,7 +148,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -185,7 +187,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_one_multi_layered/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one_multi_layered/proto.json
@@ -23,6 +23,18 @@
         },
         {
           "modelName": "Company",
+          "name": "companyProfileId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "CompanyProfile",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Company",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -51,18 +63,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "Company",
-          "name": "companyProfileId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "CompanyProfile",
-            "relatedModelField": "id"
           }
         }
       ],
@@ -97,6 +97,19 @@
           "unique": true,
           "foreignKeyFieldName": "taxProfileId",
           "inverseFieldName": "companyProfile"
+        },
+        {
+          "modelName": "CompanyProfile",
+          "name": "taxProfileId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "optional": true,
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "TaxProfile",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "CompanyProfile",
@@ -137,19 +150,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "CompanyProfile",
-          "name": "taxProfileId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "optional": true,
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "TaxProfile",
-            "relatedModelField": "id"
           }
         }
       ],
@@ -235,7 +235,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -272,7 +274,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -516,7 +520,9 @@
             "modelName": "Company",
             "fieldName": "name"
           },
-          "target": ["name"]
+          "target": [
+            "name"
+          ]
         },
         {
           "messageName": "CreateCompanyInput",
@@ -539,7 +545,10 @@
             "modelName": "CompanyProfile",
             "fieldName": "employeeCount"
           },
-          "target": ["companyProfile", "employeeCount"]
+          "target": [
+            "companyProfile",
+            "employeeCount"
+          ]
         },
         {
           "messageName": "CreateCompanyCompanyProfileInput",
@@ -563,7 +572,11 @@
             "modelName": "TaxProfile",
             "fieldName": "taxNumber"
           },
-          "target": ["companyProfile", "taxProfile", "taxNumber"]
+          "target": [
+            "companyProfile",
+            "taxProfile",
+            "taxNumber"
+          ]
         }
       ]
     },
@@ -577,7 +590,10 @@
             "type": "TYPE_MESSAGE",
             "messageName": "IdQueryInput"
           },
-          "target": ["company", "id"]
+          "target": [
+            "company",
+            "id"
+          ]
         }
       ]
     },
@@ -697,7 +713,11 @@
             "type": "TYPE_MESSAGE",
             "messageName": "IdQueryInput"
           },
-          "target": ["companyProfile", "company", "id"]
+          "target": [
+            "companyProfile",
+            "company",
+            "id"
+          ]
         }
       ]
     },

--- a/schema/testdata/proto/relationships_one_to_one_multi_layered/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one_multi_layered/proto.json
@@ -235,9 +235,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -274,9 +272,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -520,9 +516,7 @@
             "modelName": "Company",
             "fieldName": "name"
           },
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         },
         {
           "messageName": "CreateCompanyInput",
@@ -545,10 +539,7 @@
             "modelName": "CompanyProfile",
             "fieldName": "employeeCount"
           },
-          "target": [
-            "companyProfile",
-            "employeeCount"
-          ]
+          "target": ["companyProfile", "employeeCount"]
         },
         {
           "messageName": "CreateCompanyCompanyProfileInput",
@@ -572,11 +563,7 @@
             "modelName": "TaxProfile",
             "fieldName": "taxNumber"
           },
-          "target": [
-            "companyProfile",
-            "taxProfile",
-            "taxNumber"
-          ]
+          "target": ["companyProfile", "taxProfile", "taxNumber"]
         }
       ]
     },
@@ -590,10 +577,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "IdQueryInput"
           },
-          "target": [
-            "company",
-            "id"
-          ]
+          "target": ["company", "id"]
         }
       ]
     },
@@ -713,11 +697,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "IdQueryInput"
           },
-          "target": [
-            "companyProfile",
-            "company",
-            "id"
-          ]
+          "target": ["companyProfile", "company", "id"]
         }
       ]
     },

--- a/schema/testdata/proto/relationships_one_to_one_nested_create/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one_nested_create/proto.json
@@ -154,9 +154,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -193,9 +191,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -444,10 +440,7 @@
             "modelName": "UserDetails",
             "fieldName": "name"
           },
-          "target": [
-            "details",
-            "name"
-          ]
+          "target": ["details", "name"]
         }
       ]
     },
@@ -462,9 +455,7 @@
             "modelName": "UserDetails",
             "fieldName": "name"
           },
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         }
       ]
     }

--- a/schema/testdata/proto/relationships_one_to_one_nested_create/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one_nested_create/proto.json
@@ -6,45 +6,64 @@
         {
           "modelName": "User",
           "name": "email",
-          "type": { "type": "TYPE_STRING" },
+          "type": {
+            "type": "TYPE_STRING"
+          },
           "unique": true
         },
         {
           "modelName": "User",
           "name": "details",
-          "type": { "type": "TYPE_MODEL", "modelName": "UserDetails" },
+          "type": {
+            "type": "TYPE_MODEL",
+            "modelName": "UserDetails"
+          },
           "unique": true,
           "foreignKeyFieldName": "detailsId",
           "inverseFieldName": "user"
         },
         {
           "modelName": "User",
-          "name": "id",
-          "type": { "type": "TYPE_ID" },
-          "unique": true,
-          "primaryKey": true,
-          "defaultValue": { "useZeroValue": true }
-        },
-        {
-          "modelName": "User",
-          "name": "createdAt",
-          "type": { "type": "TYPE_DATETIME" },
-          "defaultValue": { "useZeroValue": true }
-        },
-        {
-          "modelName": "User",
-          "name": "updatedAt",
-          "type": { "type": "TYPE_DATETIME" },
-          "defaultValue": { "useZeroValue": true }
-        },
-        {
-          "modelName": "User",
           "name": "detailsId",
-          "type": { "type": "TYPE_ID" },
+          "type": {
+            "type": "TYPE_ID"
+          },
           "unique": true,
           "foreignKeyInfo": {
             "relatedModelName": "UserDetails",
             "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "User",
+          "name": "id",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "primaryKey": true,
+          "defaultValue": {
+            "useZeroValue": true
+          }
+        },
+        {
+          "modelName": "User",
+          "name": "createdAt",
+          "type": {
+            "type": "TYPE_DATETIME"
+          },
+          "defaultValue": {
+            "useZeroValue": true
+          }
+        },
+        {
+          "modelName": "User",
+          "name": "updatedAt",
+          "type": {
+            "type": "TYPE_DATETIME"
+          },
+          "defaultValue": {
+            "useZeroValue": true
           }
         }
       ],
@@ -54,7 +73,11 @@
           "name": "createUser",
           "type": "ACTION_TYPE_CREATE",
           "implementation": "ACTION_IMPLEMENTATION_AUTO",
-          "setExpressions": [{ "source": "user.email = ctx.identity.email" }],
+          "setExpressions": [
+            {
+              "source": "user.email = ctx.identity.email"
+            }
+          ],
           "inputMessageName": "CreateUserInput"
         }
       ]
@@ -65,33 +88,50 @@
         {
           "modelName": "UserDetails",
           "name": "user",
-          "type": { "type": "TYPE_MODEL", "modelName": "User" },
+          "type": {
+            "type": "TYPE_MODEL",
+            "modelName": "User"
+          },
           "inverseFieldName": "details"
         },
         {
           "modelName": "UserDetails",
           "name": "name",
-          "type": { "type": "TYPE_STRING" }
+          "type": {
+            "type": "TYPE_STRING"
+          }
         },
         {
           "modelName": "UserDetails",
           "name": "id",
-          "type": { "type": "TYPE_ID" },
+          "type": {
+            "type": "TYPE_ID"
+          },
           "unique": true,
           "primaryKey": true,
-          "defaultValue": { "useZeroValue": true }
+          "defaultValue": {
+            "useZeroValue": true
+          }
         },
         {
           "modelName": "UserDetails",
           "name": "createdAt",
-          "type": { "type": "TYPE_DATETIME" },
-          "defaultValue": { "useZeroValue": true }
+          "type": {
+            "type": "TYPE_DATETIME"
+          },
+          "defaultValue": {
+            "useZeroValue": true
+          }
         },
         {
           "modelName": "UserDetails",
           "name": "updatedAt",
-          "type": { "type": "TYPE_DATETIME" },
-          "defaultValue": { "useZeroValue": true }
+          "type": {
+            "type": "TYPE_DATETIME"
+          },
+          "defaultValue": {
+            "useZeroValue": true
+          }
         }
       ],
       "actions": [
@@ -110,120 +150,172 @@
         {
           "modelName": "Identity",
           "name": "email",
-          "type": { "type": "TYPE_STRING" },
+          "type": {
+            "type": "TYPE_STRING"
+          },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
           "name": "emailVerified",
-          "type": { "type": "TYPE_BOOL" },
-          "defaultValue": { "expression": { "source": "false" } }
+          "type": {
+            "type": "TYPE_BOOL"
+          },
+          "defaultValue": {
+            "expression": {
+              "source": "false"
+            }
+          }
         },
         {
           "modelName": "Identity",
           "name": "password",
-          "type": { "type": "TYPE_PASSWORD" },
+          "type": {
+            "type": "TYPE_PASSWORD"
+          },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "externalId",
-          "type": { "type": "TYPE_STRING" },
+          "type": {
+            "type": "TYPE_STRING"
+          },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "issuer",
-          "type": { "type": "TYPE_STRING" },
+          "type": {
+            "type": "TYPE_STRING"
+          },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
           "name": "name",
-          "type": { "type": "TYPE_STRING" },
+          "type": {
+            "type": "TYPE_STRING"
+          },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "givenName",
-          "type": { "type": "TYPE_STRING" },
+          "type": {
+            "type": "TYPE_STRING"
+          },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "familyName",
-          "type": { "type": "TYPE_STRING" },
+          "type": {
+            "type": "TYPE_STRING"
+          },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "middleName",
-          "type": { "type": "TYPE_STRING" },
+          "type": {
+            "type": "TYPE_STRING"
+          },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "nickName",
-          "type": { "type": "TYPE_STRING" },
+          "type": {
+            "type": "TYPE_STRING"
+          },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "profile",
-          "type": { "type": "TYPE_STRING" },
+          "type": {
+            "type": "TYPE_STRING"
+          },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "picture",
-          "type": { "type": "TYPE_STRING" },
+          "type": {
+            "type": "TYPE_STRING"
+          },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "website",
-          "type": { "type": "TYPE_STRING" },
+          "type": {
+            "type": "TYPE_STRING"
+          },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "gender",
-          "type": { "type": "TYPE_STRING" },
+          "type": {
+            "type": "TYPE_STRING"
+          },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "zoneInfo",
-          "type": { "type": "TYPE_STRING" },
+          "type": {
+            "type": "TYPE_STRING"
+          },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "locale",
-          "type": { "type": "TYPE_STRING" },
+          "type": {
+            "type": "TYPE_STRING"
+          },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "id",
-          "type": { "type": "TYPE_ID" },
+          "type": {
+            "type": "TYPE_ID"
+          },
           "unique": true,
           "primaryKey": true,
-          "defaultValue": { "useZeroValue": true }
+          "defaultValue": {
+            "useZeroValue": true
+          }
         },
         {
           "modelName": "Identity",
           "name": "createdAt",
-          "type": { "type": "TYPE_DATETIME" },
-          "defaultValue": { "useZeroValue": true }
+          "type": {
+            "type": "TYPE_DATETIME"
+          },
+          "defaultValue": {
+            "useZeroValue": true
+          }
         },
         {
           "modelName": "Identity",
           "name": "updatedAt",
-          "type": { "type": "TYPE_DATETIME" },
-          "defaultValue": { "useZeroValue": true }
+          "type": {
+            "type": "TYPE_DATETIME"
+          },
+          "defaultValue": {
+            "useZeroValue": true
+          }
         }
       ],
       "actions": [
@@ -252,56 +344,82 @@
       "apiModels": [
         {
           "modelName": "User",
-          "modelActions": [{ "actionName": "createUser" }]
+          "modelActions": [
+            {
+              "actionName": "createUser"
+            }
+          ]
         },
         {
           "modelName": "UserDetails",
-          "modelActions": [{ "actionName": "createUserDetails" }]
+          "modelActions": [
+            {
+              "actionName": "createUserDetails"
+            }
+          ]
         },
         {
           "modelName": "Identity",
           "modelActions": [
-            { "actionName": "requestPasswordReset" },
-            { "actionName": "resetPassword" }
+            {
+              "actionName": "requestPasswordReset"
+            },
+            {
+              "actionName": "resetPassword"
+            }
           ]
         }
       ]
     }
   ],
   "messages": [
-    { "name": "Any" },
+    {
+      "name": "Any"
+    },
     {
       "name": "RequestPasswordResetInput",
       "fields": [
         {
           "messageName": "RequestPasswordResetInput",
           "name": "email",
-          "type": { "type": "TYPE_STRING" }
+          "type": {
+            "type": "TYPE_STRING"
+          }
         },
         {
           "messageName": "RequestPasswordResetInput",
           "name": "redirectUrl",
-          "type": { "type": "TYPE_STRING" }
+          "type": {
+            "type": "TYPE_STRING"
+          }
         }
       ]
     },
-    { "name": "RequestPasswordResetResponse" },
+    {
+      "name": "RequestPasswordResetResponse"
+    },
     {
       "name": "ResetPasswordInput",
       "fields": [
         {
           "messageName": "ResetPasswordInput",
           "name": "token",
-          "type": { "type": "TYPE_STRING" }
+          "type": {
+            "type": "TYPE_STRING"
+          }
         },
         {
           "messageName": "ResetPasswordInput",
           "name": "password",
-          "type": { "type": "TYPE_STRING" }
+          "type": {
+            "type": "TYPE_STRING"
+          }
         }
       ]
     },
-    { "name": "ResetPasswordResponse" },
+    {
+      "name": "ResetPasswordResponse"
+    },
     {
       "name": "CreateUserInput",
       "fields": [
@@ -326,7 +444,10 @@
             "modelName": "UserDetails",
             "fieldName": "name"
           },
-          "target": ["details", "name"]
+          "target": [
+            "details",
+            "name"
+          ]
         }
       ]
     },
@@ -341,7 +462,9 @@
             "modelName": "UserDetails",
             "fieldName": "name"
           },
-          "target": ["name"]
+          "target": [
+            "name"
+          ]
         }
       ]
     }

--- a/schema/testdata/proto/relationships_one_to_one_unique_both_sides/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one_unique_both_sides/proto.json
@@ -15,6 +15,18 @@
         },
         {
           "modelName": "User",
+          "name": "studentId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Student",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "User",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -43,18 +55,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "User",
-          "name": "studentId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Student",
-            "relatedModelField": "id"
           }
         }
       ]
@@ -74,6 +74,18 @@
         },
         {
           "modelName": "Student",
+          "name": "userId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "User",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Student",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -103,18 +115,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Student",
-          "name": "userId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "User",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -128,7 +128,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -165,7 +167,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_one_unique_both_sides/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one_unique_both_sides/proto.json
@@ -128,9 +128,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -167,9 +165,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_one_with_unique/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one_with_unique/proto.json
@@ -16,6 +16,18 @@
         },
         {
           "modelName": "User",
+          "name": "identityId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Identity",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "User",
           "name": "student",
           "type": {
             "type": "TYPE_MODEL",
@@ -55,18 +67,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "User",
-          "name": "identityId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Identity",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -83,6 +83,18 @@
           "unique": true,
           "foreignKeyFieldName": "userId",
           "inverseFieldName": "student"
+        },
+        {
+          "modelName": "Student",
+          "name": "userId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "User",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Student",
@@ -115,18 +127,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Student",
-          "name": "userId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "User",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -140,7 +140,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -177,7 +179,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_one_to_one_with_unique/proto.json
+++ b/schema/testdata/proto/relationships_one_to_one_with_unique/proto.json
@@ -140,9 +140,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -179,9 +177,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_self_referencing_multiple/proto.json
+++ b/schema/testdata/proto/relationships_self_referencing_multiple/proto.json
@@ -113,9 +113,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -152,9 +150,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_self_referencing_multiple/proto.json
+++ b/schema/testdata/proto/relationships_self_referencing_multiple/proto.json
@@ -16,6 +16,18 @@
         },
         {
           "modelName": "Person",
+          "name": "bestFriendId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "optional": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Person",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Person",
           "name": "bestFriendsOf",
           "type": {
             "type": "TYPE_MODEL",
@@ -34,6 +46,18 @@
           "optional": true,
           "foreignKeyFieldName": "motherId",
           "inverseFieldName": "children"
+        },
+        {
+          "modelName": "Person",
+          "name": "motherId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "optional": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Person",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Person",
@@ -76,30 +100,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Person",
-          "name": "bestFriendId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "optional": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Person",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Person",
-          "name": "motherId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "optional": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Person",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -113,7 +113,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -150,7 +152,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_self_referencing_no_reln_attribute/proto.json
+++ b/schema/testdata/proto/relationships_self_referencing_no_reln_attribute/proto.json
@@ -26,6 +26,18 @@
         },
         {
           "modelName": "Person",
+          "name": "motherId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "optional": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Person",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Person",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -54,18 +66,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "Person",
-          "name": "motherId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "optional": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Person",
-            "relatedModelField": "id"
           }
         }
       ]
@@ -96,6 +96,18 @@
         },
         {
           "modelName": "Person2",
+          "name": "motherId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "optional": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Person2",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Person2",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -125,18 +137,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Person2",
-          "name": "motherId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "optional": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Person2",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -150,7 +150,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -187,7 +189,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_self_referencing_no_reln_attribute/proto.json
+++ b/schema/testdata/proto/relationships_self_referencing_no_reln_attribute/proto.json
@@ -150,9 +150,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -189,9 +187,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_self_referencing_uses_reln_attribute/proto.json
+++ b/schema/testdata/proto/relationships_self_referencing_uses_reln_attribute/proto.json
@@ -26,6 +26,18 @@
         },
         {
           "modelName": "Person",
+          "name": "motherId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "optional": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Person",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Person",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -54,18 +66,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "Person",
-          "name": "motherId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "optional": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Person",
-            "relatedModelField": "id"
           }
         }
       ]
@@ -96,6 +96,18 @@
         },
         {
           "modelName": "Person2",
+          "name": "motherId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "optional": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Person2",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Person2",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -125,18 +137,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Person2",
-          "name": "motherId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "optional": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Person2",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -150,7 +150,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -187,7 +189,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_self_referencing_uses_reln_attribute/proto.json
+++ b/schema/testdata/proto/relationships_self_referencing_uses_reln_attribute/proto.json
@@ -150,9 +150,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -189,9 +187,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/relationships_update_with_explicit_input/proto.json
+++ b/schema/testdata/proto/relationships_update_with_explicit_input/proto.json
@@ -184,9 +184,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -223,9 +221,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -462,9 +458,7 @@
             "modelName": "ChildModel",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -479,9 +473,7 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": [
-            "isActive"
-          ]
+          "target": ["isActive"]
         },
         {
           "messageName": "UpdateChild1Values",
@@ -524,9 +516,7 @@
             "modelName": "ChildModel",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -541,9 +531,7 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": [
-            "isActive"
-          ]
+          "target": ["isActive"]
         },
         {
           "messageName": "UpdateChild2Values",
@@ -586,9 +574,7 @@
             "modelName": "ChildModel",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -603,9 +589,7 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": [
-            "isActive"
-          ]
+          "target": ["isActive"]
         },
         {
           "messageName": "UpdateChild3Values",

--- a/schema/testdata/proto/relationships_update_with_explicit_input/proto.json
+++ b/schema/testdata/proto/relationships_update_with_explicit_input/proto.json
@@ -21,6 +21,17 @@
         },
         {
           "modelName": "ChildModel",
+          "name": "parentId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "ParentModel",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "ChildModel",
           "name": "parentOptional",
           "type": {
             "type": "TYPE_MODEL",
@@ -28,6 +39,18 @@
           },
           "optional": true,
           "foreignKeyFieldName": "parentOptionalId"
+        },
+        {
+          "modelName": "ChildModel",
+          "name": "parentOptionalId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "optional": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "ParentModel",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "ChildModel",
@@ -59,29 +82,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "ChildModel",
-          "name": "parentId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "ParentModel",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "ChildModel",
-          "name": "parentOptionalId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "optional": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "ParentModel",
-            "relatedModelField": "id"
           }
         }
       ],
@@ -184,7 +184,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -221,7 +223,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -458,7 +462,9 @@
             "modelName": "ChildModel",
             "fieldName": "id"
           },
-          "target": ["id"]
+          "target": [
+            "id"
+          ]
         }
       ]
     },
@@ -473,7 +479,9 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": ["isActive"]
+          "target": [
+            "isActive"
+          ]
         },
         {
           "messageName": "UpdateChild1Values",
@@ -516,7 +524,9 @@
             "modelName": "ChildModel",
             "fieldName": "id"
           },
-          "target": ["id"]
+          "target": [
+            "id"
+          ]
         }
       ]
     },
@@ -531,7 +541,9 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": ["isActive"]
+          "target": [
+            "isActive"
+          ]
         },
         {
           "messageName": "UpdateChild2Values",
@@ -574,7 +586,9 @@
             "modelName": "ChildModel",
             "fieldName": "id"
           },
-          "target": ["id"]
+          "target": [
+            "id"
+          ]
         }
       ]
     },
@@ -589,7 +603,9 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": ["isActive"]
+          "target": [
+            "isActive"
+          ]
         },
         {
           "messageName": "UpdateChild3Values",

--- a/schema/testdata/proto/relationships_update_with_implicit_input/proto.json
+++ b/schema/testdata/proto/relationships_update_with_implicit_input/proto.json
@@ -21,6 +21,16 @@
         },
         {
           "modelName": "ChildModel",
+          "name": "parentOptional",
+          "type": {
+            "type": "TYPE_MODEL",
+            "modelName": "ParentModel"
+          },
+          "optional": true,
+          "foreignKeyFieldName": "parentOptionalId"
+        },
+        {
+          "modelName": "ChildModel",
           "name": "parentId",
           "type": {
             "type": "TYPE_ID"
@@ -29,16 +39,6 @@
             "relatedModelName": "ParentModel",
             "relatedModelField": "id"
           }
-        },
-        {
-          "modelName": "ChildModel",
-          "name": "parentOptional",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "ParentModel"
-          },
-          "optional": true,
-          "foreignKeyFieldName": "parentOptionalId"
         },
         {
           "modelName": "ChildModel",

--- a/schema/testdata/proto/relationships_update_with_implicit_input/proto.json
+++ b/schema/testdata/proto/relationships_update_with_implicit_input/proto.json
@@ -21,6 +21,17 @@
         },
         {
           "modelName": "ChildModel",
+          "name": "parentId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "ParentModel",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "ChildModel",
           "name": "parentOptional",
           "type": {
             "type": "TYPE_MODEL",
@@ -28,6 +39,18 @@
           },
           "optional": true,
           "foreignKeyFieldName": "parentOptionalId"
+        },
+        {
+          "modelName": "ChildModel",
+          "name": "parentOptionalId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "optional": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "ParentModel",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "ChildModel",
@@ -59,29 +82,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "ChildModel",
-          "name": "parentId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "ParentModel",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "ChildModel",
-          "name": "parentOptionalId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "optional": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "ParentModel",
-            "relatedModelField": "id"
           }
         }
       ],
@@ -170,7 +170,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -207,7 +209,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -447,7 +451,9 @@
             "modelName": "ChildModel",
             "fieldName": "id"
           },
-          "target": ["id"]
+          "target": [
+            "id"
+          ]
         }
       ]
     },
@@ -462,7 +468,9 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": ["isActive"]
+          "target": [
+            "isActive"
+          ]
         },
         {
           "messageName": "UpdateChild1Values",
@@ -485,7 +493,10 @@
             "modelName": "ParentModel",
             "fieldName": "id"
           },
-          "target": ["parent", "id"]
+          "target": [
+            "parent",
+            "id"
+          ]
         }
       ]
     },
@@ -521,7 +532,9 @@
             "modelName": "ChildModel",
             "fieldName": "id"
           },
-          "target": ["id"]
+          "target": [
+            "id"
+          ]
         }
       ]
     },
@@ -536,7 +549,9 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": ["isActive"]
+          "target": [
+            "isActive"
+          ]
         },
         {
           "messageName": "UpdateChild2Values",
@@ -546,7 +561,9 @@
             "modelName": "ChildModel",
             "fieldName": "parentId"
           },
-          "target": ["parentId"]
+          "target": [
+            "parentId"
+          ]
         }
       ]
     },
@@ -582,7 +599,9 @@
             "modelName": "ChildModel",
             "fieldName": "id"
           },
-          "target": ["id"]
+          "target": [
+            "id"
+          ]
         }
       ]
     },
@@ -597,7 +616,9 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": ["isActive"]
+          "target": [
+            "isActive"
+          ]
         },
         {
           "messageName": "UpdateChild3Values",
@@ -629,7 +650,10 @@
             "modelName": "ParentModel",
             "fieldName": "id"
           },
-          "target": ["parent", "id"]
+          "target": [
+            "parent",
+            "id"
+          ]
         }
       ]
     },
@@ -644,7 +668,10 @@
             "modelName": "ParentModel",
             "fieldName": "id"
           },
-          "target": ["parentOptional", "id"]
+          "target": [
+            "parentOptional",
+            "id"
+          ]
         }
       ]
     },
@@ -680,7 +707,9 @@
             "modelName": "ChildModel",
             "fieldName": "id"
           },
-          "target": ["id"]
+          "target": [
+            "id"
+          ]
         }
       ]
     },
@@ -695,7 +724,9 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": ["isActive"]
+          "target": [
+            "isActive"
+          ]
         },
         {
           "messageName": "UpdateChild4Values",
@@ -705,7 +736,9 @@
             "modelName": "ChildModel",
             "fieldName": "parentId"
           },
-          "target": ["parentId"]
+          "target": [
+            "parentId"
+          ]
         },
         {
           "messageName": "UpdateChild4Values",
@@ -716,7 +749,9 @@
             "fieldName": "parentOptionalId"
           },
           "nullable": true,
-          "target": ["parentOptionalId"]
+          "target": [
+            "parentOptionalId"
+          ]
         }
       ]
     },

--- a/schema/testdata/proto/relationships_update_with_implicit_input/proto.json
+++ b/schema/testdata/proto/relationships_update_with_implicit_input/proto.json
@@ -21,16 +21,6 @@
         },
         {
           "modelName": "ChildModel",
-          "name": "parentOptional",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "ParentModel"
-          },
-          "optional": true,
-          "foreignKeyFieldName": "parentOptionalId"
-        },
-        {
-          "modelName": "ChildModel",
           "name": "parentId",
           "type": {
             "type": "TYPE_ID"
@@ -39,6 +29,16 @@
             "relatedModelName": "ParentModel",
             "relatedModelField": "id"
           }
+        },
+        {
+          "modelName": "ChildModel",
+          "name": "parentOptional",
+          "type": {
+            "type": "TYPE_MODEL",
+            "modelName": "ParentModel"
+          },
+          "optional": true,
+          "foreignKeyFieldName": "parentOptionalId"
         },
         {
           "modelName": "ChildModel",
@@ -170,7 +170,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -207,7 +209,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -447,7 +451,9 @@
             "modelName": "ChildModel",
             "fieldName": "id"
           },
-          "target": ["id"]
+          "target": [
+            "id"
+          ]
         }
       ]
     },
@@ -462,7 +468,9 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": ["isActive"]
+          "target": [
+            "isActive"
+          ]
         },
         {
           "messageName": "UpdateChild1Values",
@@ -485,7 +493,10 @@
             "modelName": "ParentModel",
             "fieldName": "id"
           },
-          "target": ["parent", "id"]
+          "target": [
+            "parent",
+            "id"
+          ]
         }
       ]
     },
@@ -521,7 +532,9 @@
             "modelName": "ChildModel",
             "fieldName": "id"
           },
-          "target": ["id"]
+          "target": [
+            "id"
+          ]
         }
       ]
     },
@@ -536,7 +549,9 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": ["isActive"]
+          "target": [
+            "isActive"
+          ]
         },
         {
           "messageName": "UpdateChild2Values",
@@ -546,7 +561,9 @@
             "modelName": "ChildModel",
             "fieldName": "parentId"
           },
-          "target": ["parentId"]
+          "target": [
+            "parentId"
+          ]
         }
       ]
     },
@@ -582,7 +599,9 @@
             "modelName": "ChildModel",
             "fieldName": "id"
           },
-          "target": ["id"]
+          "target": [
+            "id"
+          ]
         }
       ]
     },
@@ -597,7 +616,9 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": ["isActive"]
+          "target": [
+            "isActive"
+          ]
         },
         {
           "messageName": "UpdateChild3Values",
@@ -629,7 +650,10 @@
             "modelName": "ParentModel",
             "fieldName": "id"
           },
-          "target": ["parent", "id"]
+          "target": [
+            "parent",
+            "id"
+          ]
         }
       ]
     },
@@ -644,7 +668,10 @@
             "modelName": "ParentModel",
             "fieldName": "id"
           },
-          "target": ["parentOptional", "id"]
+          "target": [
+            "parentOptional",
+            "id"
+          ]
         }
       ]
     },
@@ -680,7 +707,9 @@
             "modelName": "ChildModel",
             "fieldName": "id"
           },
-          "target": ["id"]
+          "target": [
+            "id"
+          ]
         }
       ]
     },
@@ -695,7 +724,9 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": ["isActive"]
+          "target": [
+            "isActive"
+          ]
         },
         {
           "messageName": "UpdateChild4Values",
@@ -705,7 +736,9 @@
             "modelName": "ChildModel",
             "fieldName": "parentId"
           },
-          "target": ["parentId"]
+          "target": [
+            "parentId"
+          ]
         },
         {
           "messageName": "UpdateChild4Values",
@@ -716,7 +749,9 @@
             "fieldName": "parentOptionalId"
           },
           "nullable": true,
-          "target": ["parentOptionalId"]
+          "target": [
+            "parentOptionalId"
+          ]
         }
       ]
     },

--- a/schema/testdata/proto/relationships_update_with_implicit_input/proto.json
+++ b/schema/testdata/proto/relationships_update_with_implicit_input/proto.json
@@ -170,9 +170,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -209,9 +207,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -451,9 +447,7 @@
             "modelName": "ChildModel",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -468,9 +462,7 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": [
-            "isActive"
-          ]
+          "target": ["isActive"]
         },
         {
           "messageName": "UpdateChild1Values",
@@ -493,10 +485,7 @@
             "modelName": "ParentModel",
             "fieldName": "id"
           },
-          "target": [
-            "parent",
-            "id"
-          ]
+          "target": ["parent", "id"]
         }
       ]
     },
@@ -532,9 +521,7 @@
             "modelName": "ChildModel",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -549,9 +536,7 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": [
-            "isActive"
-          ]
+          "target": ["isActive"]
         },
         {
           "messageName": "UpdateChild2Values",
@@ -561,9 +546,7 @@
             "modelName": "ChildModel",
             "fieldName": "parentId"
           },
-          "target": [
-            "parentId"
-          ]
+          "target": ["parentId"]
         }
       ]
     },
@@ -599,9 +582,7 @@
             "modelName": "ChildModel",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -616,9 +597,7 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": [
-            "isActive"
-          ]
+          "target": ["isActive"]
         },
         {
           "messageName": "UpdateChild3Values",
@@ -650,10 +629,7 @@
             "modelName": "ParentModel",
             "fieldName": "id"
           },
-          "target": [
-            "parent",
-            "id"
-          ]
+          "target": ["parent", "id"]
         }
       ]
     },
@@ -668,10 +644,7 @@
             "modelName": "ParentModel",
             "fieldName": "id"
           },
-          "target": [
-            "parentOptional",
-            "id"
-          ]
+          "target": ["parentOptional", "id"]
         }
       ]
     },
@@ -707,9 +680,7 @@
             "modelName": "ChildModel",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
@@ -724,9 +695,7 @@
             "modelName": "ChildModel",
             "fieldName": "isActive"
           },
-          "target": [
-            "isActive"
-          ]
+          "target": ["isActive"]
         },
         {
           "messageName": "UpdateChild4Values",
@@ -736,9 +705,7 @@
             "modelName": "ChildModel",
             "fieldName": "parentId"
           },
-          "target": [
-            "parentId"
-          ]
+          "target": ["parentId"]
         },
         {
           "messageName": "UpdateChild4Values",
@@ -749,9 +716,7 @@
             "fieldName": "parentOptionalId"
           },
           "nullable": true,
-          "target": [
-            "parentOptionalId"
-          ]
+          "target": ["parentOptionalId"]
         }
       ]
     },

--- a/schema/testdata/proto/set_attribute_backlink_repeated_rhs_fields/proto.json
+++ b/schema/testdata/proto/set_attribute_backlink_repeated_rhs_fields/proto.json
@@ -21,6 +21,17 @@
         },
         {
           "modelName": "Record",
+          "name": "ownerId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "User",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Record",
           "name": "organisation",
           "type": {
             "type": "TYPE_MODEL",
@@ -30,12 +41,12 @@
         },
         {
           "modelName": "Record",
-          "name": "ownerId",
+          "name": "organisationId",
           "type": {
             "type": "TYPE_ID"
           },
           "foreignKeyInfo": {
-            "relatedModelName": "User",
+            "relatedModelName": "Organisation",
             "relatedModelField": "id"
           }
         },
@@ -49,17 +60,6 @@
             "expression": {
               "source": "false"
             }
-          }
-        },
-        {
-          "modelName": "Record",
-          "name": "organisationId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Organisation",
-            "relatedModelField": "id"
           }
         },
         {

--- a/schema/testdata/proto/set_attribute_backlink_repeated_rhs_fields/proto.json
+++ b/schema/testdata/proto/set_attribute_backlink_repeated_rhs_fields/proto.json
@@ -163,10 +163,7 @@
           "expression": {
             "source": "true"
           },
-          "actionTypes": [
-            "ACTION_TYPE_CREATE",
-            "ACTION_TYPE_UPDATE"
-          ]
+          "actionTypes": ["ACTION_TYPE_CREATE", "ACTION_TYPE_UPDATE"]
         }
       ]
     },
@@ -332,9 +329,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -371,9 +366,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -617,9 +610,7 @@
             "modelName": "Record",
             "fieldName": "name"
           },
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         },
         {
           "messageName": "CreateRecordWithChildrenInput",
@@ -643,10 +634,7 @@
             "modelName": "Record",
             "fieldName": "name"
           },
-          "target": [
-            "children",
-            "name"
-          ]
+          "target": ["children", "name"]
         }
       ]
     }

--- a/schema/testdata/proto/set_attribute_backlink_repeated_rhs_fields/proto.json
+++ b/schema/testdata/proto/set_attribute_backlink_repeated_rhs_fields/proto.json
@@ -21,6 +21,17 @@
         },
         {
           "modelName": "Record",
+          "name": "ownerId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "User",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Record",
           "name": "organisation",
           "type": {
             "type": "TYPE_MODEL",
@@ -30,12 +41,12 @@
         },
         {
           "modelName": "Record",
-          "name": "ownerId",
+          "name": "organisationId",
           "type": {
             "type": "TYPE_ID"
           },
           "foreignKeyInfo": {
-            "relatedModelName": "User",
+            "relatedModelName": "Organisation",
             "relatedModelField": "id"
           }
         },
@@ -49,17 +60,6 @@
             "expression": {
               "source": "false"
             }
-          }
-        },
-        {
-          "modelName": "Record",
-          "name": "organisationId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Organisation",
-            "relatedModelField": "id"
           }
         },
         {
@@ -163,10 +163,7 @@
           "expression": {
             "source": "true"
           },
-          "actionTypes": [
-            "ACTION_TYPE_CREATE",
-            "ACTION_TYPE_UPDATE"
-          ]
+          "actionTypes": ["ACTION_TYPE_CREATE", "ACTION_TYPE_UPDATE"]
         }
       ]
     },
@@ -332,9 +329,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -371,9 +366,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -617,9 +610,7 @@
             "modelName": "Record",
             "fieldName": "name"
           },
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         },
         {
           "messageName": "CreateRecordWithChildrenInput",
@@ -643,10 +634,7 @@
             "modelName": "Record",
             "fieldName": "name"
           },
-          "target": [
-            "children",
-            "name"
-          ]
+          "target": ["children", "name"]
         }
       ]
     }

--- a/schema/testdata/proto/set_attribute_backlink_repeated_rhs_fields/proto.json
+++ b/schema/testdata/proto/set_attribute_backlink_repeated_rhs_fields/proto.json
@@ -21,17 +21,6 @@
         },
         {
           "modelName": "Record",
-          "name": "ownerId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "User",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Record",
           "name": "organisation",
           "type": {
             "type": "TYPE_MODEL",
@@ -41,12 +30,12 @@
         },
         {
           "modelName": "Record",
-          "name": "organisationId",
+          "name": "ownerId",
           "type": {
             "type": "TYPE_ID"
           },
           "foreignKeyInfo": {
-            "relatedModelName": "Organisation",
+            "relatedModelName": "User",
             "relatedModelField": "id"
           }
         },
@@ -60,6 +49,17 @@
             "expression": {
               "source": "false"
             }
+          }
+        },
+        {
+          "modelName": "Record",
+          "name": "organisationId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Organisation",
+            "relatedModelField": "id"
           }
         },
         {

--- a/schema/testdata/proto/set_attribute_backlink_repeated_rhs_fields/proto.json
+++ b/schema/testdata/proto/set_attribute_backlink_repeated_rhs_fields/proto.json
@@ -30,6 +30,17 @@
         },
         {
           "modelName": "Record",
+          "name": "ownerId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "User",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Record",
           "name": "isActive",
           "type": {
             "type": "TYPE_BOOL"
@@ -42,6 +53,17 @@
         },
         {
           "modelName": "Record",
+          "name": "organisationId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Organisation",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Record",
           "name": "parent",
           "type": {
             "type": "TYPE_MODEL",
@@ -50,6 +72,18 @@
           "optional": true,
           "foreignKeyFieldName": "parentId",
           "inverseFieldName": "children"
+        },
+        {
+          "modelName": "Record",
+          "name": "parentId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "optional": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Record",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Record",
@@ -92,40 +126,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Record",
-          "name": "ownerId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "User",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Record",
-          "name": "organisationId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Organisation",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Record",
-          "name": "parentId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "optional": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Record",
-            "relatedModelField": "id"
-          }
         }
       ],
       "actions": [
@@ -163,7 +163,10 @@
           "expression": {
             "source": "true"
           },
-          "actionTypes": ["ACTION_TYPE_CREATE", "ACTION_TYPE_UPDATE"]
+          "actionTypes": [
+            "ACTION_TYPE_CREATE",
+            "ACTION_TYPE_UPDATE"
+          ]
         }
       ]
     },
@@ -183,6 +186,18 @@
         },
         {
           "modelName": "User",
+          "name": "identityId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Identity",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "User",
           "name": "organisation",
           "type": {
             "type": "TYPE_MODEL",
@@ -190,6 +205,17 @@
           },
           "foreignKeyFieldName": "organisationId",
           "inverseFieldName": "users"
+        },
+        {
+          "modelName": "User",
+          "name": "organisationId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Organisation",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "User",
@@ -233,29 +259,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "User",
-          "name": "identityId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Identity",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "User",
-          "name": "organisationId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Organisation",
-            "relatedModelField": "id"
           }
         }
       ]
@@ -329,7 +332,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -366,7 +371,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -610,7 +617,9 @@
             "modelName": "Record",
             "fieldName": "name"
           },
-          "target": ["name"]
+          "target": [
+            "name"
+          ]
         },
         {
           "messageName": "CreateRecordWithChildrenInput",
@@ -634,7 +643,10 @@
             "modelName": "Record",
             "fieldName": "name"
           },
-          "target": ["children", "name"]
+          "target": [
+            "children",
+            "name"
+          ]
         }
       ]
     }

--- a/schema/testdata/proto/set_attribute_backlink_repeated_rhs_fields/proto.json
+++ b/schema/testdata/proto/set_attribute_backlink_repeated_rhs_fields/proto.json
@@ -21,17 +21,6 @@
         },
         {
           "modelName": "Record",
-          "name": "ownerId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "User",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Record",
           "name": "organisation",
           "type": {
             "type": "TYPE_MODEL",
@@ -41,12 +30,12 @@
         },
         {
           "modelName": "Record",
-          "name": "organisationId",
+          "name": "ownerId",
           "type": {
             "type": "TYPE_ID"
           },
           "foreignKeyInfo": {
-            "relatedModelName": "Organisation",
+            "relatedModelName": "User",
             "relatedModelField": "id"
           }
         },
@@ -60,6 +49,17 @@
             "expression": {
               "source": "false"
             }
+          }
+        },
+        {
+          "modelName": "Record",
+          "name": "organisationId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Organisation",
+            "relatedModelField": "id"
           }
         },
         {
@@ -163,7 +163,10 @@
           "expression": {
             "source": "true"
           },
-          "actionTypes": ["ACTION_TYPE_CREATE", "ACTION_TYPE_UPDATE"]
+          "actionTypes": [
+            "ACTION_TYPE_CREATE",
+            "ACTION_TYPE_UPDATE"
+          ]
         }
       ]
     },
@@ -329,7 +332,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -366,7 +371,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -610,7 +617,9 @@
             "modelName": "Record",
             "fieldName": "name"
           },
-          "target": ["name"]
+          "target": [
+            "name"
+          ]
         },
         {
           "messageName": "CreateRecordWithChildrenInput",
@@ -634,7 +643,10 @@
             "modelName": "Record",
             "fieldName": "name"
           },
-          "target": ["children", "name"]
+          "target": [
+            "children",
+            "name"
+          ]
         }
       ]
     }

--- a/schema/testdata/proto/set_attribute_backlinks/proto.json
+++ b/schema/testdata/proto/set_attribute_backlinks/proto.json
@@ -21,6 +21,17 @@
         },
         {
           "modelName": "Record",
+          "name": "ownerId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "User",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Record",
           "name": "organisation",
           "type": {
             "type": "TYPE_MODEL",
@@ -36,17 +47,6 @@
           },
           "foreignKeyInfo": {
             "relatedModelName": "Organisation",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Record",
-          "name": "ownerId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "User",
             "relatedModelField": "id"
           }
         },
@@ -183,6 +183,16 @@
         },
         {
           "modelName": "User",
+          "name": "organisation",
+          "type": {
+            "type": "TYPE_MODEL",
+            "modelName": "Organisation"
+          },
+          "foreignKeyFieldName": "organisationId",
+          "inverseFieldName": "users"
+        },
+        {
+          "modelName": "User",
           "name": "identityId",
           "type": {
             "type": "TYPE_ID"
@@ -192,16 +202,6 @@
             "relatedModelName": "Identity",
             "relatedModelField": "id"
           }
-        },
-        {
-          "modelName": "User",
-          "name": "organisation",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "Organisation"
-          },
-          "foreignKeyFieldName": "organisationId",
-          "inverseFieldName": "users"
         },
         {
           "modelName": "User",

--- a/schema/testdata/proto/set_attribute_backlinks/proto.json
+++ b/schema/testdata/proto/set_attribute_backlinks/proto.json
@@ -30,6 +30,17 @@
         },
         {
           "modelName": "Record",
+          "name": "ownerId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "User",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Record",
           "name": "isActive",
           "type": {
             "type": "TYPE_BOOL"
@@ -42,6 +53,17 @@
         },
         {
           "modelName": "Record",
+          "name": "organisationId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Organisation",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Record",
           "name": "parent",
           "type": {
             "type": "TYPE_MODEL",
@@ -50,6 +72,18 @@
           "optional": true,
           "foreignKeyFieldName": "parentId",
           "inverseFieldName": "children"
+        },
+        {
+          "modelName": "Record",
+          "name": "parentId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "optional": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Record",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Record",
@@ -91,40 +125,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "Record",
-          "name": "ownerId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "User",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Record",
-          "name": "organisationId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Organisation",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Record",
-          "name": "parentId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "optional": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Record",
-            "relatedModelField": "id"
           }
         }
       ],
@@ -183,6 +183,18 @@
         },
         {
           "modelName": "User",
+          "name": "identityId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Identity",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "User",
           "name": "organisation",
           "type": {
             "type": "TYPE_MODEL",
@@ -190,6 +202,17 @@
           },
           "foreignKeyFieldName": "organisationId",
           "inverseFieldName": "users"
+        },
+        {
+          "modelName": "User",
+          "name": "organisationId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Organisation",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "User",
@@ -233,29 +256,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "User",
-          "name": "identityId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Identity",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "User",
-          "name": "organisationId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Organisation",
-            "relatedModelField": "id"
           }
         }
       ]
@@ -329,7 +329,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -366,7 +368,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -613,7 +617,9 @@
             "modelName": "Record",
             "fieldName": "name"
           },
-          "target": ["name"]
+          "target": [
+            "name"
+          ]
         }
       ]
     },
@@ -628,7 +634,9 @@
             "modelName": "Record",
             "fieldName": "id"
           },
-          "target": ["id"]
+          "target": [
+            "id"
+          ]
         }
       ]
     },

--- a/schema/testdata/proto/set_attribute_backlinks/proto.json
+++ b/schema/testdata/proto/set_attribute_backlinks/proto.json
@@ -30,6 +30,17 @@
         },
         {
           "modelName": "Record",
+          "name": "organisationId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Organisation",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Record",
           "name": "ownerId",
           "type": {
             "type": "TYPE_ID"
@@ -49,17 +60,6 @@
             "expression": {
               "source": "false"
             }
-          }
-        },
-        {
-          "modelName": "Record",
-          "name": "organisationId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Organisation",
-            "relatedModelField": "id"
           }
         },
         {
@@ -329,7 +329,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -366,7 +368,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -613,7 +617,9 @@
             "modelName": "Record",
             "fieldName": "name"
           },
-          "target": ["name"]
+          "target": [
+            "name"
+          ]
         }
       ]
     },
@@ -628,7 +634,9 @@
             "modelName": "Record",
             "fieldName": "id"
           },
-          "target": ["id"]
+          "target": [
+            "id"
+          ]
         }
       ]
     },

--- a/schema/testdata/proto/set_attribute_backlinks/proto.json
+++ b/schema/testdata/proto/set_attribute_backlinks/proto.json
@@ -329,9 +329,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -368,9 +366,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -617,9 +613,7 @@
             "modelName": "Record",
             "fieldName": "name"
           },
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         }
       ]
     },
@@ -634,9 +628,7 @@
             "modelName": "Record",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },

--- a/schema/testdata/proto/set_attribute_backlinks/proto.json
+++ b/schema/testdata/proto/set_attribute_backlinks/proto.json
@@ -6,25 +6,18 @@
         {
           "modelName": "Record",
           "name": "name",
-          "type": {
-            "type": "TYPE_STRING"
-          }
+          "type": { "type": "TYPE_STRING" }
         },
         {
           "modelName": "Record",
           "name": "owner",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "User"
-          },
+          "type": { "type": "TYPE_MODEL", "modelName": "User" },
           "foreignKeyFieldName": "ownerId"
         },
         {
           "modelName": "Record",
           "name": "ownerId",
-          "type": {
-            "type": "TYPE_ID"
-          },
+          "type": { "type": "TYPE_ID" },
           "foreignKeyInfo": {
             "relatedModelName": "User",
             "relatedModelField": "id"
@@ -33,18 +26,13 @@
         {
           "modelName": "Record",
           "name": "organisation",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "Organisation"
-          },
+          "type": { "type": "TYPE_MODEL", "modelName": "Organisation" },
           "foreignKeyFieldName": "organisationId"
         },
         {
           "modelName": "Record",
           "name": "organisationId",
-          "type": {
-            "type": "TYPE_ID"
-          },
+          "type": { "type": "TYPE_ID" },
           "foreignKeyInfo": {
             "relatedModelName": "Organisation",
             "relatedModelField": "id"
@@ -53,22 +41,13 @@
         {
           "modelName": "Record",
           "name": "isActive",
-          "type": {
-            "type": "TYPE_BOOL"
-          },
-          "defaultValue": {
-            "expression": {
-              "source": "false"
-            }
-          }
+          "type": { "type": "TYPE_BOOL" },
+          "defaultValue": { "expression": { "source": "false" } }
         },
         {
           "modelName": "Record",
           "name": "parent",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "Record"
-          },
+          "type": { "type": "TYPE_MODEL", "modelName": "Record" },
           "optional": true,
           "foreignKeyFieldName": "parentId",
           "inverseFieldName": "children"
@@ -76,9 +55,7 @@
         {
           "modelName": "Record",
           "name": "parentId",
-          "type": {
-            "type": "TYPE_ID"
-          },
+          "type": { "type": "TYPE_ID" },
           "optional": true,
           "foreignKeyInfo": {
             "relatedModelName": "Record",
@@ -98,34 +75,22 @@
         {
           "modelName": "Record",
           "name": "id",
-          "type": {
-            "type": "TYPE_ID"
-          },
+          "type": { "type": "TYPE_ID" },
           "unique": true,
           "primaryKey": true,
-          "defaultValue": {
-            "useZeroValue": true
-          }
+          "defaultValue": { "useZeroValue": true }
         },
         {
           "modelName": "Record",
           "name": "createdAt",
-          "type": {
-            "type": "TYPE_DATETIME"
-          },
-          "defaultValue": {
-            "useZeroValue": true
-          }
+          "type": { "type": "TYPE_DATETIME" },
+          "defaultValue": { "useZeroValue": true }
         },
         {
           "modelName": "Record",
           "name": "updatedAt",
-          "type": {
-            "type": "TYPE_DATETIME"
-          },
-          "defaultValue": {
-            "useZeroValue": true
-          }
+          "type": { "type": "TYPE_DATETIME" },
+          "defaultValue": { "useZeroValue": true }
         }
       ],
       "actions": [
@@ -135,9 +100,7 @@
           "type": "ACTION_TYPE_CREATE",
           "implementation": "ACTION_IMPLEMENTATION_AUTO",
           "setExpressions": [
-            {
-              "source": "record.owner = ctx.identity.user"
-            },
+            { "source": "record.owner = ctx.identity.user" },
             {
               "source": "record.organisation.id = ctx.identity.user.organisation.id"
             },
@@ -153,9 +116,7 @@
           "type": "ACTION_TYPE_UPDATE",
           "implementation": "ACTION_IMPLEMENTATION_AUTO",
           "setExpressions": [
-            {
-              "source": "record.owner = ctx.identity.user"
-            },
+            { "source": "record.owner = ctx.identity.user" },
             {
               "source": "record.organisation.id = ctx.identity.user.organisation.id"
             },
@@ -173,30 +134,15 @@
         {
           "modelName": "User",
           "name": "identity",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "Identity"
-          },
+          "type": { "type": "TYPE_MODEL", "modelName": "Identity" },
           "unique": true,
           "foreignKeyFieldName": "identityId",
           "inverseFieldName": "user"
         },
         {
           "modelName": "User",
-          "name": "organisation",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "Organisation"
-          },
-          "foreignKeyFieldName": "organisationId",
-          "inverseFieldName": "users"
-        },
-        {
-          "modelName": "User",
           "name": "identityId",
-          "type": {
-            "type": "TYPE_ID"
-          },
+          "type": { "type": "TYPE_ID" },
           "unique": true,
           "foreignKeyInfo": {
             "relatedModelName": "Identity",
@@ -205,10 +151,15 @@
         },
         {
           "modelName": "User",
+          "name": "organisation",
+          "type": { "type": "TYPE_MODEL", "modelName": "Organisation" },
+          "foreignKeyFieldName": "organisationId",
+          "inverseFieldName": "users"
+        },
+        {
+          "modelName": "User",
           "name": "organisationId",
-          "type": {
-            "type": "TYPE_ID"
-          },
+          "type": { "type": "TYPE_ID" },
           "foreignKeyInfo": {
             "relatedModelName": "Organisation",
             "relatedModelField": "id"
@@ -217,46 +168,28 @@
         {
           "modelName": "User",
           "name": "isAdmin",
-          "type": {
-            "type": "TYPE_BOOL"
-          },
-          "defaultValue": {
-            "expression": {
-              "source": "false"
-            }
-          }
+          "type": { "type": "TYPE_BOOL" },
+          "defaultValue": { "expression": { "source": "false" } }
         },
         {
           "modelName": "User",
           "name": "id",
-          "type": {
-            "type": "TYPE_ID"
-          },
+          "type": { "type": "TYPE_ID" },
           "unique": true,
           "primaryKey": true,
-          "defaultValue": {
-            "useZeroValue": true
-          }
+          "defaultValue": { "useZeroValue": true }
         },
         {
           "modelName": "User",
           "name": "createdAt",
-          "type": {
-            "type": "TYPE_DATETIME"
-          },
-          "defaultValue": {
-            "useZeroValue": true
-          }
+          "type": { "type": "TYPE_DATETIME" },
+          "defaultValue": { "useZeroValue": true }
         },
         {
           "modelName": "User",
           "name": "updatedAt",
-          "type": {
-            "type": "TYPE_DATETIME"
-          },
-          "defaultValue": {
-            "useZeroValue": true
-          }
+          "type": { "type": "TYPE_DATETIME" },
+          "defaultValue": { "useZeroValue": true }
         }
       ]
     },
@@ -276,46 +209,28 @@
         {
           "modelName": "Organisation",
           "name": "isActive",
-          "type": {
-            "type": "TYPE_BOOL"
-          },
-          "defaultValue": {
-            "expression": {
-              "source": "true"
-            }
-          }
+          "type": { "type": "TYPE_BOOL" },
+          "defaultValue": { "expression": { "source": "true" } }
         },
         {
           "modelName": "Organisation",
           "name": "id",
-          "type": {
-            "type": "TYPE_ID"
-          },
+          "type": { "type": "TYPE_ID" },
           "unique": true,
           "primaryKey": true,
-          "defaultValue": {
-            "useZeroValue": true
-          }
+          "defaultValue": { "useZeroValue": true }
         },
         {
           "modelName": "Organisation",
           "name": "createdAt",
-          "type": {
-            "type": "TYPE_DATETIME"
-          },
-          "defaultValue": {
-            "useZeroValue": true
-          }
+          "type": { "type": "TYPE_DATETIME" },
+          "defaultValue": { "useZeroValue": true }
         },
         {
           "modelName": "Organisation",
           "name": "updatedAt",
-          "type": {
-            "type": "TYPE_DATETIME"
-          },
-          "defaultValue": {
-            "useZeroValue": true
-          }
+          "type": { "type": "TYPE_DATETIME" },
+          "defaultValue": { "useZeroValue": true }
         }
       ]
     },
@@ -325,180 +240,125 @@
         {
           "modelName": "Identity",
           "name": "email",
-          "type": {
-            "type": "TYPE_STRING"
-          },
+          "type": { "type": "TYPE_STRING" },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
           "name": "emailVerified",
-          "type": {
-            "type": "TYPE_BOOL"
-          },
-          "defaultValue": {
-            "expression": {
-              "source": "false"
-            }
-          }
+          "type": { "type": "TYPE_BOOL" },
+          "defaultValue": { "expression": { "source": "false" } }
         },
         {
           "modelName": "Identity",
           "name": "password",
-          "type": {
-            "type": "TYPE_PASSWORD"
-          },
+          "type": { "type": "TYPE_PASSWORD" },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "externalId",
-          "type": {
-            "type": "TYPE_STRING"
-          },
+          "type": { "type": "TYPE_STRING" },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "issuer",
-          "type": {
-            "type": "TYPE_STRING"
-          },
+          "type": { "type": "TYPE_STRING" },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
           "name": "name",
-          "type": {
-            "type": "TYPE_STRING"
-          },
+          "type": { "type": "TYPE_STRING" },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "givenName",
-          "type": {
-            "type": "TYPE_STRING"
-          },
+          "type": { "type": "TYPE_STRING" },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "familyName",
-          "type": {
-            "type": "TYPE_STRING"
-          },
+          "type": { "type": "TYPE_STRING" },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "middleName",
-          "type": {
-            "type": "TYPE_STRING"
-          },
+          "type": { "type": "TYPE_STRING" },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "nickName",
-          "type": {
-            "type": "TYPE_STRING"
-          },
+          "type": { "type": "TYPE_STRING" },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "profile",
-          "type": {
-            "type": "TYPE_STRING"
-          },
+          "type": { "type": "TYPE_STRING" },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "picture",
-          "type": {
-            "type": "TYPE_STRING"
-          },
+          "type": { "type": "TYPE_STRING" },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "website",
-          "type": {
-            "type": "TYPE_STRING"
-          },
+          "type": { "type": "TYPE_STRING" },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "gender",
-          "type": {
-            "type": "TYPE_STRING"
-          },
+          "type": { "type": "TYPE_STRING" },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "zoneInfo",
-          "type": {
-            "type": "TYPE_STRING"
-          },
+          "type": { "type": "TYPE_STRING" },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "locale",
-          "type": {
-            "type": "TYPE_STRING"
-          },
+          "type": { "type": "TYPE_STRING" },
           "optional": true
         },
         {
           "modelName": "Identity",
           "name": "id",
-          "type": {
-            "type": "TYPE_ID"
-          },
+          "type": { "type": "TYPE_ID" },
           "unique": true,
           "primaryKey": true,
-          "defaultValue": {
-            "useZeroValue": true
-          }
+          "defaultValue": { "useZeroValue": true }
         },
         {
           "modelName": "Identity",
           "name": "createdAt",
-          "type": {
-            "type": "TYPE_DATETIME"
-          },
-          "defaultValue": {
-            "useZeroValue": true
-          }
+          "type": { "type": "TYPE_DATETIME" },
+          "defaultValue": { "useZeroValue": true }
         },
         {
           "modelName": "Identity",
           "name": "updatedAt",
-          "type": {
-            "type": "TYPE_DATETIME"
-          },
-          "defaultValue": {
-            "useZeroValue": true
-          }
+          "type": { "type": "TYPE_DATETIME" },
+          "defaultValue": { "useZeroValue": true }
         },
         {
           "modelName": "Identity",
           "name": "user",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "User"
-          },
+          "type": { "type": "TYPE_MODEL", "modelName": "User" },
           "optional": true,
           "inverseFieldName": "identity"
         }
@@ -530,82 +390,56 @@
         {
           "modelName": "Record",
           "modelActions": [
-            {
-              "actionName": "createRecord"
-            },
-            {
-              "actionName": "updateRecordOwner"
-            }
+            { "actionName": "createRecord" },
+            { "actionName": "updateRecordOwner" }
           ]
         },
-        {
-          "modelName": "User"
-        },
-        {
-          "modelName": "Organisation"
-        },
+        { "modelName": "User" },
+        { "modelName": "Organisation" },
         {
           "modelName": "Identity",
           "modelActions": [
-            {
-              "actionName": "requestPasswordReset"
-            },
-            {
-              "actionName": "resetPassword"
-            }
+            { "actionName": "requestPasswordReset" },
+            { "actionName": "resetPassword" }
           ]
         }
       ]
     }
   ],
   "messages": [
-    {
-      "name": "Any"
-    },
+    { "name": "Any" },
     {
       "name": "RequestPasswordResetInput",
       "fields": [
         {
           "messageName": "RequestPasswordResetInput",
           "name": "email",
-          "type": {
-            "type": "TYPE_STRING"
-          }
+          "type": { "type": "TYPE_STRING" }
         },
         {
           "messageName": "RequestPasswordResetInput",
           "name": "redirectUrl",
-          "type": {
-            "type": "TYPE_STRING"
-          }
+          "type": { "type": "TYPE_STRING" }
         }
       ]
     },
-    {
-      "name": "RequestPasswordResetResponse"
-    },
+    { "name": "RequestPasswordResetResponse" },
     {
       "name": "ResetPasswordInput",
       "fields": [
         {
           "messageName": "ResetPasswordInput",
           "name": "token",
-          "type": {
-            "type": "TYPE_STRING"
-          }
+          "type": { "type": "TYPE_STRING" }
         },
         {
           "messageName": "ResetPasswordInput",
           "name": "password",
-          "type": {
-            "type": "TYPE_STRING"
-          }
+          "type": { "type": "TYPE_STRING" }
         }
       ]
     },
-    {
-      "name": "ResetPasswordResponse"
-    },
+    { "name": "ResetPasswordResponse" },
     {
       "name": "CreateRecordInput",
       "fields": [
@@ -617,9 +451,7 @@
             "modelName": "Record",
             "fieldName": "name"
           },
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         }
       ]
     },
@@ -634,15 +466,11 @@
             "modelName": "Record",
             "fieldName": "id"
           },
-          "target": [
-            "id"
-          ]
+          "target": ["id"]
         }
       ]
     },
-    {
-      "name": "UpdateRecordOwnerValues"
-    },
+    { "name": "UpdateRecordOwnerValues" },
     {
       "name": "UpdateRecordOwnerInput",
       "fields": [

--- a/schema/testdata/proto/set_attribute_lhs_within_write_scope/proto.json
+++ b/schema/testdata/proto/set_attribute_lhs_within_write_scope/proto.json
@@ -351,6 +351,16 @@
         },
         {
           "modelName": "Department",
+          "name": "head",
+          "type": {
+            "type": "TYPE_MODEL",
+            "modelName": "Person"
+          },
+          "optional": true,
+          "foreignKeyFieldName": "headId"
+        },
+        {
+          "modelName": "Department",
           "name": "publisherId",
           "type": {
             "type": "TYPE_ID"
@@ -359,16 +369,6 @@
             "relatedModelName": "Publisher",
             "relatedModelField": "id"
           }
-        },
-        {
-          "modelName": "Department",
-          "name": "head",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "Person"
-          },
-          "optional": true,
-          "foreignKeyFieldName": "headId"
         },
         {
           "modelName": "Department",
@@ -560,7 +560,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -597,7 +599,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -920,7 +924,11 @@
             "modelName": "Country",
             "fieldName": "id"
           },
-          "target": ["publisher", "country", "id"]
+          "target": [
+            "publisher",
+            "country",
+            "id"
+          ]
         }
       ]
     },
@@ -935,7 +943,11 @@
             "modelName": "Department",
             "fieldName": "name"
           },
-          "target": ["publisher", "departments", "name"]
+          "target": [
+            "publisher",
+            "departments",
+            "name"
+          ]
         },
         {
           "messageName": "NestedData1PublisherDepartmentsInput",
@@ -945,7 +957,11 @@
             "modelName": "Department",
             "fieldName": "number"
           },
-          "target": ["publisher", "departments", "number"]
+          "target": [
+            "publisher",
+            "departments",
+            "number"
+          ]
         }
       ]
     },
@@ -961,7 +977,9 @@
             "fieldName": "name"
           },
           "nullable": true,
-          "target": ["name"]
+          "target": [
+            "name"
+          ]
         }
       ]
     },
@@ -1012,7 +1030,11 @@
             "modelName": "Country",
             "fieldName": "id"
           },
-          "target": ["publisher", "country", "id"]
+          "target": [
+            "publisher",
+            "country",
+            "id"
+          ]
         }
       ]
     },
@@ -1027,7 +1049,11 @@
             "modelName": "Department",
             "fieldName": "name"
           },
-          "target": ["publisher", "departments", "name"]
+          "target": [
+            "publisher",
+            "departments",
+            "name"
+          ]
         },
         {
           "messageName": "NestedData3PublisherDepartmentsInput",
@@ -1037,7 +1063,11 @@
             "modelName": "Department",
             "fieldName": "number"
           },
-          "target": ["publisher", "departments", "number"]
+          "target": [
+            "publisher",
+            "departments",
+            "number"
+          ]
         }
       ]
     },
@@ -1088,7 +1118,11 @@
             "modelName": "Country",
             "fieldName": "id"
           },
-          "target": ["publisher", "country", "id"]
+          "target": [
+            "publisher",
+            "country",
+            "id"
+          ]
         }
       ]
     },
@@ -1103,7 +1137,11 @@
             "modelName": "Department",
             "fieldName": "name"
           },
-          "target": ["publisher", "departments", "name"]
+          "target": [
+            "publisher",
+            "departments",
+            "name"
+          ]
         },
         {
           "messageName": "NestedData4PublisherDepartmentsInput",
@@ -1113,7 +1151,11 @@
             "modelName": "Department",
             "fieldName": "number"
           },
-          "target": ["publisher", "departments", "number"]
+          "target": [
+            "publisher",
+            "departments",
+            "number"
+          ]
         }
       ]
     },
@@ -1129,7 +1171,9 @@
             "fieldName": "name"
           },
           "nullable": true,
-          "target": ["name"]
+          "target": [
+            "name"
+          ]
         }
       ]
     },
@@ -1171,7 +1215,11 @@
             "modelName": "Country",
             "fieldName": "id"
           },
-          "target": ["publisher", "country", "id"]
+          "target": [
+            "publisher",
+            "country",
+            "id"
+          ]
         }
       ]
     },
@@ -1223,7 +1271,11 @@
             "fieldName": "name"
           },
           "nullable": true,
-          "target": ["publisher", "country", "name"]
+          "target": [
+            "publisher",
+            "country",
+            "name"
+          ]
         }
       ]
     },
@@ -1238,7 +1290,11 @@
             "modelName": "Department",
             "fieldName": "name"
           },
-          "target": ["publisher", "departments", "name"]
+          "target": [
+            "publisher",
+            "departments",
+            "name"
+          ]
         },
         {
           "messageName": "NestedData7PublisherDepartmentsInput",
@@ -1248,7 +1304,11 @@
             "modelName": "Department",
             "fieldName": "number"
           },
-          "target": ["publisher", "departments", "number"]
+          "target": [
+            "publisher",
+            "departments",
+            "number"
+          ]
         }
       ]
     },
@@ -1299,7 +1359,11 @@
             "modelName": "Country",
             "fieldName": "id"
           },
-          "target": ["publisher", "country", "id"]
+          "target": [
+            "publisher",
+            "country",
+            "id"
+          ]
         }
       ]
     },
@@ -1314,7 +1378,11 @@
             "modelName": "Department",
             "fieldName": "name"
           },
-          "target": ["publisher", "departments", "name"]
+          "target": [
+            "publisher",
+            "departments",
+            "name"
+          ]
         },
         {
           "messageName": "NestedData8PublisherDepartmentsInput",
@@ -1324,7 +1392,11 @@
             "modelName": "Department",
             "fieldName": "number"
           },
-          "target": ["publisher", "departments", "number"]
+          "target": [
+            "publisher",
+            "departments",
+            "number"
+          ]
         }
       ]
     },

--- a/schema/testdata/proto/set_attribute_lhs_within_write_scope/proto.json
+++ b/schema/testdata/proto/set_attribute_lhs_within_write_scope/proto.json
@@ -31,6 +31,16 @@
         },
         {
           "modelName": "Post",
+          "name": "publisher",
+          "type": {
+            "type": "TYPE_MODEL",
+            "modelName": "Publisher"
+          },
+          "optional": true,
+          "foreignKeyFieldName": "publisherId"
+        },
+        {
+          "modelName": "Post",
           "name": "identityId",
           "type": {
             "type": "TYPE_ID"
@@ -40,16 +50,6 @@
             "relatedModelName": "Identity",
             "relatedModelField": "id"
           }
-        },
-        {
-          "modelName": "Post",
-          "name": "publisher",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "Publisher"
-          },
-          "optional": true,
-          "foreignKeyFieldName": "publisherId"
         },
         {
           "modelName": "Post",
@@ -351,16 +351,6 @@
         },
         {
           "modelName": "Department",
-          "name": "head",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "Person"
-          },
-          "optional": true,
-          "foreignKeyFieldName": "headId"
-        },
-        {
-          "modelName": "Department",
           "name": "publisherId",
           "type": {
             "type": "TYPE_ID"
@@ -369,6 +359,16 @@
             "relatedModelName": "Publisher",
             "relatedModelField": "id"
           }
+        },
+        {
+          "modelName": "Department",
+          "name": "head",
+          "type": {
+            "type": "TYPE_MODEL",
+            "modelName": "Person"
+          },
+          "optional": true,
+          "foreignKeyFieldName": "headId"
         },
         {
           "modelName": "Department",

--- a/schema/testdata/proto/set_attribute_lhs_within_write_scope/proto.json
+++ b/schema/testdata/proto/set_attribute_lhs_within_write_scope/proto.json
@@ -31,16 +31,6 @@
         },
         {
           "modelName": "Post",
-          "name": "publisher",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "Publisher"
-          },
-          "optional": true,
-          "foreignKeyFieldName": "publisherId"
-        },
-        {
-          "modelName": "Post",
           "name": "identityId",
           "type": {
             "type": "TYPE_ID"
@@ -50,6 +40,16 @@
             "relatedModelName": "Identity",
             "relatedModelField": "id"
           }
+        },
+        {
+          "modelName": "Post",
+          "name": "publisher",
+          "type": {
+            "type": "TYPE_MODEL",
+            "modelName": "Publisher"
+          },
+          "optional": true,
+          "foreignKeyFieldName": "publisherId"
         },
         {
           "modelName": "Post",
@@ -560,9 +560,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -599,9 +597,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -924,11 +920,7 @@
             "modelName": "Country",
             "fieldName": "id"
           },
-          "target": [
-            "publisher",
-            "country",
-            "id"
-          ]
+          "target": ["publisher", "country", "id"]
         }
       ]
     },
@@ -943,11 +935,7 @@
             "modelName": "Department",
             "fieldName": "name"
           },
-          "target": [
-            "publisher",
-            "departments",
-            "name"
-          ]
+          "target": ["publisher", "departments", "name"]
         },
         {
           "messageName": "NestedData1PublisherDepartmentsInput",
@@ -957,11 +945,7 @@
             "modelName": "Department",
             "fieldName": "number"
           },
-          "target": [
-            "publisher",
-            "departments",
-            "number"
-          ]
+          "target": ["publisher", "departments", "number"]
         }
       ]
     },
@@ -977,9 +961,7 @@
             "fieldName": "name"
           },
           "nullable": true,
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         }
       ]
     },
@@ -1030,11 +1012,7 @@
             "modelName": "Country",
             "fieldName": "id"
           },
-          "target": [
-            "publisher",
-            "country",
-            "id"
-          ]
+          "target": ["publisher", "country", "id"]
         }
       ]
     },
@@ -1049,11 +1027,7 @@
             "modelName": "Department",
             "fieldName": "name"
           },
-          "target": [
-            "publisher",
-            "departments",
-            "name"
-          ]
+          "target": ["publisher", "departments", "name"]
         },
         {
           "messageName": "NestedData3PublisherDepartmentsInput",
@@ -1063,11 +1037,7 @@
             "modelName": "Department",
             "fieldName": "number"
           },
-          "target": [
-            "publisher",
-            "departments",
-            "number"
-          ]
+          "target": ["publisher", "departments", "number"]
         }
       ]
     },
@@ -1118,11 +1088,7 @@
             "modelName": "Country",
             "fieldName": "id"
           },
-          "target": [
-            "publisher",
-            "country",
-            "id"
-          ]
+          "target": ["publisher", "country", "id"]
         }
       ]
     },
@@ -1137,11 +1103,7 @@
             "modelName": "Department",
             "fieldName": "name"
           },
-          "target": [
-            "publisher",
-            "departments",
-            "name"
-          ]
+          "target": ["publisher", "departments", "name"]
         },
         {
           "messageName": "NestedData4PublisherDepartmentsInput",
@@ -1151,11 +1113,7 @@
             "modelName": "Department",
             "fieldName": "number"
           },
-          "target": [
-            "publisher",
-            "departments",
-            "number"
-          ]
+          "target": ["publisher", "departments", "number"]
         }
       ]
     },
@@ -1171,9 +1129,7 @@
             "fieldName": "name"
           },
           "nullable": true,
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         }
       ]
     },
@@ -1215,11 +1171,7 @@
             "modelName": "Country",
             "fieldName": "id"
           },
-          "target": [
-            "publisher",
-            "country",
-            "id"
-          ]
+          "target": ["publisher", "country", "id"]
         }
       ]
     },
@@ -1271,11 +1223,7 @@
             "fieldName": "name"
           },
           "nullable": true,
-          "target": [
-            "publisher",
-            "country",
-            "name"
-          ]
+          "target": ["publisher", "country", "name"]
         }
       ]
     },
@@ -1290,11 +1238,7 @@
             "modelName": "Department",
             "fieldName": "name"
           },
-          "target": [
-            "publisher",
-            "departments",
-            "name"
-          ]
+          "target": ["publisher", "departments", "name"]
         },
         {
           "messageName": "NestedData7PublisherDepartmentsInput",
@@ -1304,11 +1248,7 @@
             "modelName": "Department",
             "fieldName": "number"
           },
-          "target": [
-            "publisher",
-            "departments",
-            "number"
-          ]
+          "target": ["publisher", "departments", "number"]
         }
       ]
     },
@@ -1359,11 +1299,7 @@
             "modelName": "Country",
             "fieldName": "id"
           },
-          "target": [
-            "publisher",
-            "country",
-            "id"
-          ]
+          "target": ["publisher", "country", "id"]
         }
       ]
     },
@@ -1378,11 +1314,7 @@
             "modelName": "Department",
             "fieldName": "name"
           },
-          "target": [
-            "publisher",
-            "departments",
-            "name"
-          ]
+          "target": ["publisher", "departments", "name"]
         },
         {
           "messageName": "NestedData8PublisherDepartmentsInput",
@@ -1392,11 +1324,7 @@
             "modelName": "Department",
             "fieldName": "number"
           },
-          "target": [
-            "publisher",
-            "departments",
-            "number"
-          ]
+          "target": ["publisher", "departments", "number"]
         }
       ]
     },

--- a/schema/testdata/proto/set_attribute_lhs_within_write_scope/proto.json
+++ b/schema/testdata/proto/set_attribute_lhs_within_write_scope/proto.json
@@ -31,6 +31,18 @@
         },
         {
           "modelName": "Post",
+          "name": "identityId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "optional": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Identity",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Post",
           "name": "publisher",
           "type": {
             "type": "TYPE_MODEL",
@@ -38,6 +50,18 @@
           },
           "optional": true,
           "foreignKeyFieldName": "publisherId"
+        },
+        {
+          "modelName": "Post",
+          "name": "publisherId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "optional": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Publisher",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Post",
@@ -69,30 +93,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "Post",
-          "name": "identityId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "optional": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Identity",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Post",
-          "name": "publisherId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "optional": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Publisher",
-            "relatedModelField": "id"
           }
         }
       ],
@@ -259,6 +259,28 @@
         },
         {
           "modelName": "Publisher",
+          "name": "ownerId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Person",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Publisher",
+          "name": "countryId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Country",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Publisher",
           "name": "admin",
           "type": {
             "type": "TYPE_MODEL",
@@ -267,6 +289,18 @@
           "unique": true,
           "foreignKeyFieldName": "adminId",
           "inverseFieldName": "publisher"
+        },
+        {
+          "modelName": "Publisher",
+          "name": "adminId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Identity",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Publisher",
@@ -299,40 +333,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Publisher",
-          "name": "ownerId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Person",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Publisher",
-          "name": "countryId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Country",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Publisher",
-          "name": "adminId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Identity",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -351,6 +351,17 @@
         },
         {
           "modelName": "Department",
+          "name": "publisherId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Publisher",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Department",
           "name": "head",
           "type": {
             "type": "TYPE_MODEL",
@@ -358,6 +369,18 @@
           },
           "optional": true,
           "foreignKeyFieldName": "headId"
+        },
+        {
+          "modelName": "Department",
+          "name": "headId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "optional": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Person",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Department",
@@ -403,29 +426,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "Department",
-          "name": "publisherId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Publisher",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Department",
-          "name": "headId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "optional": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Person",
-            "relatedModelField": "id"
           }
         }
       ]
@@ -506,6 +506,18 @@
         },
         {
           "modelName": "Person",
+          "name": "identityId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Identity",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Person",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -535,18 +547,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "Person",
-          "name": "identityId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Identity",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -560,7 +560,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -597,7 +599,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -920,7 +924,11 @@
             "modelName": "Country",
             "fieldName": "id"
           },
-          "target": ["publisher", "country", "id"]
+          "target": [
+            "publisher",
+            "country",
+            "id"
+          ]
         }
       ]
     },
@@ -935,7 +943,11 @@
             "modelName": "Department",
             "fieldName": "name"
           },
-          "target": ["publisher", "departments", "name"]
+          "target": [
+            "publisher",
+            "departments",
+            "name"
+          ]
         },
         {
           "messageName": "NestedData1PublisherDepartmentsInput",
@@ -945,7 +957,11 @@
             "modelName": "Department",
             "fieldName": "number"
           },
-          "target": ["publisher", "departments", "number"]
+          "target": [
+            "publisher",
+            "departments",
+            "number"
+          ]
         }
       ]
     },
@@ -961,7 +977,9 @@
             "fieldName": "name"
           },
           "nullable": true,
-          "target": ["name"]
+          "target": [
+            "name"
+          ]
         }
       ]
     },
@@ -1012,7 +1030,11 @@
             "modelName": "Country",
             "fieldName": "id"
           },
-          "target": ["publisher", "country", "id"]
+          "target": [
+            "publisher",
+            "country",
+            "id"
+          ]
         }
       ]
     },
@@ -1027,7 +1049,11 @@
             "modelName": "Department",
             "fieldName": "name"
           },
-          "target": ["publisher", "departments", "name"]
+          "target": [
+            "publisher",
+            "departments",
+            "name"
+          ]
         },
         {
           "messageName": "NestedData3PublisherDepartmentsInput",
@@ -1037,7 +1063,11 @@
             "modelName": "Department",
             "fieldName": "number"
           },
-          "target": ["publisher", "departments", "number"]
+          "target": [
+            "publisher",
+            "departments",
+            "number"
+          ]
         }
       ]
     },
@@ -1088,7 +1118,11 @@
             "modelName": "Country",
             "fieldName": "id"
           },
-          "target": ["publisher", "country", "id"]
+          "target": [
+            "publisher",
+            "country",
+            "id"
+          ]
         }
       ]
     },
@@ -1103,7 +1137,11 @@
             "modelName": "Department",
             "fieldName": "name"
           },
-          "target": ["publisher", "departments", "name"]
+          "target": [
+            "publisher",
+            "departments",
+            "name"
+          ]
         },
         {
           "messageName": "NestedData4PublisherDepartmentsInput",
@@ -1113,7 +1151,11 @@
             "modelName": "Department",
             "fieldName": "number"
           },
-          "target": ["publisher", "departments", "number"]
+          "target": [
+            "publisher",
+            "departments",
+            "number"
+          ]
         }
       ]
     },
@@ -1129,7 +1171,9 @@
             "fieldName": "name"
           },
           "nullable": true,
-          "target": ["name"]
+          "target": [
+            "name"
+          ]
         }
       ]
     },
@@ -1171,7 +1215,11 @@
             "modelName": "Country",
             "fieldName": "id"
           },
-          "target": ["publisher", "country", "id"]
+          "target": [
+            "publisher",
+            "country",
+            "id"
+          ]
         }
       ]
     },
@@ -1223,7 +1271,11 @@
             "fieldName": "name"
           },
           "nullable": true,
-          "target": ["publisher", "country", "name"]
+          "target": [
+            "publisher",
+            "country",
+            "name"
+          ]
         }
       ]
     },
@@ -1238,7 +1290,11 @@
             "modelName": "Department",
             "fieldName": "name"
           },
-          "target": ["publisher", "departments", "name"]
+          "target": [
+            "publisher",
+            "departments",
+            "name"
+          ]
         },
         {
           "messageName": "NestedData7PublisherDepartmentsInput",
@@ -1248,7 +1304,11 @@
             "modelName": "Department",
             "fieldName": "number"
           },
-          "target": ["publisher", "departments", "number"]
+          "target": [
+            "publisher",
+            "departments",
+            "number"
+          ]
         }
       ]
     },
@@ -1299,7 +1359,11 @@
             "modelName": "Country",
             "fieldName": "id"
           },
-          "target": ["publisher", "country", "id"]
+          "target": [
+            "publisher",
+            "country",
+            "id"
+          ]
         }
       ]
     },
@@ -1314,7 +1378,11 @@
             "modelName": "Department",
             "fieldName": "name"
           },
-          "target": ["publisher", "departments", "name"]
+          "target": [
+            "publisher",
+            "departments",
+            "name"
+          ]
         },
         {
           "messageName": "NestedData8PublisherDepartmentsInput",
@@ -1324,7 +1392,11 @@
             "modelName": "Department",
             "fieldName": "number"
           },
-          "target": ["publisher", "departments", "number"]
+          "target": [
+            "publisher",
+            "departments",
+            "number"
+          ]
         }
       ]
     },

--- a/schema/testdata/proto/set_attribute_lhs_within_write_scope/proto.json
+++ b/schema/testdata/proto/set_attribute_lhs_within_write_scope/proto.json
@@ -240,6 +240,17 @@
         },
         {
           "modelName": "Publisher",
+          "name": "ownerId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Person",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Publisher",
           "name": "departments",
           "type": {
             "type": "TYPE_MODEL",
@@ -256,17 +267,6 @@
             "modelName": "Country"
           },
           "foreignKeyFieldName": "countryId"
-        },
-        {
-          "modelName": "Publisher",
-          "name": "ownerId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Person",
-            "relatedModelField": "id"
-          }
         },
         {
           "modelName": "Publisher",

--- a/schema/testdata/proto/set_attribute_lhs_within_write_scope/proto.json
+++ b/schema/testdata/proto/set_attribute_lhs_within_write_scope/proto.json
@@ -560,9 +560,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -599,9 +597,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -924,11 +920,7 @@
             "modelName": "Country",
             "fieldName": "id"
           },
-          "target": [
-            "publisher",
-            "country",
-            "id"
-          ]
+          "target": ["publisher", "country", "id"]
         }
       ]
     },
@@ -943,11 +935,7 @@
             "modelName": "Department",
             "fieldName": "name"
           },
-          "target": [
-            "publisher",
-            "departments",
-            "name"
-          ]
+          "target": ["publisher", "departments", "name"]
         },
         {
           "messageName": "NestedData1PublisherDepartmentsInput",
@@ -957,11 +945,7 @@
             "modelName": "Department",
             "fieldName": "number"
           },
-          "target": [
-            "publisher",
-            "departments",
-            "number"
-          ]
+          "target": ["publisher", "departments", "number"]
         }
       ]
     },
@@ -977,9 +961,7 @@
             "fieldName": "name"
           },
           "nullable": true,
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         }
       ]
     },
@@ -1030,11 +1012,7 @@
             "modelName": "Country",
             "fieldName": "id"
           },
-          "target": [
-            "publisher",
-            "country",
-            "id"
-          ]
+          "target": ["publisher", "country", "id"]
         }
       ]
     },
@@ -1049,11 +1027,7 @@
             "modelName": "Department",
             "fieldName": "name"
           },
-          "target": [
-            "publisher",
-            "departments",
-            "name"
-          ]
+          "target": ["publisher", "departments", "name"]
         },
         {
           "messageName": "NestedData3PublisherDepartmentsInput",
@@ -1063,11 +1037,7 @@
             "modelName": "Department",
             "fieldName": "number"
           },
-          "target": [
-            "publisher",
-            "departments",
-            "number"
-          ]
+          "target": ["publisher", "departments", "number"]
         }
       ]
     },
@@ -1118,11 +1088,7 @@
             "modelName": "Country",
             "fieldName": "id"
           },
-          "target": [
-            "publisher",
-            "country",
-            "id"
-          ]
+          "target": ["publisher", "country", "id"]
         }
       ]
     },
@@ -1137,11 +1103,7 @@
             "modelName": "Department",
             "fieldName": "name"
           },
-          "target": [
-            "publisher",
-            "departments",
-            "name"
-          ]
+          "target": ["publisher", "departments", "name"]
         },
         {
           "messageName": "NestedData4PublisherDepartmentsInput",
@@ -1151,11 +1113,7 @@
             "modelName": "Department",
             "fieldName": "number"
           },
-          "target": [
-            "publisher",
-            "departments",
-            "number"
-          ]
+          "target": ["publisher", "departments", "number"]
         }
       ]
     },
@@ -1171,9 +1129,7 @@
             "fieldName": "name"
           },
           "nullable": true,
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         }
       ]
     },
@@ -1215,11 +1171,7 @@
             "modelName": "Country",
             "fieldName": "id"
           },
-          "target": [
-            "publisher",
-            "country",
-            "id"
-          ]
+          "target": ["publisher", "country", "id"]
         }
       ]
     },
@@ -1271,11 +1223,7 @@
             "fieldName": "name"
           },
           "nullable": true,
-          "target": [
-            "publisher",
-            "country",
-            "name"
-          ]
+          "target": ["publisher", "country", "name"]
         }
       ]
     },
@@ -1290,11 +1238,7 @@
             "modelName": "Department",
             "fieldName": "name"
           },
-          "target": [
-            "publisher",
-            "departments",
-            "name"
-          ]
+          "target": ["publisher", "departments", "name"]
         },
         {
           "messageName": "NestedData7PublisherDepartmentsInput",
@@ -1304,11 +1248,7 @@
             "modelName": "Department",
             "fieldName": "number"
           },
-          "target": [
-            "publisher",
-            "departments",
-            "number"
-          ]
+          "target": ["publisher", "departments", "number"]
         }
       ]
     },
@@ -1359,11 +1299,7 @@
             "modelName": "Country",
             "fieldName": "id"
           },
-          "target": [
-            "publisher",
-            "country",
-            "id"
-          ]
+          "target": ["publisher", "country", "id"]
         }
       ]
     },
@@ -1378,11 +1314,7 @@
             "modelName": "Department",
             "fieldName": "name"
           },
-          "target": [
-            "publisher",
-            "departments",
-            "name"
-          ]
+          "target": ["publisher", "departments", "name"]
         },
         {
           "messageName": "NestedData8PublisherDepartmentsInput",
@@ -1392,11 +1324,7 @@
             "modelName": "Department",
             "fieldName": "number"
           },
-          "target": [
-            "publisher",
-            "departments",
-            "number"
-          ]
+          "target": ["publisher", "departments", "number"]
         }
       ]
     },

--- a/schema/testdata/proto/unique_attribute/proto.json
+++ b/schema/testdata/proto/unique_attribute/proto.json
@@ -9,9 +9,7 @@
           "type": {
             "type": "TYPE_STRING"
           },
-          "uniqueWith": [
-            "publisher"
-          ]
+          "uniqueWith": ["publisher"]
         },
         {
           "modelName": "Product",
@@ -20,9 +18,7 @@
             "type": "TYPE_MODEL",
             "modelName": "Publisher"
           },
-          "uniqueWith": [
-            "name"
-          ],
+          "uniqueWith": ["name"],
           "foreignKeyFieldName": "publisherId"
         },
         {
@@ -117,9 +113,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -156,9 +150,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/unique_attribute/proto.json
+++ b/schema/testdata/proto/unique_attribute/proto.json
@@ -9,7 +9,9 @@
           "type": {
             "type": "TYPE_STRING"
           },
-          "uniqueWith": ["publisher"]
+          "uniqueWith": [
+            "publisher"
+          ]
         },
         {
           "modelName": "Product",
@@ -18,8 +20,21 @@
             "type": "TYPE_MODEL",
             "modelName": "Publisher"
           },
-          "uniqueWith": ["name"],
+          "uniqueWith": [
+            "name"
+          ],
           "foreignKeyFieldName": "publisherId"
+        },
+        {
+          "modelName": "Product",
+          "name": "publisherId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Publisher",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Product",
@@ -51,17 +66,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "Product",
-          "name": "publisherId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Publisher",
-            "relatedModelField": "id"
           }
         }
       ]
@@ -113,7 +117,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -150,7 +156,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/unique_composite_lookup/proto.json
+++ b/schema/testdata/proto/unique_composite_lookup/proto.json
@@ -128,9 +128,7 @@
             "type": "TYPE_MODEL",
             "modelName": "Supplier"
           },
-          "uniqueWith": [
-            "supplierSku"
-          ],
+          "uniqueWith": ["supplierSku"],
           "foreignKeyFieldName": "supplierId",
           "inverseFieldName": "products"
         },
@@ -151,9 +149,7 @@
           "type": {
             "type": "TYPE_STRING"
           },
-          "uniqueWith": [
-            "supplier"
-          ]
+          "uniqueWith": ["supplier"]
         },
         {
           "modelName": "Product",
@@ -453,9 +449,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -492,9 +486,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -778,9 +770,7 @@
             "modelName": "Product",
             "fieldName": "supplierSku"
           },
-          "target": [
-            "supplierSku"
-          ]
+          "target": ["supplierSku"]
         },
         {
           "messageName": "GetBySupplierSkuInputAndIdInputInput",
@@ -790,10 +780,7 @@
             "modelName": "Supplier",
             "fieldName": "id"
           },
-          "target": [
-            "supplier",
-            "id"
-          ]
+          "target": ["supplier", "id"]
         }
       ]
     },
@@ -808,9 +795,7 @@
             "modelName": "Product",
             "fieldName": "supplierSku"
           },
-          "target": [
-            "supplierSku"
-          ]
+          "target": ["supplierSku"]
         },
         {
           "messageName": "GetBySupplierSkuInputAndCodeInputInput",
@@ -820,10 +805,7 @@
             "modelName": "Supplier",
             "fieldName": "supplierCode"
           },
-          "target": [
-            "supplier",
-            "supplierCode"
-          ]
+          "target": ["supplier", "supplierCode"]
         }
       ]
     },
@@ -895,9 +877,7 @@
             "modelName": "Product",
             "fieldName": "supplierSku"
           },
-          "target": [
-            "supplierSku"
-          ]
+          "target": ["supplierSku"]
         }
       ]
     },
@@ -915,10 +895,7 @@
             "modelName": "Product",
             "fieldName": "supplierSku"
           },
-          "target": [
-            "product",
-            "supplierSku"
-          ]
+          "target": ["product", "supplierSku"]
         },
         {
           "messageName": "GetBySupplierSkuAndCodeInput",
@@ -928,11 +905,7 @@
             "modelName": "Supplier",
             "fieldName": "supplierCode"
           },
-          "target": [
-            "product",
-            "supplier",
-            "supplierCode"
-          ]
+          "target": ["product", "supplier", "supplierCode"]
         }
       ]
     },
@@ -947,10 +920,7 @@
             "modelName": "Product",
             "fieldName": "sku"
           },
-          "target": [
-            "product",
-            "sku"
-          ]
+          "target": ["product", "sku"]
         }
       ]
     },
@@ -968,9 +938,7 @@
             "modelName": "Supplier",
             "fieldName": "supplierCode"
           },
-          "target": [
-            "supplierCode"
-          ]
+          "target": ["supplierCode"]
         }
       ]
     },
@@ -985,10 +953,7 @@
             "modelName": "Product",
             "fieldName": "sku"
           },
-          "target": [
-            "products",
-            "sku"
-          ]
+          "target": ["products", "sku"]
         }
       ]
     }

--- a/schema/testdata/proto/unique_composite_lookup/proto.json
+++ b/schema/testdata/proto/unique_composite_lookup/proto.json
@@ -14,6 +14,17 @@
         },
         {
           "modelName": "User",
+          "name": "assignedProductId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Product",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "User",
           "name": "identity",
           "type": {
             "type": "TYPE_MODEL",
@@ -22,6 +33,18 @@
           "unique": true,
           "foreignKeyFieldName": "identityId",
           "inverseFieldName": "user"
+        },
+        {
+          "modelName": "User",
+          "name": "identityId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Identity",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "User",
@@ -53,29 +76,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "User",
-          "name": "assignedProductId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Product",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "User",
-          "name": "identityId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Identity",
-            "relatedModelField": "id"
           }
         }
       ]
@@ -111,14 +111,39 @@
         },
         {
           "modelName": "Product",
+          "name": "stockId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Stock",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Product",
           "name": "supplier",
           "type": {
             "type": "TYPE_MODEL",
             "modelName": "Supplier"
           },
-          "uniqueWith": ["supplierSku"],
+          "uniqueWith": [
+            "supplierSku"
+          ],
           "foreignKeyFieldName": "supplierId",
           "inverseFieldName": "products"
+        },
+        {
+          "modelName": "Product",
+          "name": "supplierId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Supplier",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Product",
@@ -126,7 +151,9 @@
           "type": {
             "type": "TYPE_STRING"
           },
-          "uniqueWith": ["supplier"]
+          "uniqueWith": [
+            "supplier"
+          ]
         },
         {
           "modelName": "Product",
@@ -165,29 +192,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "Product",
-          "name": "stockId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Stock",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Product",
-          "name": "supplierId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Supplier",
-            "relatedModelField": "id"
           }
         }
       ],
@@ -449,7 +453,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -486,7 +492,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -770,7 +778,9 @@
             "modelName": "Product",
             "fieldName": "supplierSku"
           },
-          "target": ["supplierSku"]
+          "target": [
+            "supplierSku"
+          ]
         },
         {
           "messageName": "GetBySupplierSkuInputAndIdInputInput",
@@ -780,7 +790,10 @@
             "modelName": "Supplier",
             "fieldName": "id"
           },
-          "target": ["supplier", "id"]
+          "target": [
+            "supplier",
+            "id"
+          ]
         }
       ]
     },
@@ -795,7 +808,9 @@
             "modelName": "Product",
             "fieldName": "supplierSku"
           },
-          "target": ["supplierSku"]
+          "target": [
+            "supplierSku"
+          ]
         },
         {
           "messageName": "GetBySupplierSkuInputAndCodeInputInput",
@@ -805,7 +820,10 @@
             "modelName": "Supplier",
             "fieldName": "supplierCode"
           },
-          "target": ["supplier", "supplierCode"]
+          "target": [
+            "supplier",
+            "supplierCode"
+          ]
         }
       ]
     },
@@ -877,7 +895,9 @@
             "modelName": "Product",
             "fieldName": "supplierSku"
           },
-          "target": ["supplierSku"]
+          "target": [
+            "supplierSku"
+          ]
         }
       ]
     },
@@ -895,7 +915,10 @@
             "modelName": "Product",
             "fieldName": "supplierSku"
           },
-          "target": ["product", "supplierSku"]
+          "target": [
+            "product",
+            "supplierSku"
+          ]
         },
         {
           "messageName": "GetBySupplierSkuAndCodeInput",
@@ -905,7 +928,11 @@
             "modelName": "Supplier",
             "fieldName": "supplierCode"
           },
-          "target": ["product", "supplier", "supplierCode"]
+          "target": [
+            "product",
+            "supplier",
+            "supplierCode"
+          ]
         }
       ]
     },
@@ -920,7 +947,10 @@
             "modelName": "Product",
             "fieldName": "sku"
           },
-          "target": ["product", "sku"]
+          "target": [
+            "product",
+            "sku"
+          ]
         }
       ]
     },
@@ -938,7 +968,9 @@
             "modelName": "Supplier",
             "fieldName": "supplierCode"
           },
-          "target": ["supplierCode"]
+          "target": [
+            "supplierCode"
+          ]
         }
       ]
     },
@@ -953,7 +985,10 @@
             "modelName": "Product",
             "fieldName": "sku"
           },
-          "target": ["products", "sku"]
+          "target": [
+            "products",
+            "sku"
+          ]
         }
       ]
     }

--- a/schema/testdata/proto/unique_composite_lookup/proto.json
+++ b/schema/testdata/proto/unique_composite_lookup/proto.json
@@ -14,17 +14,6 @@
         },
         {
           "modelName": "User",
-          "name": "identity",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "Identity"
-          },
-          "unique": true,
-          "foreignKeyFieldName": "identityId",
-          "inverseFieldName": "user"
-        },
-        {
-          "modelName": "User",
           "name": "assignedProductId",
           "type": {
             "type": "TYPE_ID"
@@ -33,6 +22,17 @@
             "relatedModelName": "Product",
             "relatedModelField": "id"
           }
+        },
+        {
+          "modelName": "User",
+          "name": "identity",
+          "type": {
+            "type": "TYPE_MODEL",
+            "modelName": "Identity"
+          },
+          "unique": true,
+          "foreignKeyFieldName": "identityId",
+          "inverseFieldName": "user"
         },
         {
           "modelName": "User",

--- a/schema/testdata/proto/unique_composite_lookup/proto.json
+++ b/schema/testdata/proto/unique_composite_lookup/proto.json
@@ -14,17 +14,6 @@
         },
         {
           "modelName": "User",
-          "name": "assignedProductId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Product",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "User",
           "name": "identity",
           "type": {
             "type": "TYPE_MODEL",
@@ -33,6 +22,17 @@
           "unique": true,
           "foreignKeyFieldName": "identityId",
           "inverseFieldName": "user"
+        },
+        {
+          "modelName": "User",
+          "name": "assignedProductId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Product",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "User",
@@ -128,7 +128,9 @@
             "type": "TYPE_MODEL",
             "modelName": "Supplier"
           },
-          "uniqueWith": ["supplierSku"],
+          "uniqueWith": [
+            "supplierSku"
+          ],
           "foreignKeyFieldName": "supplierId",
           "inverseFieldName": "products"
         },
@@ -149,7 +151,9 @@
           "type": {
             "type": "TYPE_STRING"
           },
-          "uniqueWith": ["supplier"]
+          "uniqueWith": [
+            "supplier"
+          ]
         },
         {
           "modelName": "Product",
@@ -449,7 +453,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -486,7 +492,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -770,7 +778,9 @@
             "modelName": "Product",
             "fieldName": "supplierSku"
           },
-          "target": ["supplierSku"]
+          "target": [
+            "supplierSku"
+          ]
         },
         {
           "messageName": "GetBySupplierSkuInputAndIdInputInput",
@@ -780,7 +790,10 @@
             "modelName": "Supplier",
             "fieldName": "id"
           },
-          "target": ["supplier", "id"]
+          "target": [
+            "supplier",
+            "id"
+          ]
         }
       ]
     },
@@ -795,7 +808,9 @@
             "modelName": "Product",
             "fieldName": "supplierSku"
           },
-          "target": ["supplierSku"]
+          "target": [
+            "supplierSku"
+          ]
         },
         {
           "messageName": "GetBySupplierSkuInputAndCodeInputInput",
@@ -805,7 +820,10 @@
             "modelName": "Supplier",
             "fieldName": "supplierCode"
           },
-          "target": ["supplier", "supplierCode"]
+          "target": [
+            "supplier",
+            "supplierCode"
+          ]
         }
       ]
     },
@@ -877,7 +895,9 @@
             "modelName": "Product",
             "fieldName": "supplierSku"
           },
-          "target": ["supplierSku"]
+          "target": [
+            "supplierSku"
+          ]
         }
       ]
     },
@@ -895,7 +915,10 @@
             "modelName": "Product",
             "fieldName": "supplierSku"
           },
-          "target": ["product", "supplierSku"]
+          "target": [
+            "product",
+            "supplierSku"
+          ]
         },
         {
           "messageName": "GetBySupplierSkuAndCodeInput",
@@ -905,7 +928,11 @@
             "modelName": "Supplier",
             "fieldName": "supplierCode"
           },
-          "target": ["product", "supplier", "supplierCode"]
+          "target": [
+            "product",
+            "supplier",
+            "supplierCode"
+          ]
         }
       ]
     },
@@ -920,7 +947,10 @@
             "modelName": "Product",
             "fieldName": "sku"
           },
-          "target": ["product", "sku"]
+          "target": [
+            "product",
+            "sku"
+          ]
         }
       ]
     },
@@ -938,7 +968,9 @@
             "modelName": "Supplier",
             "fieldName": "supplierCode"
           },
-          "target": ["supplierCode"]
+          "target": [
+            "supplierCode"
+          ]
         }
       ]
     },
@@ -953,7 +985,10 @@
             "modelName": "Product",
             "fieldName": "sku"
           },
-          "target": ["products", "sku"]
+          "target": [
+            "products",
+            "sku"
+          ]
         }
       ]
     }

--- a/schema/testdata/proto/unique_lookup/proto.json
+++ b/schema/testdata/proto/unique_lookup/proto.json
@@ -259,9 +259,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -298,9 +296,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -568,9 +564,7 @@
             "modelName": "Product",
             "fieldName": "sku"
           },
-          "target": [
-            "sku"
-          ]
+          "target": ["sku"]
         }
       ]
     },
@@ -597,9 +591,7 @@
             "modelName": "Product",
             "fieldName": "name"
           },
-          "target": [
-            "name"
-          ]
+          "target": ["name"]
         }
       ]
     },
@@ -617,9 +609,7 @@
             "modelName": "Product",
             "fieldName": "sku"
           },
-          "target": [
-            "sku"
-          ]
+          "target": ["sku"]
         }
       ]
     },

--- a/schema/testdata/proto/unique_lookup/proto.json
+++ b/schema/testdata/proto/unique_lookup/proto.json
@@ -183,6 +183,17 @@
         },
         {
           "modelName": "User",
+          "name": "assignedProductId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Product",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "User",
           "name": "identity",
           "type": {
             "type": "TYPE_MODEL",
@@ -191,6 +202,18 @@
           "unique": true,
           "foreignKeyFieldName": "identityId",
           "inverseFieldName": "user"
+        },
+        {
+          "modelName": "User",
+          "name": "identityId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Identity",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "User",
@@ -223,29 +246,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "User",
-          "name": "assignedProductId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Product",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "User",
-          "name": "identityId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Identity",
-            "relatedModelField": "id"
-          }
         }
       ]
     },
@@ -259,7 +259,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -296,7 +298,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -564,7 +568,9 @@
             "modelName": "Product",
             "fieldName": "sku"
           },
-          "target": ["sku"]
+          "target": [
+            "sku"
+          ]
         }
       ]
     },
@@ -591,7 +597,9 @@
             "modelName": "Product",
             "fieldName": "name"
           },
-          "target": ["name"]
+          "target": [
+            "name"
+          ]
         }
       ]
     },
@@ -609,7 +617,9 @@
             "modelName": "Product",
             "fieldName": "sku"
           },
-          "target": ["sku"]
+          "target": [
+            "sku"
+          ]
         }
       ]
     },

--- a/schema/testdata/proto/unique_lookup_model/proto.json
+++ b/schema/testdata/proto/unique_lookup_model/proto.json
@@ -16,6 +16,18 @@
         },
         {
           "modelName": "BankAccount",
+          "name": "identityId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "Identity",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "BankAccount",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -45,18 +57,6 @@
           "defaultValue": {
             "useZeroValue": true
           }
-        },
-        {
-          "modelName": "BankAccount",
-          "name": "identityId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "Identity",
-            "relatedModelField": "id"
-          }
         }
       ],
       "actions": [
@@ -84,7 +84,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -121,7 +123,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/unique_lookup_model/proto.json
+++ b/schema/testdata/proto/unique_lookup_model/proto.json
@@ -84,9 +84,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -123,9 +121,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/unique_lookup_nested/proto.json
+++ b/schema/testdata/proto/unique_lookup_nested/proto.json
@@ -233,9 +233,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -272,9 +270,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -528,10 +524,7 @@
             "modelName": "ProductStock",
             "fieldName": "id"
           },
-          "target": [
-            "stock",
-            "id"
-          ]
+          "target": ["stock", "id"]
         }
       ]
     },
@@ -546,10 +539,7 @@
             "modelName": "ProductStock",
             "fieldName": "barcode"
           },
-          "target": [
-            "stock",
-            "barcode"
-          ]
+          "target": ["stock", "barcode"]
         }
       ]
     },
@@ -576,10 +566,7 @@
             "modelName": "ProductStock",
             "fieldName": "barcode"
           },
-          "target": [
-            "stock",
-            "barcode"
-          ]
+          "target": ["stock", "barcode"]
         }
       ]
     },
@@ -618,9 +605,7 @@
             "modelName": "Product",
             "fieldName": "sku"
           },
-          "target": [
-            "sku"
-          ]
+          "target": ["sku"]
         }
       ]
     },
@@ -635,10 +620,7 @@
             "modelName": "Product",
             "fieldName": "sku"
           },
-          "target": [
-            "product",
-            "sku"
-          ]
+          "target": ["product", "sku"]
         }
       ]
     }

--- a/schema/testdata/proto/unique_lookup_nested/proto.json
+++ b/schema/testdata/proto/unique_lookup_nested/proto.json
@@ -32,6 +32,19 @@
         },
         {
           "modelName": "Product",
+          "name": "stockId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "optional": true,
+          "unique": true,
+          "foreignKeyInfo": {
+            "relatedModelName": "ProductStock",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Product",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -60,19 +73,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "Product",
-          "name": "stockId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "optional": true,
-          "unique": true,
-          "foreignKeyInfo": {
-            "relatedModelName": "ProductStock",
-            "relatedModelField": "id"
           }
         }
       ],
@@ -233,7 +233,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -270,7 +272,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -524,7 +528,10 @@
             "modelName": "ProductStock",
             "fieldName": "id"
           },
-          "target": ["stock", "id"]
+          "target": [
+            "stock",
+            "id"
+          ]
         }
       ]
     },
@@ -539,7 +546,10 @@
             "modelName": "ProductStock",
             "fieldName": "barcode"
           },
-          "target": ["stock", "barcode"]
+          "target": [
+            "stock",
+            "barcode"
+          ]
         }
       ]
     },
@@ -566,7 +576,10 @@
             "modelName": "ProductStock",
             "fieldName": "barcode"
           },
-          "target": ["stock", "barcode"]
+          "target": [
+            "stock",
+            "barcode"
+          ]
         }
       ]
     },
@@ -605,7 +618,9 @@
             "modelName": "Product",
             "fieldName": "sku"
           },
-          "target": ["sku"]
+          "target": [
+            "sku"
+          ]
         }
       ]
     },
@@ -620,7 +635,10 @@
             "modelName": "Product",
             "fieldName": "sku"
           },
-          "target": ["product", "sku"]
+          "target": [
+            "product",
+            "sku"
+          ]
         }
       ]
     }

--- a/schema/testdata/proto/where_expression_allowed_operators_builtin_types/proto.json
+++ b/schema/testdata/proto/where_expression_allowed_operators_builtin_types/proto.json
@@ -35,13 +35,6 @@
         },
         {
           "modelName": "Post",
-          "name": "date",
-          "type": {
-            "type": "TYPE_DATE"
-          }
-        },
-        {
-          "modelName": "Post",
           "name": "identityId",
           "type": {
             "type": "TYPE_ID"
@@ -49,6 +42,13 @@
           "foreignKeyInfo": {
             "relatedModelName": "Identity",
             "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Post",
+          "name": "date",
+          "type": {
+            "type": "TYPE_DATE"
           }
         },
         {
@@ -310,7 +310,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -347,7 +349,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/where_expression_allowed_operators_builtin_types/proto.json
+++ b/schema/testdata/proto/where_expression_allowed_operators_builtin_types/proto.json
@@ -310,9 +310,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -349,9 +347,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/where_expression_allowed_operators_builtin_types/proto.json
+++ b/schema/testdata/proto/where_expression_allowed_operators_builtin_types/proto.json
@@ -35,6 +35,17 @@
         },
         {
           "modelName": "Post",
+          "name": "identityId",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Identity",
+            "relatedModelField": "id"
+          }
+        },
+        {
+          "modelName": "Post",
           "name": "date",
           "type": {
             "type": "TYPE_DATE"
@@ -84,6 +95,17 @@
             "modelName": "Identity"
           },
           "foreignKeyFieldName": "identity2Id"
+        },
+        {
+          "modelName": "Post",
+          "name": "identity2Id",
+          "type": {
+            "type": "TYPE_ID"
+          },
+          "foreignKeyInfo": {
+            "relatedModelName": "Identity",
+            "relatedModelField": "id"
+          }
         },
         {
           "modelName": "Post",
@@ -137,28 +159,6 @@
           },
           "defaultValue": {
             "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "Post",
-          "name": "identityId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Identity",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Post",
-          "name": "identity2Id",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Identity",
-            "relatedModelField": "id"
           }
         }
       ],
@@ -310,7 +310,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -347,7 +349,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",

--- a/schema/testdata/proto/where_expression_allowed_operators_builtin_types/proto.json
+++ b/schema/testdata/proto/where_expression_allowed_operators_builtin_types/proto.json
@@ -35,6 +35,13 @@
         },
         {
           "modelName": "Post",
+          "name": "date",
+          "type": {
+            "type": "TYPE_DATE"
+          }
+        },
+        {
+          "modelName": "Post",
           "name": "identityId",
           "type": {
             "type": "TYPE_ID"
@@ -42,13 +49,6 @@
           "foreignKeyInfo": {
             "relatedModelName": "Identity",
             "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Post",
-          "name": "date",
-          "type": {
-            "type": "TYPE_DATE"
           }
         },
         {

--- a/tools/testdata/blog/tools.json
+++ b/tools/testdata/blog/tools.json
@@ -146,11 +146,20 @@
         },
         {
           "fieldLocation": {
+            "path": "$.authorId"
+          },
+          "fieldType": "TYPE_ID",
+          "displayName": "Author id",
+          "displayOrder": 4,
+          "visible": true
+        },
+        {
+          "fieldLocation": {
             "path": "$.image"
           },
           "fieldType": "TYPE_FILE",
           "displayName": "Image",
-          "displayOrder": 4,
+          "displayOrder": 5,
           "visible": true,
           "imagePreview": true
         },
@@ -161,8 +170,28 @@
           "fieldType": "TYPE_STRING",
           "repeated": true,
           "displayName": "Tags",
-          "displayOrder": 5,
+          "displayOrder": 6,
           "visible": true
+        },
+        {
+          "fieldLocation": {
+            "path": "$.categoryId"
+          },
+          "fieldType": "TYPE_ID",
+          "displayName": "Category id",
+          "displayOrder": 7,
+          "visible": true,
+          "link": {
+            "toolId": "getCategory",
+            "data": [
+              {
+                "key": "$.id",
+                "path": {
+                  "path": "$.categoryId"
+                }
+              }
+            ]
+          }
         },
         {
           "fieldLocation": {
@@ -190,35 +219,6 @@
           "displayName": "Updated at",
           "displayOrder": 14,
           "visible": true
-        },
-        {
-          "fieldLocation": {
-            "path": "$.authorId"
-          },
-          "fieldType": "TYPE_ID",
-          "displayName": "Author id",
-          "displayOrder": 6,
-          "visible": true
-        },
-        {
-          "fieldLocation": {
-            "path": "$.categoryId"
-          },
-          "fieldType": "TYPE_ID",
-          "displayName": "Category id",
-          "displayOrder": 7,
-          "visible": true,
-          "link": {
-            "toolId": "getCategory",
-            "data": [
-              {
-                "key": "$.id",
-                "path": {
-                  "path": "$.categoryId"
-                }
-              }
-            ]
-          }
         }
       ],
       "entitySingle": "blog post",
@@ -379,11 +379,20 @@
         },
         {
           "fieldLocation": {
+            "path": "$.authorId"
+          },
+          "fieldType": "TYPE_ID",
+          "displayName": "Author id",
+          "displayOrder": 4,
+          "visible": true
+        },
+        {
+          "fieldLocation": {
             "path": "$.image"
           },
           "fieldType": "TYPE_FILE",
           "displayName": "Image",
-          "displayOrder": 4,
+          "displayOrder": 5,
           "visible": true,
           "imagePreview": true
         },
@@ -394,8 +403,28 @@
           "fieldType": "TYPE_STRING",
           "repeated": true,
           "displayName": "Tags",
-          "displayOrder": 5,
+          "displayOrder": 6,
           "visible": true
+        },
+        {
+          "fieldLocation": {
+            "path": "$.categoryId"
+          },
+          "fieldType": "TYPE_ID",
+          "displayName": "Category id",
+          "displayOrder": 7,
+          "visible": true,
+          "link": {
+            "toolId": "getCategory",
+            "data": [
+              {
+                "key": "$.id",
+                "path": {
+                  "path": "$.categoryId"
+                }
+              }
+            ]
+          }
         },
         {
           "fieldLocation": {
@@ -423,35 +452,6 @@
           "displayName": "Updated at",
           "displayOrder": 14,
           "visible": true
-        },
-        {
-          "fieldLocation": {
-            "path": "$.authorId"
-          },
-          "fieldType": "TYPE_ID",
-          "displayName": "Author id",
-          "displayOrder": 6,
-          "visible": true
-        },
-        {
-          "fieldLocation": {
-            "path": "$.categoryId"
-          },
-          "fieldType": "TYPE_ID",
-          "displayName": "Category id",
-          "displayOrder": 7,
-          "visible": true,
-          "link": {
-            "toolId": "getCategory",
-            "data": [
-              {
-                "key": "$.id",
-                "path": {
-                  "path": "$.categoryId"
-                }
-              }
-            ]
-          }
         }
       ],
       "entitySingle": "blog post",
@@ -620,11 +620,20 @@
         },
         {
           "fieldLocation": {
+            "path": "$.authorId"
+          },
+          "fieldType": "TYPE_ID",
+          "displayName": "Author id",
+          "displayOrder": 4,
+          "visible": true
+        },
+        {
+          "fieldLocation": {
             "path": "$.image"
           },
           "fieldType": "TYPE_FILE",
           "displayName": "Image",
-          "displayOrder": 4,
+          "displayOrder": 5,
           "visible": true,
           "imagePreview": true
         },
@@ -635,8 +644,28 @@
           "fieldType": "TYPE_STRING",
           "repeated": true,
           "displayName": "Tags",
-          "displayOrder": 5,
+          "displayOrder": 6,
           "visible": true
+        },
+        {
+          "fieldLocation": {
+            "path": "$.categoryId"
+          },
+          "fieldType": "TYPE_ID",
+          "displayName": "Category id",
+          "displayOrder": 7,
+          "visible": true,
+          "link": {
+            "toolId": "getCategory",
+            "data": [
+              {
+                "key": "$.id",
+                "path": {
+                  "path": "$.categoryId"
+                }
+              }
+            ]
+          }
         },
         {
           "fieldLocation": {
@@ -664,35 +693,6 @@
           "displayName": "Updated at",
           "displayOrder": 14,
           "visible": true
-        },
-        {
-          "fieldLocation": {
-            "path": "$.authorId"
-          },
-          "fieldType": "TYPE_ID",
-          "displayName": "Author id",
-          "displayOrder": 6,
-          "visible": true
-        },
-        {
-          "fieldLocation": {
-            "path": "$.categoryId"
-          },
-          "fieldType": "TYPE_ID",
-          "displayName": "Category id",
-          "displayOrder": 7,
-          "visible": true,
-          "link": {
-            "toolId": "getCategory",
-            "data": [
-              {
-                "key": "$.id",
-                "path": {
-                  "path": "$.categoryId"
-                }
-              }
-            ]
-          }
         }
       ],
       "title": {
@@ -1144,10 +1144,39 @@
         },
         {
           "fieldLocation": {
+            "path": "$.results[*].authorId"
+          },
+          "fieldType": "TYPE_ID",
+          "displayName": "Author id",
+          "visible": true
+        },
+        {
+          "fieldLocation": {
+            "path": "$.results[*].parentId"
+          },
+          "fieldType": "TYPE_ID",
+          "displayName": "Parent id",
+          "displayOrder": 1,
+          "visible": true,
+          "link": {
+            "toolId": "getPost",
+            "data": [
+              {
+                "key": "$.id",
+                "path": {
+                  "path": "$.results[*].parentId"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "fieldLocation": {
             "path": "$.results[*].content"
           },
           "fieldType": "TYPE_STRING",
           "displayName": "Content",
+          "displayOrder": 2,
           "visible": true
         },
         {
@@ -1176,35 +1205,6 @@
           "displayName": "Updated at",
           "displayOrder": 8,
           "visible": true
-        },
-        {
-          "fieldLocation": {
-            "path": "$.results[*].authorId"
-          },
-          "fieldType": "TYPE_ID",
-          "displayName": "Author id",
-          "displayOrder": 1,
-          "visible": true
-        },
-        {
-          "fieldLocation": {
-            "path": "$.results[*].parentId"
-          },
-          "fieldType": "TYPE_ID",
-          "displayName": "Parent id",
-          "displayOrder": 2,
-          "visible": true,
-          "link": {
-            "toolId": "getPost",
-            "data": [
-              {
-                "key": "$.id",
-                "path": {
-                  "path": "$.results[*].parentId"
-                }
-              }
-            ]
-          }
         }
       ],
       "entitySingle": "comment",
@@ -1391,11 +1391,20 @@
         },
         {
           "fieldLocation": {
+            "path": "$.results[*].authorId"
+          },
+          "fieldType": "TYPE_ID",
+          "displayName": "Author id",
+          "displayOrder": 4,
+          "visible": true
+        },
+        {
+          "fieldLocation": {
             "path": "$.results[*].image"
           },
           "fieldType": "TYPE_FILE",
           "displayName": "Image",
-          "displayOrder": 4,
+          "displayOrder": 5,
           "visible": true,
           "imagePreview": true
         },
@@ -1406,8 +1415,28 @@
           "fieldType": "TYPE_STRING",
           "repeated": true,
           "displayName": "Tags",
-          "displayOrder": 5,
+          "displayOrder": 6,
           "visible": true
+        },
+        {
+          "fieldLocation": {
+            "path": "$.results[*].categoryId"
+          },
+          "fieldType": "TYPE_ID",
+          "displayName": "Category id",
+          "displayOrder": 7,
+          "visible": true,
+          "link": {
+            "toolId": "getCategory",
+            "data": [
+              {
+                "key": "$.id",
+                "path": {
+                  "path": "$.results[*].categoryId"
+                }
+              }
+            ]
+          }
         },
         {
           "fieldLocation": {
@@ -1435,35 +1464,6 @@
           "displayName": "Updated at",
           "displayOrder": 14,
           "visible": true
-        },
-        {
-          "fieldLocation": {
-            "path": "$.results[*].authorId"
-          },
-          "fieldType": "TYPE_ID",
-          "displayName": "Author id",
-          "displayOrder": 6,
-          "visible": true
-        },
-        {
-          "fieldLocation": {
-            "path": "$.results[*].categoryId"
-          },
-          "fieldType": "TYPE_ID",
-          "displayName": "Category id",
-          "displayOrder": 7,
-          "visible": true,
-          "link": {
-            "toolId": "getCategory",
-            "data": [
-              {
-                "key": "$.id",
-                "path": {
-                  "path": "$.results[*].categoryId"
-                }
-              }
-            ]
-          }
         }
       ],
       "entitySingle": "blog post",
@@ -1725,11 +1725,20 @@
         },
         {
           "fieldLocation": {
+            "path": "$.results[*].author.authorId"
+          },
+          "fieldType": "TYPE_ID",
+          "displayName": "Author id",
+          "displayOrder": 4,
+          "visible": true
+        },
+        {
+          "fieldLocation": {
             "path": "$.results[*].author.image"
           },
           "fieldType": "TYPE_FILE",
           "displayName": "Image",
-          "displayOrder": 4,
+          "displayOrder": 5,
           "visible": true,
           "imagePreview": true
         },
@@ -1740,8 +1749,28 @@
           "fieldType": "TYPE_STRING",
           "repeated": true,
           "displayName": "Tags",
-          "displayOrder": 5,
+          "displayOrder": 6,
           "visible": true
+        },
+        {
+          "fieldLocation": {
+            "path": "$.results[*].author.categoryId"
+          },
+          "fieldType": "TYPE_ID",
+          "displayName": "Category id",
+          "displayOrder": 7,
+          "visible": true,
+          "link": {
+            "toolId": "getCategory",
+            "data": [
+              {
+                "key": "$.id",
+                "path": {
+                  "path": "$.results[*].author.categoryId"
+                }
+              }
+            ]
+          }
         },
         {
           "fieldLocation": {
@@ -1772,32 +1801,12 @@
         },
         {
           "fieldLocation": {
-            "path": "$.results[*].author.authorId"
+            "path": "$.results[*].authorId"
           },
           "fieldType": "TYPE_ID",
           "displayName": "Author id",
-          "displayOrder": 6,
+          "displayOrder": 4,
           "visible": true
-        },
-        {
-          "fieldLocation": {
-            "path": "$.results[*].author.categoryId"
-          },
-          "fieldType": "TYPE_ID",
-          "displayName": "Category id",
-          "displayOrder": 7,
-          "visible": true,
-          "link": {
-            "toolId": "getCategory",
-            "data": [
-              {
-                "key": "$.id",
-                "path": {
-                  "path": "$.results[*].author.categoryId"
-                }
-              }
-            ]
-          }
         },
         {
           "fieldLocation": {
@@ -1805,7 +1814,7 @@
           },
           "fieldType": "TYPE_FILE",
           "displayName": "Image",
-          "displayOrder": 4,
+          "displayOrder": 5,
           "visible": true,
           "imagePreview": true
         },
@@ -1816,7 +1825,7 @@
           "fieldType": "TYPE_STRING",
           "repeated": true,
           "displayName": "Tags",
-          "displayOrder": 5,
+          "displayOrder": 6,
           "visible": true
         },
         {
@@ -1856,11 +1865,20 @@
         },
         {
           "fieldLocation": {
+            "path": "$.results[*].category.authorId"
+          },
+          "fieldType": "TYPE_ID",
+          "displayName": "Author id",
+          "displayOrder": 4,
+          "visible": true
+        },
+        {
+          "fieldLocation": {
             "path": "$.results[*].category.image"
           },
           "fieldType": "TYPE_FILE",
           "displayName": "Image",
-          "displayOrder": 4,
+          "displayOrder": 5,
           "visible": true,
           "imagePreview": true
         },
@@ -1871,8 +1889,28 @@
           "fieldType": "TYPE_STRING",
           "repeated": true,
           "displayName": "Tags",
-          "displayOrder": 5,
+          "displayOrder": 6,
           "visible": true
+        },
+        {
+          "fieldLocation": {
+            "path": "$.results[*].category.categoryId"
+          },
+          "fieldType": "TYPE_ID",
+          "displayName": "Category id",
+          "displayOrder": 7,
+          "visible": true,
+          "link": {
+            "toolId": "getCategory",
+            "data": [
+              {
+                "key": "$.id",
+                "path": {
+                  "path": "$.results[*].category.categoryId"
+                }
+              }
+            ]
+          }
         },
         {
           "fieldLocation": {
@@ -1903,16 +1941,7 @@
         },
         {
           "fieldLocation": {
-            "path": "$.results[*].category.authorId"
-          },
-          "fieldType": "TYPE_ID",
-          "displayName": "Author id",
-          "displayOrder": 6,
-          "visible": true
-        },
-        {
-          "fieldLocation": {
-            "path": "$.results[*].category.categoryId"
+            "path": "$.results[*].categoryId"
           },
           "fieldType": "TYPE_ID",
           "displayName": "Category id",
@@ -1924,7 +1953,7 @@
               {
                 "key": "$.id",
                 "path": {
-                  "path": "$.results[*].category.categoryId"
+                  "path": "$.results[*].categoryId"
                 }
               }
             ]
@@ -1956,35 +1985,6 @@
           "displayName": "Updated at",
           "displayOrder": 14,
           "visible": true
-        },
-        {
-          "fieldLocation": {
-            "path": "$.results[*].authorId"
-          },
-          "fieldType": "TYPE_ID",
-          "displayName": "Author id",
-          "displayOrder": 6,
-          "visible": true
-        },
-        {
-          "fieldLocation": {
-            "path": "$.results[*].categoryId"
-          },
-          "fieldType": "TYPE_ID",
-          "displayName": "Category id",
-          "displayOrder": 7,
-          "visible": true,
-          "link": {
-            "toolId": "getCategory",
-            "data": [
-              {
-                "key": "$.id",
-                "path": {
-                  "path": "$.results[*].categoryId"
-                }
-              }
-            ]
-          }
         }
       ],
       "entitySingle": "blog post",
@@ -2294,11 +2294,20 @@
         },
         {
           "fieldLocation": {
+            "path": "$.authorId"
+          },
+          "fieldType": "TYPE_ID",
+          "displayName": "Author id",
+          "displayOrder": 4,
+          "visible": true
+        },
+        {
+          "fieldLocation": {
             "path": "$.image"
           },
           "fieldType": "TYPE_FILE",
           "displayName": "Image",
-          "displayOrder": 4,
+          "displayOrder": 5,
           "visible": true,
           "imagePreview": true
         },
@@ -2309,8 +2318,28 @@
           "fieldType": "TYPE_STRING",
           "repeated": true,
           "displayName": "Tags",
-          "displayOrder": 5,
+          "displayOrder": 6,
           "visible": true
+        },
+        {
+          "fieldLocation": {
+            "path": "$.categoryId"
+          },
+          "fieldType": "TYPE_ID",
+          "displayName": "Category id",
+          "displayOrder": 7,
+          "visible": true,
+          "link": {
+            "toolId": "getCategory",
+            "data": [
+              {
+                "key": "$.id",
+                "path": {
+                  "path": "$.categoryId"
+                }
+              }
+            ]
+          }
         },
         {
           "fieldLocation": {
@@ -2338,35 +2367,6 @@
           "displayName": "Updated at",
           "displayOrder": 14,
           "visible": true
-        },
-        {
-          "fieldLocation": {
-            "path": "$.authorId"
-          },
-          "fieldType": "TYPE_ID",
-          "displayName": "Author id",
-          "displayOrder": 6,
-          "visible": true
-        },
-        {
-          "fieldLocation": {
-            "path": "$.categoryId"
-          },
-          "fieldType": "TYPE_ID",
-          "displayName": "Category id",
-          "displayOrder": 7,
-          "visible": true,
-          "link": {
-            "toolId": "getCategory",
-            "data": [
-              {
-                "key": "$.id",
-                "path": {
-                  "path": "$.categoryId"
-                }
-              }
-            ]
-          }
         }
       ],
       "entitySingle": "blog post",

--- a/tools/testdata/nested_inputs/tools.json
+++ b/tools/testdata/nested_inputs/tools.json
@@ -81,6 +81,15 @@
         },
         {
           "fieldLocation": {
+            "path": "$.customerId"
+          },
+          "fieldType": "TYPE_ID",
+          "displayName": "Customer id",
+          "displayOrder": 1,
+          "visible": true
+        },
+        {
+          "fieldLocation": {
             "path": "$.id"
           },
           "fieldType": "TYPE_ID",
@@ -104,15 +113,6 @@
           "fieldType": "TYPE_DATETIME",
           "displayName": "Updated at",
           "displayOrder": 7,
-          "visible": true
-        },
-        {
-          "fieldLocation": {
-            "path": "$.customerId"
-          },
-          "fieldType": "TYPE_ID",
-          "displayName": "Customer id",
-          "displayOrder": 1,
           "visible": true
         }
       ],


### PR DESCRIPTION
The foreign key fields for relationships were being added to the end of the model's field list.  This change will insert them at the same position as their relationship field, thus better preserving the schema's order.