### PR TITLE
fix: dont stderr for config errors with --json flag set

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -40,11 +40,14 @@ var validateCmd = &cobra.Command{
 
 			_, err = b.MakeFromString(string(schema), string(configBytes))
 			if err != nil {
-				if _, ok := err.(*errorhandling.ValidationErrors); !ok {
+				switch err := err.(type) {
+				case *errorhandling.ValidationErrors:
+					validationErrors = err
+				case *config.ConfigErrors:
+					// Handle ConfigErrors if needed
+				default:
 					return err
 				}
-
-				validationErrors = err.(*errorhandling.ValidationErrors)
 			}
 
 			c, err := config.LoadFromBytes(configBytes, "")

--- a/config/schema.json
+++ b/config/schema.json
@@ -2,7 +2,7 @@
   "type": "object",
   "properties": {
     "environment": {
-      "type": "array",
+      "type": [ "array", "null" ],
       "items": {
         "type": "object",
         "properties": {
@@ -20,7 +20,7 @@
       }
     },
     "secrets": {
-      "type": "array",
+      "type": [ "array", "null" ],
       "items": {
         "type": "object",
         "properties": {
@@ -38,7 +38,7 @@
       "type": "boolean"
     },
     "auth": {
-      "type": "object",
+      "type": [ "object", "null" ],
       "properties": {
         "redirectUrl": {
           "type": "string",


### PR DESCRIPTION
`keelconfig.yaml` errors are now not sent to stderr when calling `keel validate --json`.  This is important for the VSCode extension as any stderr  in `--json` mode is recognised as a CLI failure.

Furthermore, relaxing the config schema rules to allow empty (null) values for the root level `secrets:`, `auth:` and `environment:` properties. These are generated as so by `keel init` and so this would be a breaking change otherwise.

@jonbretman FYI - hope this makes sense