### PR TITLE
fix: dont swallow schema validation when config has errors

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -39,16 +39,11 @@ var validateCmd = &cobra.Command{
 			}
 
 			_, err = b.MakeFromString(string(schema), string(configBytes))
-			if err != nil {
-				switch err := err.(type) {
-				case *errorhandling.ValidationErrors:
-					validationErrors = err
-				case *config.ConfigErrors:
-					// Handle ConfigErrors if needed
-				default:
-					return err
-				}
+			if _, ok := err.(*errorhandling.ValidationErrors); !ok {
+				return err
 			}
+
+			validationErrors = err.(*errorhandling.ValidationErrors)
 
 			c, err := config.LoadFromBytes(configBytes, "")
 			if err != nil {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -59,9 +59,11 @@ func (scm *Builder) MakeFromString(schemaString string, configString string) (*p
 	})
 
 	cfg, err := config.LoadFromBytes([]byte(configString), "")
-	if _, ok := err.(*config.ConfigErrors); !ok {
-		// This is a bit messy, but for now we dont return config validation errors from here
-		return nil, err
+	if err != nil {
+		if _, ok := err.(*config.ConfigErrors); !ok {
+			// This is a bit messy, but for now we dont return config validation errors from here
+			return nil, err
+		}
 	}
 
 	scm.Config = cfg

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -58,12 +58,13 @@ func (scm *Builder) MakeFromString(schemaString string, configString string) (*p
 		FileName: "schema.keel",
 	})
 
-	config, err := config.LoadFromBytes([]byte(configString), "")
-	if err != nil {
+	cfg, err := config.LoadFromBytes([]byte(configString), "")
+	if _, ok := err.(*config.ConfigErrors); !ok {
+		// This is a bit messy, but for now we dont return config validation errors from here
 		return nil, err
 	}
 
-	scm.Config = config
+	scm.Config = cfg
 
 	return scm.makeFromInputs(&reader.Inputs{
 		SchemaFiles: scm.schemaFiles,


### PR DESCRIPTION
If a `keelconfig.yaml` validations exist, any schema validation errors weren't being returned in `--json` mode.  @jonbretman FYI