### PR TITLE
chore: update display name for foreign key fields

### DIFF
--- a/tools/testdata/blog/tools.json
+++ b/tools/testdata/blog/tools.json
@@ -116,7 +116,7 @@
           {
             "fieldLocation": { "path": "$.authorId" },
             "fieldType": "TYPE_ID",
-            "displayName": "Author id",
+            "displayName": "Author",
             "displayOrder": 4,
             "visible": true
           },
@@ -287,7 +287,7 @@
           {
             "fieldLocation": { "path": "$.authorId" },
             "fieldType": "TYPE_ID",
-            "displayName": "Author id",
+            "displayName": "Author",
             "displayOrder": 4,
             "visible": true
           },
@@ -461,7 +461,7 @@
           {
             "fieldLocation": { "path": "$.authorId" },
             "fieldType": "TYPE_ID",
-            "displayName": "Author id",
+            "displayName": "Author",
             "displayOrder": 4,
             "visible": true
           },
@@ -832,7 +832,7 @@
           {
             "fieldLocation": { "path": "$.results[*].authorId" },
             "fieldType": "TYPE_ID",
-            "displayName": "Author id",
+            "displayName": "Author",
             "visible": true
           },
           {
@@ -1021,7 +1021,7 @@
           {
             "fieldLocation": { "path": "$.results[*].authorId" },
             "fieldType": "TYPE_ID",
-            "displayName": "Author id",
+            "displayName": "Author",
             "displayOrder": 4,
             "visible": true
           },
@@ -1259,7 +1259,7 @@
           {
             "fieldLocation": { "path": "$.results[*].author.authorId" },
             "fieldType": "TYPE_ID",
-            "displayName": "Author id",
+            "displayName": "Author",
             "displayOrder": 4,
             "visible": true
           },
@@ -1319,7 +1319,7 @@
           {
             "fieldLocation": { "path": "$.results[*].authorId" },
             "fieldType": "TYPE_ID",
-            "displayName": "Author id",
+            "displayName": "Author",
             "displayOrder": 4,
             "visible": true
           },
@@ -1369,7 +1369,7 @@
           {
             "fieldLocation": { "path": "$.results[*].category.authorId" },
             "fieldType": "TYPE_ID",
-            "displayName": "Author id",
+            "displayName": "Author",
             "displayOrder": 4,
             "visible": true
           },
@@ -1683,7 +1683,7 @@
           {
             "fieldLocation": { "path": "$.authorId" },
             "fieldType": "TYPE_ID",
-            "displayName": "Author id",
+            "displayName": "Author",
             "displayOrder": 4,
             "visible": true
           },

--- a/tools/testdata/nested_inputs/tools.json
+++ b/tools/testdata/nested_inputs/tools.json
@@ -66,7 +66,7 @@
           {
             "fieldLocation": { "path": "$.customerId" },
             "fieldType": "TYPE_ID",
-            "displayName": "Customer id",
+            "displayName": "Customer",
             "displayOrder": 1,
             "visible": true
           },


### PR DESCRIPTION
We were changing the display name to remove the `ID` suffix only if there was a linked action for the given response field, to retrieve the item by ID. This PR will trim the ID from display names regardless of wether there's a action link for that response or not.