### PR TITLE
fix: config schema missing disablekeelauth

### DIFF
--- a/config/fixtures/test_keel_auth_disable.yaml
+++ b/config/fixtures/test_keel_auth_disable.yaml
@@ -1,0 +1,1 @@
+disableKeelAuth: true

--- a/config/schema.json
+++ b/config/schema.json
@@ -126,7 +126,11 @@
         }
       },
       "additionalProperties": false
+    },
+    "disableKeelAuth": {
+      "type": "boolean"
     }
   },
+
   "additionalProperties": false
 }


### PR DESCRIPTION
The `disableKeelAuth` root field in the `keelconfig.yaml` schema wasn't being tolerated.