### PR TITLE
fix: add embed attribute to code completions

### DIFF
--- a/schema/completions/completions.go
+++ b/schema/completions/completions.go
@@ -392,6 +392,7 @@ func getActionCompletions(asts []*parser.AST, tokenAtPos *TokensAtPosition) []*C
 			parser.AttributeOrderBy,
 			parser.AttributeSortable,
 			parser.AttributeFunction,
+			parser.AttributeEmbed,
 		})
 	}
 

--- a/schema/completions/completions_test.go
+++ b/schema/completions/completions_test.go
@@ -656,7 +656,7 @@ func TestActionCompletions(t *testing.T) {
 				}
 			  }
 		    }`,
-			expected: []string{"@function", "@orderBy", "@permission", "@set", "@sortable", "@validate", "@where"},
+			expected: []string{"@embed", "@function", "@orderBy", "@permission", "@set", "@sortable", "@validate", "@where"},
 		},
 		{
 			name: "action-attributes-whitespace",
@@ -671,7 +671,7 @@ func TestActionCompletions(t *testing.T) {
 				}
 			  }
 		    }`,
-			expected: []string{"@function", "@orderBy", "@permission", "@set", "@sortable", "@validate", "@where"},
+			expected: []string{"@embed", "@function", "@orderBy", "@permission", "@set", "@sortable", "@validate", "@where"},
 		},
 	}
 


### PR DESCRIPTION
`@embed` was previously not included in code completions for attributes within a action block. This now fixes the issue.