### PR TITLE
fix: keel schema api formatting

### DIFF
--- a/schema/format/format.go
+++ b/schema/format/format.go
@@ -406,10 +406,29 @@ func printApi(writer *Writer, api *parser.APINode) {
 						writer.block(func() {
 							for _, model := range section.Models {
 								writer.comments(model, func() {
-									writer.writeLine(camel(model.Name.Value))
+									writer.write(camel(model.Name.Value))
+									if len(model.Sections) == 1 {
+										writer.block(func() {
+											writer.write("actions")
+											writer.block(func() {
+												for j, action := range model.Sections[0].Actions {
+													if j > 0 {
+														writer.writeLine("")
+													}
+													writer.comments(action, func() {
+														writer.write(action.Name.Value)
+													})
+												}
+												writer.writeLine("")
+											})
+										})
+									} else {
+										writer.writeLine("")
+									}
 								})
 							}
 						})
+
 					case section.Attribute != nil:
 						printAttributes(writer, []*parser.AttributeNode{section.Attribute})
 					}

--- a/schema/format/testdata/api_with_actions.txt
+++ b/schema/format/testdata/api_with_actions.txt
@@ -1,0 +1,39 @@
+api Api {
+models {
+    // Something or other
+Author
+Post {
+actions {
+getPost
+listPosts
+}
+}
+Category {
+actions {
+    // Something or other
+listCategories
+}
+}
+}
+}
+
+===
+
+api Api {
+    models {
+        // Something or other
+        Author
+        Post {
+            actions {
+                getPost
+                listPosts
+            }
+        }
+        Category {
+            actions {
+                // Something or other
+                listCategories
+            }
+        }
+    }
+}


### PR DESCRIPTION
The formatter (used by the VSCode extension) will now correctly format the `api` sections in the Keel schema.  For example:

```
api Api {
    models {
        // Something or other
        Author
        Post {
            actions {
                getPost
                listPosts
            }
        }
        Category {
            actions {
                // Something or other
                listCategories
            }
        }
    }
}
```