### PR TITLE
fix: gen tools repeated for list action

### DIFF
--- a/tools/generator.go
+++ b/tools/generator.go
@@ -350,6 +350,7 @@ func (g *Generator) generateResponses() error {
 			tool.Config.Response = append(tool.Config.Response, &toolsproto.ResponseFieldConfig{
 				FieldLocation: &toolsproto.JsonPath{Path: "$.results"},
 				FieldType:     proto.Type_TYPE_OBJECT,
+				Repeated:      true,
 				DisplayName:   "Results",
 				Visible:       true,
 			})

--- a/tools/testdata/blog/tools.json
+++ b/tools/testdata/blog/tools.json
@@ -847,6 +847,7 @@
             "path": "$.results"
           },
           "fieldType": "TYPE_OBJECT",
+          "repeated": true,
           "displayName": "Results",
           "visible": true
         },
@@ -1139,6 +1140,7 @@
             "path": "$.results"
           },
           "fieldType": "TYPE_OBJECT",
+          "repeated": true,
           "displayName": "Results",
           "visible": true
         },
@@ -1350,6 +1352,7 @@
             "path": "$.results"
           },
           "fieldType": "TYPE_OBJECT",
+          "repeated": true,
           "displayName": "Results",
           "visible": true
         },
@@ -1650,6 +1653,7 @@
             "path": "$.results"
           },
           "fieldType": "TYPE_OBJECT",
+          "repeated": true,
           "displayName": "Results",
           "visible": true
         },


### PR DESCRIPTION
The list action `results` property not correctly marked as repeated in tools config