### PR TITLE
fix: relaxed requirement on token and auth url in keelconfig

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -372,23 +372,9 @@ func validateAuthProviders(c *ProjectConfig) []*ConfigError {
 				Type:    "reserved-prefix",
 			})
 		}
-		if p.Type == "oidc" && p.AuthorizationUrl == "" {
-			errors = append(errors, &ConfigError{
-				Message: fmt.Sprintf("auth.providers.%d: 'authorizationUrl' is required if 'type' is 'oidc'", i),
-				Field:   fmt.Sprintf("auth.providers.%d", i),
-				Type:    "required",
-			})
-		}
 		if p.Type == "oidc" && p.IssuerUrl == "" {
 			errors = append(errors, &ConfigError{
 				Message: fmt.Sprintf("auth.providers.%d: 'issuerUrl' is required if 'type' is 'oidc'", i),
-				Field:   fmt.Sprintf("auth.providers.%d", i),
-				Type:    "required",
-			})
-		}
-		if p.Type == "oidc" && p.TokenUrl == "" {
-			errors = append(errors, &ConfigError{
-				Message: fmt.Sprintf("auth.providers.%d: 'tokenUrl' is required if 'type' is 'oidc'", i),
 				Field:   fmt.Sprintf("auth.providers.%d", i),
 				Type:    "required",
 			})

--- a/config/fixtures/test_auth.yaml
+++ b/config/fixtures/test_auth.yaml
@@ -17,10 +17,23 @@ auth:
       name: google_2
       clientId: foo_2
 
+    # Built-in Slack provider
+    - type: slack
+      name: sl
+      clientId: foo_3
+
+    # Built-in Facebook provider
+    - type: facebook
+      name: fb
+      clientId: foo_4
+
+    # Built-in Gitlab provider
+    - type: gitlab
+      name: gitlab
+      clientId: foo_5
+
     # Custom OIDC
     - type: oidc
       name: baidu
       issuerUrl: "https://dev-skhlutl45lbqkvhv.us.auth0.com"
-      authorizationUrl: "https://dev-skhlutl45lbqkvhv.us.auth0.com"
-      tokenUrl: "https://dev-skhlutl45lbqkvhv.us.auth0.com"
       clientId: "kasj28fnq09ak"

--- a/config/fixtures/test_auth_invalid_auth_url.yaml
+++ b/config/fixtures/test_auth_invalid_auth_url.yaml
@@ -1,7 +1,6 @@
 # auth.providers.0.authorizationUrl: Does not match pattern '^https://'
 # auth.providers.1.authorizationUrl: Does not match pattern '^https://'
 # auth.providers.1.authorizationUrl: Does not match format 'uri'
-# auth.providers.2: 'authorizationUrl' is required if 'type' is 'oidc'
 
 auth:
   providers:

--- a/config/fixtures/test_auth_invalid_token_url.yaml
+++ b/config/fixtures/test_auth_invalid_token_url.yaml
@@ -1,7 +1,6 @@
 # auth.providers.0.tokenUrl: Does not match pattern '^https://'
 # auth.providers.1.tokenUrl: Does not match pattern '^https://'
 # auth.providers.1.tokenUrl: Does not match format 'uri'
-# auth.providers.2: 'tokenUrl' is required if 'type' is 'oidc'
 
 auth:
   tokens:


### PR DESCRIPTION
`tokenUrl` and `authorizationUrl` are not required for `oidc` auth type due to the auto discovery nature of OpenID Connect.