### PR TITLE
fix: sql keyword escaping for create and update actions

### DIFF
--- a/runtime/actions/query.go
+++ b/runtime/actions/query.go
@@ -723,7 +723,7 @@ func (query *QueryBuilder) InsertStatement(ctx context.Context) *Statement {
 	statement := fmt.Sprintf("WITH %s SELECT %s FROM %s",
 		strings.Join(ctes, ", "),
 		strings.Join(selection, ", "),
-		alias)
+		sqlQuote(alias))
 
 	return &Statement{
 		model:    query.Model,
@@ -745,14 +745,14 @@ func (query *QueryBuilder) generateInsertCte(ctes []string, args []any, row *Row
 
 		// For every row that this references, we need to set the foreign key.
 		// For example, on the Sale row; customerId = (SELECT id FROM new_customer_1)
-		row.values[r.foreignKey.ForeignKeyFieldName.Value] = Raw(fmt.Sprintf("(SELECT id FROM %s)", primaryKeyTable))
+		row.values[r.foreignKey.ForeignKeyFieldName.Value] = Raw(fmt.Sprintf("(SELECT \"id\" FROM %s)", sqlQuote(primaryKeyTable)))
 	}
 
 	// Does this foreign key of the relationship exist on this row?
 	// This means this row exists as a referencedBy row for another.
 	// For example, on the SaleItem row; saleId = (SELECT id FROM new_sale_1)
 	if foreignKey != nil && row.model.Name == foreignKey.ModelName {
-		row.values[foreignKey.ForeignKeyFieldName.Value] = Raw(fmt.Sprintf("(SELECT id FROM %s)", primaryKeyTableAlias))
+		row.values[foreignKey.ForeignKeyFieldName.Value] = Raw(fmt.Sprintf("(SELECT \"id\" FROM %s)", sqlQuote(primaryKeyTableAlias)))
 	}
 
 	// Make iterating through the map with deterministic ordering
@@ -777,7 +777,7 @@ func (query *QueryBuilder) generateInsertCte(ctes []string, args []any, row *Row
 		cteAlias := fmt.Sprintf("select_%s", operand.query.table)
 		cteExists := false
 		for _, c := range ctes {
-			if strings.HasPrefix(c, cteAlias) {
+			if strings.HasPrefix(c, sqlQuote(cteAlias)) {
 				cteExists = true
 				break
 			}
@@ -786,11 +786,11 @@ func (query *QueryBuilder) generateInsertCte(ctes []string, args []any, row *Row
 		if !cteExists {
 			cteAliases := []string{}
 			for i := range operand.query.selection {
-				cteAliases = append(cteAliases, fmt.Sprintf("column_%v", i))
+				cteAliases = append(cteAliases, sqlQuote(fmt.Sprintf("column_%v", i)))
 			}
 
 			cte := fmt.Sprintf("%s (%s) AS (%s)",
-				cteAlias,
+				sqlQuote(cteAlias),
 				strings.Join(cteAliases, ", "),
 				operand.query.SelectStatement().SqlTemplate())
 
@@ -801,7 +801,7 @@ func (query *QueryBuilder) generateInsertCte(ctes []string, args []any, row *Row
 
 	for _, col := range orderedKeys {
 		colName := casing.ToSnake(col)
-		columnNames = append(columnNames, colName)
+		columnNames = append(columnNames, sqlQuote(colName))
 		operand := row.values[col]
 
 		switch {
@@ -822,7 +822,7 @@ func (query *QueryBuilder) generateInsertCte(ctes []string, args []any, row *Row
 				}
 			}
 
-			sql := fmt.Sprintf("(SELECT %s FROM %s)", columnAlias, cteAlias)
+			sql := fmt.Sprintf("(SELECT %s FROM %s)", sqlQuote(columnAlias), sqlQuote(cteAlias))
 			columnValues = append(columnValues, sql)
 		default:
 			panic("no handling for rhs QueryOperand type")
@@ -840,7 +840,7 @@ func (query *QueryBuilder) generateInsertCte(ctes []string, args []any, row *Row
 	}
 
 	cte := fmt.Sprintf("%s AS (INSERT INTO %s %s RETURNING *)",
-		alias,
+		sqlQuote(alias),
 		sqlQuote(casing.ToSnake(row.model.Name)),
 		values)
 
@@ -1257,7 +1257,6 @@ func ParsePostgresArray[T any](array string, parse func(string) (T, error)) ([]T
 			}
 			arrayOpened = true
 		case escapeOpened:
-
 			item.WriteRune(r)
 			escapeOpened = false
 		case quoteOpened:

--- a/runtime/actions/query.go
+++ b/runtime/actions/query.go
@@ -917,7 +917,7 @@ func (query *QueryBuilder) UpdateStatement(ctx context.Context) *Statement {
 		cteAlias := fmt.Sprintf("select_%s", operand.query.table)
 		cteExists := false
 		for _, c := range ctes {
-			if strings.HasPrefix(c, cteAlias) {
+			if strings.HasPrefix(c, sqlQuote(cteAlias)) {
 				cteExists = true
 				break
 			}
@@ -926,11 +926,11 @@ func (query *QueryBuilder) UpdateStatement(ctx context.Context) *Statement {
 		if !cteExists {
 			cteAliases := []string{}
 			for i := range operand.query.selection {
-				cteAliases = append(cteAliases, fmt.Sprintf("column_%v", i))
+				cteAliases = append(cteAliases, sqlQuote(fmt.Sprintf("column_%v", i)))
 			}
 
 			cte := fmt.Sprintf("%s (%s) AS (%s)",
-				cteAlias,
+				sqlQuote(cteAlias),
 				strings.Join(cteAliases, ", "),
 				operand.query.SelectStatement().SqlTemplate())
 
@@ -953,14 +953,14 @@ func (query *QueryBuilder) UpdateStatement(ctx context.Context) *Statement {
 				}
 			}
 
-			sql := fmt.Sprintf("(SELECT %s FROM %s)", columnAlias, cteAlias)
-			sets = append(sets, fmt.Sprintf("%s = %s", casing.ToSnake(v), sql))
+			sql := fmt.Sprintf("(SELECT %s FROM %s)", sqlQuote(columnAlias), sqlQuote(cteAlias))
+			sets = append(sets, fmt.Sprintf("%s = %s", sqlQuote(casing.ToSnake(v)), sql))
 		} else {
 			sqlOperand := operand.toSqlOperandString(query)
 			sqlArgs := operand.toSqlArgs()
 
 			args = append(args, sqlArgs...)
-			sets = append(sets, fmt.Sprintf("%s = %s", casing.ToSnake(v), sqlOperand))
+			sets = append(sets, fmt.Sprintf("%s = %s", sqlQuote(casing.ToSnake(v)), sqlOperand))
 		}
 	}
 

--- a/runtime/actions/query_test.go
+++ b/runtime/actions/query_test.go
@@ -3474,8 +3474,8 @@ func TestInsertStatement(t *testing.T) {
 	stmt := query.InsertStatement(context.Background())
 
 	expected := `
-		WITH new_1_person AS (INSERT INTO "person" (name) VALUES (?) RETURNING *)
-		SELECT * FROM new_1_person`
+		WITH "new_1_person" AS (INSERT INTO "person" ("name") VALUES (?) RETURNING *)
+		SELECT * FROM "new_1_person"`
 
 	require.Equal(t, clean(expected), clean(stmt.SqlTemplate()))
 }
@@ -3491,7 +3491,7 @@ func TestUpdateStatement(t *testing.T) {
 	stmt := query.UpdateStatement(context.Background())
 
 	expected := `
-		UPDATE "person" SET name = ? WHERE "person"."id" IS NOT DISTINCT FROM ? RETURNING "person".*`
+		UPDATE "person" SET "name" = ? WHERE "person"."id" IS NOT DISTINCT FROM ? RETURNING "person".*`
 
 	require.Equal(t, clean(expected), clean(stmt.SqlTemplate()))
 }
@@ -3524,12 +3524,12 @@ func TestInsertStatementWithAuditing(t *testing.T) {
 	stmt := query.InsertStatement(ctx)
 
 	expected := `
-		WITH new_1_person AS (INSERT INTO "person" (name) VALUES (?) RETURNING *)
+		WITH "new_1_person" AS (INSERT INTO "person" ("name") VALUES (?) RETURNING *)
 		SELECT
 			*,
 			set_identity_id(?) AS __keel_identity_id,
 			set_trace_id(?) AS __keel_trace_id
-		FROM new_1_person`
+		FROM "new_1_person"`
 
 	require.Equal(t, clean(expected), clean(stmt.SqlTemplate()))
 	require.Equal(t, "Fred", stmt.SqlArgs()[0])
@@ -3552,7 +3552,7 @@ func TestUpdateStatementWithAuditing(t *testing.T) {
 	stmt := query.UpdateStatement(ctx)
 
 	expected := `
-		UPDATE "person" SET name = ? WHERE "person"."id" IS NOT DISTINCT FROM ? RETURNING
+		UPDATE "person" SET "name" = ? WHERE "person"."id" IS NOT DISTINCT FROM ? RETURNING
 			"person".*,
 			set_identity_id(?) AS __keel_identity_id,
 			set_trace_id(?) AS __keel_trace_id`
@@ -3578,7 +3578,7 @@ func TestUpdateStatementNoReturnsWithAuditing(t *testing.T) {
 	stmt := query.UpdateStatement(ctx)
 
 	expected := `
-		UPDATE "person" SET name = ? WHERE "person"."id" IS NOT DISTINCT FROM ? RETURNING
+		UPDATE "person" SET "name" = ? WHERE "person"."id" IS NOT DISTINCT FROM ? RETURNING
 			set_identity_id(?) AS __keel_identity_id,
 			set_trace_id(?) AS __keel_trace_id`
 

--- a/runtime/actions/query_test.go
+++ b/runtime/actions/query_test.go
@@ -336,7 +336,7 @@ var testCases = []testCase{
 		},
 		expectedTemplate: `
 			UPDATE "person"
-			SET main_identity_id = ?
+			SET "main_identity_id" = ?
 			WHERE "person"."id" IS NOT DISTINCT FROM ?
 			RETURNING "person".*, set_identity_id(?) AS __keel_identity_id`,
 		identity:     identity,
@@ -364,7 +364,7 @@ var testCases = []testCase{
 		},
 		expectedTemplate: `
 			UPDATE "person"
-			SET main_identity_id = ?
+			SET "main_identity_id" = ?
 			WHERE "person"."id" IS NOT DISTINCT FROM ?
 			RETURNING "person".*, set_identity_id(?) AS __keel_identity_id`,
 		identity:     identity,
@@ -397,8 +397,8 @@ var testCases = []testCase{
 		expectedTemplate: `
 			UPDATE "person"
 			SET
-				name = ?,
-				nick_name = ?
+				"name" = ?,
+				"nick_name" = ?
 			WHERE "person"."id" IS NOT DISTINCT FROM ?
 			RETURNING "person".*`,
 		expectedArgs: []any{"Dave", "Dave", "xyz"},
@@ -434,15 +434,15 @@ var testCases = []testCase{
 		},
 		expectedTemplate: `
 			WITH
-				select_identity (column_0, column_1) AS (
+				"select_identity" ("column_0", "column_1") AS (
 					SELECT "identity$user"."id", "identity$user"."is_active"
 					FROM "identity"
 					LEFT JOIN "company_user" AS "identity$user" ON "identity$user"."identity_id" = "identity"."id"
 					WHERE "identity"."id" IS NOT DISTINCT FROM ?)
 			UPDATE "record"
 			SET
-				is_active = (SELECT column_1 FROM select_identity),
-				user_id = (SELECT column_0 FROM select_identity)
+				"is_active" = (SELECT "column_1" FROM "select_identity"),
+				"user_id" = (SELECT "column_0" FROM "select_identity")
 			WHERE
 				"record"."id" IS NOT DISTINCT FROM ?
 			RETURNING "record".*, set_identity_id(?) AS __keel_identity_id`,
@@ -535,7 +535,7 @@ var testCases = []testCase{
 			UPDATE
 				"person"
 			SET
-			    age = ?, bio = ?, is_active = ?, name = ?
+			    "age" = ?, "bio" = ?, "is_active" = ?, "name" = ?
 			WHERE
 				"person"."id" IS NOT DISTINCT FROM ?
 			RETURNING
@@ -569,7 +569,7 @@ var testCases = []testCase{
 			UPDATE
 				"person"
 			SET
-			    name = ?
+			    "name" = ?
 			WHERE
 				"person"."id" IS NOT DISTINCT FROM ?
 			RETURNING
@@ -1724,9 +1724,9 @@ var testCases = []testCase{
 			UPDATE
 				"thing"
 			SET
-				age = ?,
-				name = ?,
-				parent_id = ?
+				"age" = ?,
+				"name" = ?,
+				"parent_id" = ?
 			WHERE
 				"thing"."id" IS NOT DISTINCT FROM ?
 			RETURNING
@@ -2070,7 +2070,7 @@ var testCases = []testCase{
 			UPDATE
 				"thing"
 			SET
-				name = ?
+				"name" = ?
 			WHERE
 				"thing"."id" IS NOT DISTINCT FROM ? AND
 				( "thing"."code" IS NOT DISTINCT FROM ? OR "thing"."code" IS NOT DISTINCT FROM ? )
@@ -2521,7 +2521,7 @@ var testCases = []testCase{
 		},
 		expectedTemplate: `
 			UPDATE "product"
-			SET is_active = ?
+			SET "is_active" = ?
 			WHERE
 				"product"."barcode" IS NOT DISTINCT FROM ? AND
 				"product"."is_active" IS NOT DISTINCT FROM ?
@@ -2560,7 +2560,7 @@ var testCases = []testCase{
 		},
 		expectedTemplate: `
 			UPDATE "product"
-			SET is_active = ?
+			SET "is_active" = ?
 			WHERE "id" = (
 				SELECT "product"."id" 
 				FROM "product" 
@@ -2610,7 +2610,7 @@ var testCases = []testCase{
 		},
 		expectedTemplate: `
 			UPDATE "product"
-			SET is_active = ?
+			SET "is_active" = ?
 			WHERE "id" = (
 				SELECT "product"."id" 
 				FROM "product" 
@@ -2804,16 +2804,16 @@ var testCases = []testCase{
 		identity:   identity,
 		expectedTemplate: `
 			WITH
-				select_identity (column_0, column_1, column_2, column_3, column_4) AS (
+				"select_identity" ("column_0", "column_1", "column_2", "column_3", "column_4") AS (
 					SELECT "identity"."email", "identity"."created_at", "identity"."email_verified", "identity"."external_id", "identity"."issuer"
 					FROM "identity"
 					WHERE "identity"."id" IS NOT DISTINCT FROM ?)
 			UPDATE "person" SET
-				created = (SELECT column_1 FROM select_identity),
-				email = (SELECT column_0 FROM select_identity),
-				email_verified = (SELECT column_2 FROM select_identity),
-				external_id = (SELECT column_3 FROM select_identity),
-				issuer = (SELECT column_4 FROM select_identity)
+				"created" = (SELECT "column_1" FROM "select_identity"),
+				"email" = (SELECT "column_0" FROM "select_identity"),
+				"email_verified" = (SELECT "column_2" FROM "select_identity"),
+				"external_id" = (SELECT "column_3" FROM "select_identity"),
+				"issuer" = (SELECT "column_4" FROM "select_identity")
 			WHERE "person"."id" IS NOT DISTINCT FROM ?
 			RETURNING "person".*, set_identity_id(?) AS __keel_identity_id`,
 		expectedArgs: []any{identity[parser.FieldNameId].(string), "xyz", identity[parser.FieldNameId].(string)},

--- a/runtime/actions/query_test.go
+++ b/runtime/actions/query_test.go
@@ -106,11 +106,11 @@ var testCases = []testCase{
 		input:      map[string]any{},
 		expectedTemplate: `
 			WITH
-				new_1_person AS
+				"new_1_person" AS
 					(INSERT INTO "person"
 					DEFAULT VALUES
 					RETURNING *)
-			SELECT * FROM new_1_person`,
+			SELECT * FROM "new_1_person"`,
 		expectedArgs: []any{},
 	},
 	{
@@ -137,13 +137,13 @@ var testCases = []testCase{
 		input:      map[string]any{},
 		expectedTemplate: `
 			WITH
-				new_1_person AS
+				"new_1_person" AS
 					(INSERT INTO "person"
-						(age, bio, is_active, name)
+						("age", "bio", "is_active", "name")
 					VALUES
 						(?, ?, ?, ?)
 					RETURNING *)
-			SELECT * FROM new_1_person`,
+			SELECT * FROM "new_1_person"`,
 		expectedArgs: []any{int64(100), "# Biography", true, "Bob"},
 	},
 	{
@@ -164,13 +164,13 @@ var testCases = []testCase{
 		input:      map[string]any{},
 		expectedTemplate: `
 			WITH
-				new_1_person AS
+				"new_1_person" AS
 					(INSERT INTO "person"
-						(main_identity_id)
+						("main_identity_id")
 					VALUES
 						(?)
 					RETURNING *)
-			SELECT *, set_identity_id(?) AS __keel_identity_id FROM new_1_person`,
+			SELECT *, set_identity_id(?) AS __keel_identity_id FROM "new_1_person"`,
 		identity:     identity,
 		expectedArgs: []any{"identityId", identity[parser.FieldNameId].(string)},
 	},
@@ -192,13 +192,13 @@ var testCases = []testCase{
 		input:      map[string]any{},
 		expectedTemplate: `
 			WITH
-				new_1_person AS
+				"new_1_person" AS
 					(INSERT INTO "person"
-						(main_identity_id)
+						("main_identity_id")
 					VALUES
 						(?)
 					RETURNING *)
-			SELECT *, set_identity_id(?) AS __keel_identity_id FROM new_1_person`,
+			SELECT *, set_identity_id(?) AS __keel_identity_id FROM "new_1_person"`,
 		identity:     identity,
 		expectedArgs: []any{"identityId", identity[parser.FieldNameId].(string)},
 	},
@@ -221,13 +221,13 @@ var testCases = []testCase{
 		input:      map[string]any{"name": "Dave"},
 		expectedTemplate: `
 			WITH
-				new_1_person AS
+				"new_1_person" AS
 					(INSERT INTO "person"
-						(name, nick_name)
+						("name", "nick_name")
 					VALUES
 						(?, ?)
 					RETURNING *)
-			SELECT *, set_identity_id(?) AS __keel_identity_id FROM new_1_person`,
+			SELECT *, set_identity_id(?) AS __keel_identity_id FROM "new_1_person"`,
 		identity:     identity,
 		expectedArgs: []any{"Dave", "Dave", identity[parser.FieldNameId].(string)},
 	},
@@ -255,18 +255,18 @@ var testCases = []testCase{
 		input:      map[string]any{"name": "Dave"},
 		expectedTemplate: `
 			WITH
-				select_identity (column_0) AS (
+				"select_identity" ("column_0") AS (
 					SELECT "identity$user"."id"
 					FROM "identity"
 					LEFT JOIN "company_user" AS "identity$user" ON "identity$user"."identity_id" = "identity"."id"
 					WHERE "identity"."id" IS NOT DISTINCT FROM ?),
-				new_1_record AS (
-					INSERT INTO "record" (name, user_id)
+				"new_1_record" AS (
+					INSERT INTO "record" ("name", "user_id")
 					VALUES (
 						?,
-						(SELECT column_0 FROM select_identity))
+						(SELECT "column_0" FROM "select_identity"))
 					RETURNING *)
-			SELECT *, set_identity_id(?) AS __keel_identity_id FROM new_1_record`,
+			SELECT *, set_identity_id(?) AS __keel_identity_id FROM "new_1_record"`,
 		identity:     identity,
 		expectedArgs: []any{identity[parser.FieldNameId].(string), "Dave", identity[parser.FieldNameId].(string)},
 	},
@@ -297,19 +297,19 @@ var testCases = []testCase{
 		input:      map[string]any{"name": "Dave"},
 		expectedTemplate: `
 			WITH
-				select_identity (column_0, column_1) AS (
+				"select_identity" ("column_0", "column_1") AS (
 					SELECT "identity$user"."id", "identity$user"."is_active"
 					FROM "identity"
 					LEFT JOIN "company_user" AS "identity$user" ON "identity$user"."identity_id" = "identity"."id"
 					WHERE "identity"."id" IS NOT DISTINCT FROM ?),
-				new_1_record AS (
-					INSERT INTO "record" (is_active, name, user_id)
+				"new_1_record" AS (
+					INSERT INTO "record" ("is_active", "name", "user_id")
 					VALUES (
-						(SELECT column_1 FROM select_identity),
+						(SELECT "column_1" FROM "select_identity"),
 						?,
-						(SELECT column_0 FROM select_identity))
+						(SELECT "column_0" FROM "select_identity"))
 					RETURNING *)
-			SELECT *, set_identity_id(?) AS __keel_identity_id FROM new_1_record`,
+			SELECT *, set_identity_id(?) AS __keel_identity_id FROM "new_1_record"`,
 		identity:     identity,
 		expectedArgs: []any{identity[parser.FieldNameId].(string), "Dave", identity[parser.FieldNameId].(string)},
 	},
@@ -467,11 +467,11 @@ var testCases = []testCase{
 		input:      map[string]any{},
 		expectedTemplate: `
 			WITH
-				new_1_person AS
+				"new_1_person" AS
 					(INSERT INTO "person"
 					DEFAULT VALUES
 					RETURNING *)
-			SELECT * FROM new_1_person`,
+			SELECT * FROM "new_1_person"`,
 		expectedArgs: []any{},
 	},
 	{
@@ -496,13 +496,13 @@ var testCases = []testCase{
 		},
 		expectedTemplate: `
 			WITH
-				new_1_person AS
+				"new_1_person" AS
 					(INSERT INTO "person"
-						(name)
+						("name")
 					VALUES
 						(?)
 					RETURNING *)
-			SELECT * FROM new_1_person`,
+			SELECT * FROM "new_1_person"`,
 		expectedArgs: []any{"Bob"},
 	},
 	{
@@ -1643,13 +1643,13 @@ var testCases = []testCase{
 		},
 		expectedTemplate: `
 			WITH
-				new_1_thing AS
+				"new_1_thing" AS
 					(INSERT INTO "thing"
-						(age, name, parent_id)
+						("age", "name", "parent_id")
 					VALUES
 						(?, ?, ?)
 					RETURNING *)
-			SELECT * FROM new_1_thing`,
+			SELECT * FROM "new_1_thing"`,
 		expectedArgs: []any{21, "bob", "123"},
 	},
 	{
@@ -1682,9 +1682,9 @@ var testCases = []testCase{
 			"name": "fred",
 		},
 		expectedTemplate: `
-			WITH new_1_customer AS (
-				INSERT INTO "customer" (name) VALUES (?) RETURNING *)
-			SELECT * FROM new_1_customer`,
+			WITH "new_1_customer" AS (
+				INSERT INTO "customer" ("name") VALUES (?) RETURNING *)
+			SELECT * FROM "new_1_customer"`,
 		expectedArgs: []any{"fred"},
 	},
 	{
@@ -2157,25 +2157,25 @@ var testCases = []testCase{
 		},
 		expectedTemplate: `
 			WITH
-				new_1_order AS
+				"new_1_order" AS
 					(INSERT INTO "order"
-						(on_promotion)
+						("on_promotion")
 					VALUES
 						(?)
 					RETURNING *),
-				new_1_order_item AS
+				"new_1_order_item" AS
 					(INSERT INTO "order_item"
-						(order_id, product_id, quantity)
+						("order_id", "product_id", "quantity")
 					VALUES
-						((SELECT id FROM new_1_order), ?, ?)
+						((SELECT "id" FROM "new_1_order"), ?, ?)
 					RETURNING *),
-				new_2_order_item AS
+				"new_2_order_item" AS
 					(INSERT INTO "order_item"
-						(order_id, product_id, quantity)
+						("order_id", "product_id", "quantity")
 					VALUES
-						((SELECT id FROM new_1_order), ?, ?)
+						((SELECT "id" FROM "new_1_order"), ?, ?)
 					RETURNING *)
-			SELECT * FROM new_1_order`,
+			SELECT * FROM "new_1_order"`,
 		expectedArgs: []any{
 			true,     // new_1_order
 			"xyz", 2, // new_1_order_item
@@ -2235,31 +2235,31 @@ var testCases = []testCase{
 		},
 		expectedTemplate: `
 			WITH
-				new_1_product AS
+				"new_1_product" AS
 					(INSERT INTO "product"
-						(created_on_order, name)
+						("created_on_order", "name")
 					VALUES
 						(?, ?)
 					RETURNING *),
-				new_1_product_attribute AS
+				"new_1_product_attribute" AS
 					(INSERT INTO "product_attribute"
-						(name, product_id, status)
+						("name", "product_id", "status")
 					VALUES
-						(?, (SELECT id FROM new_1_product), ?)
+						(?, (SELECT "id" FROM "new_1_product"), ?)
 					RETURNING *),
-				new_2_product_attribute AS
+				"new_2_product_attribute" AS
 					(INSERT INTO "product_attribute"
-						(name, product_id, status)
+						("name", "product_id", "status")
 					VALUES
-						(?, (SELECT id FROM new_1_product), ?)
+						(?, (SELECT "id" FROM "new_1_product"), ?)
 					RETURNING *),
-				new_1_order AS
+				"new_1_order" AS
 					(INSERT INTO "order"
-						(product_id)
+						("product_id")
 					VALUES
-						((SELECT id FROM new_1_product))
+						((SELECT "id" FROM "new_1_product"))
 					RETURNING *)
-			SELECT * FROM new_1_order`,
+			SELECT * FROM "new_1_order"`,
 		expectedArgs: []any{
 			true, "Child Bicycle", // new_1_product
 			"FDA approved", "NotApplicable", // new_1_product_attribute
@@ -2312,35 +2312,35 @@ var testCases = []testCase{
 		},
 		expectedTemplate: `
 			WITH
-				new_1_order AS
+				"new_1_order" AS
 					(INSERT INTO "order"
 					DEFAULT VALUES
 					RETURNING *),
-				new_1_product AS
+				"new_1_product" AS
 					(INSERT INTO "product"
-						(name)
+						("name")
 					VALUES
 						(?)
 					RETURNING *),
-				new_1_order_item AS
+				"new_1_order_item" AS
 					(INSERT INTO "order_item"
-						(order_id, product_id, quantity)
+						("order_id", "product_id", "quantity")
 					VALUES
-						((SELECT id FROM new_1_order), (SELECT id FROM new_1_product), ?)
+						((SELECT "id" FROM "new_1_order"), (SELECT "id" FROM "new_1_product"), ?)
 					RETURNING *),
-				new_2_product AS
+				"new_2_product" AS
 					(INSERT INTO "product"
-						(name)
+						("name")
 					VALUES
 						(?)
 					RETURNING *),
-				new_2_order_item AS
+				"new_2_order_item" AS
 					(INSERT INTO "order_item"
-						(order_id, product_id, quantity)
+						("order_id", "product_id", "quantity")
 					VALUES
-						((SELECT id FROM new_1_order), (SELECT id FROM new_2_product), ?)
+						((SELECT "id" FROM "new_1_order"), (SELECT "id" FROM "new_2_product"), ?)
 					RETURNING *)
-			SELECT * FROM new_1_order`,
+			SELECT * FROM "new_1_order"`,
 		expectedArgs: []any{
 			"Hair dryer", // new_1_product
 			2,            //new_1_order_item
@@ -2378,25 +2378,25 @@ var testCases = []testCase{
 		},
 		expectedTemplate: `
 			WITH
-				new_1_product AS
+				"new_1_product" AS
 					(INSERT INTO "product"
-						(name)
+						("name")
 					VALUES
 						(?)
 					RETURNING *),
-				new_2_product AS
+				"new_2_product" AS
 					(INSERT INTO "product"
-						(name)
+						("name")
 					VALUES
 						(?)
 					RETURNING *),
-				new_1_order AS
+				"new_1_order" AS
 					(INSERT INTO "order"
-						(product_1_id, product_2_id)
+						("product_1_id", "product_2_id")
 					VALUES
-						((SELECT id FROM new_1_product), (SELECT id FROM new_2_product))
+						((SELECT "id" FROM "new_1_product"), (SELECT "id" FROM "new_2_product"))
 					RETURNING *)
-			SELECT * FROM new_1_order`,
+			SELECT * FROM "new_1_order"`,
 		expectedArgs: []any{
 			"Child Bicycle", // new_1_product
 			"Adult Bicycle", // new_2_product
@@ -2461,35 +2461,35 @@ var testCases = []testCase{
 		},
 		expectedTemplate: `
 			WITH
-				new_1_order AS
+				"new_1_order" AS
 					(INSERT INTO "order"
 					DEFAULT VALUES
 					RETURNING *),
-				new_1_order_item AS
+				"new_1_order_item" AS
 					(INSERT INTO "order_item"
-						(order_id, product_id, quantity)
+						("order_id", "product_id", "quantity")
 					VALUES
-						((SELECT id FROM new_1_order), ?, ?)
+						((SELECT "id" FROM "new_1_order"), ?, ?)
 					RETURNING *),
-				new_2_order_item AS
+				"new_2_order_item" AS
 					(INSERT INTO "order_item"
-						(order_id, product_id, quantity)
+						("order_id", "product_id", "quantity")
 					VALUES
-						((SELECT id FROM new_1_order), ?, ?)
+						((SELECT "id" FROM "new_1_order"), ?, ?)
 					RETURNING *),
-				new_3_order_item AS
+				"new_3_order_item" AS
 					(INSERT INTO "order_item"
-						(free_on_order_id, product_id, quantity)
+						("free_on_order_id", "product_id", "quantity")
 					VALUES
-						((SELECT id FROM new_1_order), ?, ?)
+						((SELECT "id" FROM "new_1_order"), ?, ?)
 					RETURNING *),
-				new_4_order_item AS
+				"new_4_order_item" AS
 					(INSERT INTO "order_item"
-						(free_on_order_id, product_id, quantity)
+						("free_on_order_id", "product_id", "quantity")
 					VALUES
-						((SELECT id FROM new_1_order), ?, ?)
+						((SELECT "id" FROM "new_1_order"), ?, ?)
 					RETURNING *)
-			SELECT * FROM new_1_order`,
+			SELECT * FROM "new_1_order"`,
 		expectedArgs: []any{
 			"paid1", 2, // new_1_order_item
 			"paid2", 4, // new_2_order_item
@@ -2761,20 +2761,20 @@ var testCases = []testCase{
 		identity:   identity,
 		expectedTemplate: `
 			WITH
-				select_identity (column_0, column_1, column_2, column_3, column_4) AS (
+				"select_identity" ("column_0", "column_1", "column_2", "column_3", "column_4") AS (
 					SELECT "identity"."email", "identity"."created_at", "identity"."email_verified", "identity"."external_id", "identity"."issuer"
 					FROM "identity"
 					WHERE "identity"."id" IS NOT DISTINCT FROM ?),
-				new_1_person AS (
-					INSERT INTO "person" (created, email, email_verified, external_id, issuer)
+				"new_1_person" AS (
+					INSERT INTO "person" ("created", "email", "email_verified", "external_id", "issuer")
 					VALUES (
-						(SELECT column_1 FROM select_identity),
-						(SELECT column_0 FROM select_identity),
-						(SELECT column_2 FROM select_identity),
-						(SELECT column_3 FROM select_identity),
-						(SELECT column_4 FROM select_identity))
+						(SELECT "column_1" FROM "select_identity"),
+						(SELECT "column_0" FROM "select_identity"),
+						(SELECT "column_2" FROM "select_identity"),
+						(SELECT "column_3" FROM "select_identity"),
+						(SELECT "column_4" FROM "select_identity"))
 					RETURNING *)
-			SELECT *, set_identity_id(?) AS __keel_identity_id FROM new_1_person`,
+			SELECT *, set_identity_id(?) AS __keel_identity_id FROM "new_1_person"`,
 		expectedArgs: []any{identity[parser.FieldNameId].(string), identity[parser.FieldNameId].(string)},
 	},
 	{
@@ -2833,11 +2833,11 @@ var testCases = []testCase{
 		actionName: "createPost",
 		input:      map[string]any{"title": "Hello world", "tags": []string{"science", "politics"}},
 		expectedTemplate: `
-			WITH new_1_post AS (
-				INSERT INTO "post" (tags, title) 
+			WITH "new_1_post" AS (
+				INSERT INTO "post" ("tags", "title") 
 				VALUES (ARRAY[?, ?]::TEXT[], ?)
 				RETURNING *) 
-			SELECT * FROM new_1_post`,
+			SELECT * FROM "new_1_post"`,
 		expectedArgs: []any{"science", "politics", "Hello world"},
 	},
 	{
@@ -2857,11 +2857,11 @@ var testCases = []testCase{
 		actionName: "createPost",
 		input:      map[string]any{"title": "Hello world"},
 		expectedTemplate: `
-			WITH new_1_post AS (
-				INSERT INTO "post" (tags, title) 
+			WITH "new_1_post" AS (
+				INSERT INTO "post" ("tags", "title") 
 				VALUES ('{}', ?)
 				RETURNING *) 
-			SELECT * FROM new_1_post`,
+			SELECT * FROM "new_1_post"`,
 		expectedArgs: []any{"Hello world"},
 	},
 	{
@@ -2881,11 +2881,11 @@ var testCases = []testCase{
 		actionName: "createPost",
 		input:      map[string]any{"title": "Hello world"},
 		expectedTemplate: `
-			WITH new_1_post AS (
-				INSERT INTO "post" (tags, title) 
+			WITH "new_1_post" AS (
+				INSERT INTO "post" ("tags", "title") 
 				VALUES (ARRAY[?, ?]::TEXT[], ?)
 				RETURNING *) 
-			SELECT * FROM new_1_post`,
+			SELECT * FROM "new_1_post"`,
 		expectedArgs: []any{"science", "technology", "Hello world"},
 	},
 	{


### PR DESCRIPTION
PostgreSQL reserved keywords can now be used in the schema without risk of breaking any underlying SQL generation.  This was already the case for retrieving data using `get` and `list` actions, but now has been also fixed for `create` and `update`.