### PR TITLE
chore: attribute argument validations

### DIFF
--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -72,6 +72,7 @@ func TestValidation(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, tc := range testCases {
+
 		testCase := tc
 		if testCase.IsDir() {
 			t.Errorf("errors test data directory should only contain keel schema files - directory found: %s", testCase.Name())
@@ -139,10 +140,10 @@ func TestValidation(t *testing.T) {
 
 			missing, unexpected := lo.Difference(lo.Map(expectedErrors, errorToString), lo.Map(verrs.Errors, errorToString))
 			for _, v := range missing {
-				t.Errorf("  Expected:   %s", v)
+				t.Errorf("  Expected in %s:   %s", testCase.Name(), v)
 			}
 			for _, v := range unexpected {
-				t.Errorf("  Unexpected: %s", v)
+				t.Errorf("  Unexpected in %s: %s", testCase.Name(), v)
 			}
 		})
 	}

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -72,7 +72,6 @@ func TestValidation(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, tc := range testCases {
-
 		testCase := tc
 		if testCase.IsDir() {
 			t.Errorf("errors test data directory should only contain keel schema files - directory found: %s", testCase.Name())

--- a/schema/testdata/errors/attribute_embed.keel
+++ b/schema/testdata/errors/attribute_embed.keel
@@ -39,6 +39,7 @@ model Book {
             //expect-error:20:28:AttributeArgumentError:@embed argument is not correctly formatted
             @embed(code = 1)
             //expect-error:29:30:AttributeArgumentError:The @embed attribute can only be used with valid model fields
+            //expect-error:29:30:AttributeArgumentError:unexpected argument for @embed as only a single argument is expected
             @embed(reviews, 2)
             //expect-error:20:26:AttributeArgumentError:The @embed attribute can only be used with valid model fields
             @embed("code")

--- a/schema/testdata/errors/attribute_embed.keel
+++ b/schema/testdata/errors/attribute_embed.keel
@@ -39,7 +39,6 @@ model Book {
             //expect-error:20:28:AttributeArgumentError:@embed argument is not correctly formatted
             @embed(code = 1)
             //expect-error:29:30:AttributeArgumentError:The @embed attribute can only be used with valid model fields
-            //expect-error:29:30:AttributeArgumentError:unexpected argument for @embed as only a single argument is expected
             @embed(reviews, 2)
             //expect-error:20:26:AttributeArgumentError:The @embed attribute can only be used with valid model fields
             @embed("code")

--- a/schema/testdata/errors/attribute_orderby_invalid_args.keel
+++ b/schema/testdata/errors/attribute_orderby_invalid_args.keel
@@ -10,7 +10,7 @@ model Author {
 
     actions {
         list listAuthors() {
-            //expect-error:13:21:AttributeArgumentError:@orderBy requires at least once argument
+            //expect-error:13:21:AttributeArgumentError:@orderBy requires at least one argument
             @orderBy
             //expect-error:13:21:AttributeNotAllowedError:@orderBy can only be defined once per action
             //expect-error:22:31:AttributeArgumentError:@orderBy arguments must be specified with a label corresponding with a field on this model

--- a/schema/testdata/errors/attribute_unique.keel
+++ b/schema/testdata/errors/attribute_unique.keel
@@ -7,24 +7,24 @@ model Person {
     //expect-error:13:24:E016:Invalid value, expected at least two field names to be provided
     @unique([firstName])
 
-    //expect-error:5:12:E024:2 argument(s) provided to @unique but expected 1
     @unique(
         firstName,
+        //expect-error:9:17:AttributeArgumentError:unexpected argument for @unique as only a single argument is expected
         lastName
     )
 
     //expect-error:25:32:E016:Invalid value, expected any of the following identifiers - firstName, or lastName
     @unique([firstName, surname])
 
-    //expect-error:5:12:E024:2 argument(s) provided to @unique but expected 1
     @unique(
         unknown1,
+        //expect-error:9:17:AttributeArgumentError:unexpected argument for @unique as only a single argument is expected
         unknown2
     )
 
-    //expect-error:5:12:E024:2 argument(s) provided to @unique but expected 1
     @unique(
         "first_name",
+        //expect-error:9:20:AttributeArgumentError:unexpected argument for @unique as only a single argument is expected
         "last_name"
     )
 

--- a/schema/testdata/errors/attribute_unique_invalids_args.keel
+++ b/schema/testdata/errors/attribute_unique_invalids_args.keel
@@ -1,6 +1,6 @@
 model Post {
     fields {
-        //expect-error:20:32:E024:1 argument(s) provided to @unique but expected 0
+        //expect-error:28:31:AttributeArgumentError:unexpected argument for @unique as no arguments are expected
         title Text @unique(arg)
     }
 }

--- a/schema/testdata/errors/jobs_permission_attribute_expression_invalid_args.keel
+++ b/schema/testdata/errors/jobs_permission_attribute_expression_invalid_args.keel
@@ -14,14 +14,14 @@ job MyJob3 {
 }
 
 job MyJob4 {
-    //expect-error:17:36:AttributeArgumentError:@permission requires all arguments to be named, for example @permission(roles: [MyRole])
     //expect-error:5:16:AttributeArgumentError:@permission requires either the 'expressions' or 'roles' argument to be provided
+    //expect-error:17:36:AttributeArgumentError:unexpected argument for @permission
     @permission(ctx.isAuthenticated)
 }
 
 job MyJob5 {
-    //expect-error:17:21:AttributeArgumentError:'expr' is not a valid argument for @permission
     //expect-error:5:16:AttributeArgumentError:@permission requires either the 'expressions' or 'roles' argument to be provided
+    //expect-error:17:21:AttributeArgumentError:unexpected argument 'expr' for @permission
     @permission(expr: ctx.isAuthenticated)
 }
 

--- a/schema/testdata/errors/jobs_permission_attribute_role_invalid_args.keel
+++ b/schema/testdata/errors/jobs_permission_attribute_role_invalid_args.keel
@@ -14,7 +14,7 @@ job MyJob3 {
 }
 
 job MyJob4 {
-    //expect-error:17:24:AttributeArgumentError:@permission requires all arguments to be named, for example @permission(roles: [MyRole])
+    //expect-error:17:24:AttributeArgumentError:unexpected argument for @permission
     //expect-error:5:16:AttributeArgumentError:@permission requires either the 'expressions' or 'roles' argument to be provided
     @permission([Admin])
 }

--- a/schema/testdata/errors/jobs_schedule.keel
+++ b/schema/testdata/errors/jobs_schedule.keel
@@ -1,3 +1,7 @@
+job NoArgs {
+    //expect-error:5:14:AttributeArgumentError:expected an argument for @schedule
+    @schedule
+}
 
 job TooManyArgs {
     @schedule(
@@ -5,4 +9,30 @@ job TooManyArgs {
         //expect-error:9:23:AttributeArgumentError:unexpected argument for @schedule as only a single argument is expected
         "also mondays"
     )
+}
+
+job WrongArgType {	
+    //expect-error:15:19:AttributeArgumentError:argument must be a string	
+    @schedule(1234)	
+}
+
+job Labelled {	
+    //expect-error:15:19:AttributeArgumentError:argument to @schedule cannot be labelled	
+    @schedule(cron: "foo")	
+}
+
+job InvalidSchedule {	
+    //expect-error:25:29:AttributeArgumentError:unexpected token 'cats' - expected 'minutes' or 'hours'	
+    @schedule("every 10 cats")	
+}	
+
+job InvalidCron {	
+    //expect-error:27:30:AttributeArgumentError:invalid value 'BOB' for day-of-week field	
+    @schedule("*/10 * * * BOB")	
+}	
+
+job TwoSchedules {	
+    @schedule("every 10 minutes")	
+    //expect-error:5:14:AttributeNotAllowedError:A job cannot have more than one @schedule attribute	
+    @schedule("every 2 hours")	
 }

--- a/schema/testdata/errors/jobs_schedule.keel
+++ b/schema/testdata/errors/jobs_schedule.keel
@@ -11,28 +11,29 @@ job TooManyArgs {
     )
 }
 
-job WrongArgType {	
-    //expect-error:15:19:AttributeArgumentError:argument must be a string	
-    @schedule(1234)	
+job WrongArgType {
+    //expect-error:15:19:AttributeArgumentError:argument must be a string
+    @schedule(1234)
 }
 
-job Labelled {	
-    //expect-error:15:19:AttributeArgumentError:argument to @schedule cannot be labelled	
-    @schedule(cron: "foo")	
+job Labelled {
+    //expect-error:15:19:AttributeArgumentError:unexpected argument 'cron' for @schedule as only a single argument is expected
+    //expect-error:21:26:AttributeArgumentError:invalid schedule - must be expression like 'every day at 9am' or cron syntax e.g. '0 9 * * *'
+    @schedule(cron: "foo")
 }
 
-job InvalidSchedule {	
-    //expect-error:25:29:AttributeArgumentError:unexpected token 'cats' - expected 'minutes' or 'hours'	
-    @schedule("every 10 cats")	
-}	
+job InvalidSchedule {
+    //expect-error:25:29:AttributeArgumentError:unexpected token 'cats' - expected 'minutes' or 'hours'
+    @schedule("every 10 cats")
+}
 
-job InvalidCron {	
-    //expect-error:27:30:AttributeArgumentError:invalid value 'BOB' for day-of-week field	
-    @schedule("*/10 * * * BOB")	
-}	
+job InvalidCron {
+    //expect-error:27:30:AttributeArgumentError:invalid value 'BOB' for day-of-week field
+    @schedule("*/10 * * * BOB")
+}
 
-job TwoSchedules {	
-    @schedule("every 10 minutes")	
-    //expect-error:5:14:AttributeNotAllowedError:A job cannot have more than one @schedule attribute	
-    @schedule("every 2 hours")	
+job TwoSchedules {
+    @schedule("every 10 minutes")
+    //expect-error:5:14:AttributeNotAllowedError:A job cannot have more than one @schedule attribute
+    @schedule("every 2 hours")
 }

--- a/schema/testdata/errors/jobs_schedule.keel
+++ b/schema/testdata/errors/jobs_schedule.keel
@@ -1,38 +1,8 @@
-job NoArgs {
-    //expect-error:5:14:AttributeArgumentError:@schedule must have exactly one argument
-    @schedule
-}
 
 job TooManyArgs {
-    //expect-error:5:14:AttributeArgumentError:@schedule must have exactly one argument
     @schedule(
         "every 10 minutes",
+        //expect-error:9:23:AttributeArgumentError:unexpected argument for @schedule as only a single argument is expected
         "also mondays"
     )
-}
-
-job WrongArgType {
-    //expect-error:15:19:AttributeArgumentError:argument must be a string
-    @schedule(1234)
-}
-
-job Labelled {
-    //expect-error:15:19:AttributeArgumentError:argument to @schedule cannot be labelled
-    @schedule(cron: "foo")
-}
-
-job InvalidSchedule {
-    //expect-error:25:29:AttributeArgumentError:unexpected token 'cats' - expected 'minutes' or 'hours'
-    @schedule("every 10 cats")
-}
-
-job InvalidCron {
-    //expect-error:27:30:AttributeArgumentError:invalid value 'BOB' for day-of-week field
-    @schedule("*/10 * * * BOB")
-}
-
-job TwoSchedules {
-    @schedule("every 10 minutes")
-    //expect-error:5:14:AttributeNotAllowedError:A job cannot have more than one @schedule attribute
-    @schedule("every 2 hours")
 }

--- a/schema/testdata/errors/operation_where_too_many_arguments.keel
+++ b/schema/testdata/errors/operation_where_too_many_arguments.keel
@@ -6,9 +6,9 @@ model Profile {
 
     actions {
         get getProfile(username) {
-            //expect-error:13:14:E024:2 argument(s) provided to @where but expected 1
             @where(
                 profile.identity == ctx.identity,
+                //expect-error:17:45:AttributeArgumentError:unexpected argument for @where
                 profile.username == "adaam2"
             )
         }

--- a/schema/testdata/errors/permission_action.keel
+++ b/schema/testdata/errors/permission_action.keel
@@ -7,7 +7,7 @@ model Person {
         get getPerson(id) {
             // Invalid to provide actions inside an action
             @permission(
-                //expect-error:17:24:AttributeArgumentError:cannot provide 'actions' arguments when using @permission in an action
+                //expect-error:17:24:AttributeArgumentError:unexpected argument 'actions' for @permission
                 actions: [create],
                 expression: true
             )

--- a/schema/testdata/errors/permission_attribute_invalid_args.keel
+++ b/schema/testdata/errors/permission_attribute_invalid_args.keel
@@ -3,8 +3,8 @@ model Person {
         get getPerson(id)
     }
 
-    //expect-error:17:21:AttributeArgumentError:@permission requires all arguments to be named, for example @permission(roles: [MyRole])
     //expect-error:5:16:AttributeArgumentError:required argument 'actions' missing
     //expect-error:5:16:AttributeArgumentError:@permission requires either the 'expressions' or 'roles' argument to be provided
+    //expect-error:17:21:AttributeArgumentError:unexpected argument for @permission
     @permission(true)
 }

--- a/schema/testdata/errors/permission_job.keel
+++ b/schema/testdata/errors/permission_job.keel
@@ -1,6 +1,6 @@
 job MyJob {
     @permission(
-        //expect-error:9:16:AttributeArgumentError:cannot provide 'actions' arguments when using @permission in a job
+        //expect-error:9:16:AttributeArgumentError:unexpected argument 'actions' for @permission
         actions: [get],
         roles: [MyRole]
     )

--- a/schema/testdata/errors/relationships_attr_empty.keel
+++ b/schema/testdata/errors/relationships_attr_empty.keel
@@ -1,7 +1,6 @@
 model Post {
     fields {
-        //expect-error:22:31:RelationshipError:The @relation attribute cannot be used on non-model fields
-        author1 Text @relation
+        //expect-error:24:33:AttributeArgumentError:expected an argument for @relation
         //expect-error:24:33:RelationshipError:The @relation argument must refer to a field on Author
         author2 Author @relation
     }

--- a/schema/validation/attribute_arguments.go
+++ b/schema/validation/attribute_arguments.go
@@ -5,24 +5,23 @@ import (
 
 	"github.com/teamkeel/keel/schema/node"
 	"github.com/teamkeel/keel/schema/parser"
-	"github.com/teamkeel/keel/schema/query"
 	"github.com/teamkeel/keel/schema/validation/errorhandling"
 )
 
 // AttributeArgumentsRules tests for the very basic rules around required arguments for attributes
 func AttributeArgumentsRules(asts []*parser.AST, errs *errorhandling.ValidationErrors) Visitor {
-	var model *parser.ModelNode
+	//var model *parser.ModelNode
 	var field *parser.FieldNode
 	var action *parser.ActionNode
 	var job *parser.JobNode
 
 	return Visitor{
-		EnterModel: func(m *parser.ModelNode) {
-			model = m
-		},
-		LeaveModel: func(*parser.ModelNode) {
-			model = nil
-		},
+		// EnterModel: func(m *parser.ModelNode) {
+		// 	model = m
+		// },
+		// LeaveModel: func(*parser.ModelNode) {
+		// 	model = nil
+		// },
 		EnterAction: func(a *parser.ActionNode) {
 			action = a
 		},
@@ -126,15 +125,6 @@ func AttributeArgumentsRules(asts []*parser.AST, errs *errorhandling.ValidationE
 
 					hint = `the @permission attribute at the model level accepts either an expression or a roles argument, and an actions argument, for e.g. @permission(expression: ctx.isAuthenticated, actions: [get, list])`
 				}
-			case parser.AttributeEmbed:
-				template = map[string]bool{}
-				for _, f := range query.ModelFields(model) {
-					if query.Model(asts, f.Type.Value) != nil {
-						template[f.Name.Value] = false
-					}
-				}
-
-				hint = `the @embed attribute accepts any number of model fields, for e.g. @embed(author, publisher)`
 			default:
 				return
 			}

--- a/schema/validation/attribute_arguments.go
+++ b/schema/validation/attribute_arguments.go
@@ -1,0 +1,213 @@
+package validation
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/teamkeel/keel/schema/node"
+	"github.com/teamkeel/keel/schema/parser"
+	"github.com/teamkeel/keel/schema/query"
+	"github.com/teamkeel/keel/schema/validation/errorhandling"
+)
+
+// AttributeArgumentsRules tests for the very basic rules around required arguments for attributes
+func AttributeArgumentsRules(asts []*parser.AST, errs *errorhandling.ValidationErrors) Visitor {
+	var model *parser.ModelNode
+	var field *parser.FieldNode
+	var action *parser.ActionNode
+	var job *parser.JobNode
+
+	return Visitor{
+		EnterModel: func(m *parser.ModelNode) {
+			model = m
+		},
+		LeaveModel: func(*parser.ModelNode) {
+			model = nil
+		},
+		EnterAction: func(a *parser.ActionNode) {
+			action = a
+		},
+		LeaveAction: func(*parser.ActionNode) {
+			action = nil
+		},
+		EnterField: func(f *parser.FieldNode) {
+			field = f
+		},
+		LeaveField: func(*parser.FieldNode) {
+			field = nil
+		},
+		EnterJob: func(j *parser.JobNode) {
+			job = j
+		},
+		LeaveJob: func(*parser.JobNode) {
+			job = nil
+		},
+		EnterAttribute: func(attribute *parser.AttributeNode) {
+			var template map[string]bool
+			validationErrors := []*errorhandling.ValidationError{}
+
+			switch attribute.Name.Value {
+			case parser.AttributeDefault:
+				// A single optional argument
+				template = map[string]bool{
+					"": false,
+				}
+			case parser.AttributeFunction:
+				// No arguments
+				template = map[string]bool{}
+			case parser.AttributeUnique:
+				if field == nil {
+					// A composite unique requires a single argument
+					template = map[string]bool{
+						"": true,
+					}
+				} else {
+					// A field-level unique has no arguments
+					template = map[string]bool{}
+				}
+			case parser.AttributeWhere:
+				// Optional expression argument
+				template = map[string]bool{
+					"":           false,
+					"expression": false,
+				}
+			case parser.AttributeRelation, parser.AttributeSet, parser.AttributeSchedule:
+				// A single required argument without a label
+				template = map[string]bool{
+					"": true,
+				}
+			case parser.AttributePermission:
+				if action != nil {
+					template = map[string]bool{
+						"expression": false,
+						"roles":      false,
+					}
+				} else if job != nil {
+					template = map[string]bool{
+						"expression": false,
+						"roles":      false,
+					}
+				} else {
+					template = map[string]bool{
+						"expression": false,
+						"roles":      false,
+						"actions":    false,
+					}
+				}
+			case parser.AttributeEmbed:
+				template = map[string]bool{}
+				for _, f := range query.ModelFields(model) {
+					if query.Model(asts, f.Type.Value) != nil {
+						template[f.Name.Value] = false
+					}
+				}
+			default:
+				return
+			}
+
+			var expected []string
+			for k := range template {
+				expected = append(expected, k)
+			}
+
+			hint := fmt.Sprintf("the signature for this @%s attribute is (%s)", attribute.Name.Value, strings.Join(expected, ", "))
+
+			// copy a map
+			arguments := make(map[string]bool)
+			for k, v := range template {
+				arguments[k] = v
+			}
+
+			// Look for unexpected arguments
+			for _, arg := range attribute.Arguments {
+				label := ""
+				if arg.Label != nil {
+					label = arg.Label.Value
+				}
+
+				if _, has := arguments[label]; has {
+					delete(arguments, label)
+				} else {
+					var message string
+					if label == "" {
+						message = fmt.Sprintf("unexpected argument for @%s", attribute.Name.Value)
+					} else {
+						message = fmt.Sprintf("unexpected argument '%s' for @%s", label, attribute.Name.Value)
+					}
+
+					if len(expected) == 1 && expected[0] == "" {
+						message = message + " as only a single argument is expected"
+					} else if len(expected) == 0 {
+						message = message + " as no arguments are expected"
+					}
+
+					var node node.ParserNode
+					if label != "" {
+						node = arg.Label
+					} else {
+						node = arg
+					}
+
+					validationErrors = append(validationErrors, errorhandling.NewValidationErrorWithDetails(
+						errorhandling.AttributeArgumentError,
+						errorhandling.ErrorDetails{
+							Message: message,
+							//Hint:    hint,
+						},
+						node,
+					))
+				}
+			}
+
+			if len(validationErrors) > 0 {
+				errs.AppendErrors(validationErrors)
+				return
+			}
+
+			// Look for expected arguments
+			for k, v := range arguments {
+				if !v {
+					// if the argument is optional, then continue
+					continue
+				}
+				if k == "" {
+					validationErrors = append(validationErrors, errorhandling.NewValidationErrorWithDetails(
+						errorhandling.AttributeArgumentError,
+						errorhandling.ErrorDetails{
+							Message: fmt.Sprintf("expected an argument for @%s", attribute.Name.Value),
+							Hint:    hint,
+						},
+						attribute,
+					))
+				} else {
+					validationErrors = append(validationErrors, errorhandling.NewValidationErrorWithDetails(
+						errorhandling.AttributeArgumentError,
+						errorhandling.ErrorDetails{
+							Message: fmt.Sprintf("expected argument '%s' for @%s", k, attribute.Name.Value),
+							Hint:    hint,
+						},
+						attribute,
+					))
+				}
+			}
+
+			errs.AppendErrors(validationErrors)
+
+		},
+	}
+}
+
+// E024:
+// message: "{{ .ActualArgsCount }} argument(s) provided to @{{ .AttributeName }} but expected {{ .ExpectedArgsCount }}"
+// hint: '{{ if eq .Signature "()" }}@{{ .AttributeName }} doesn''t accept any arguments{{ else }}the signature of this attribute is @{{ .AttributeName }}{{ .Signature }}{{ end }}'
+
+// func makeWhereExpressionError(t errorhandling.ErrorType, message string, hint string, node node.ParserNode) *errorhandling.ValidationError {
+// 	return errorhandling.NewValidationErrorWithDetails(
+// 		t,
+// 		errorhandling.ErrorDetails{
+// 			Message: message,
+// 			Hint:    hint,
+// 		},
+// 		node,
+// 	)
+// }

--- a/schema/validation/errorhandling/errors.go
+++ b/schema/validation/errorhandling/errors.go
@@ -117,9 +117,7 @@ func (v *ValidationErrors) AppendError(e *ValidationError) {
 }
 
 func (v *ValidationErrors) AppendErrors(errs []*ValidationError) {
-	for _, e := range errs {
-		v.Errors = append(v.Errors, e)
-	}
+	v.Errors = append(v.Errors, errs...)
 }
 
 func (v *ValidationErrors) Concat(verrs ValidationErrors) {

--- a/schema/validation/errorhandling/errors.go
+++ b/schema/validation/errorhandling/errors.go
@@ -32,7 +32,6 @@ const (
 	ErrorUniqueEnumGlobally                  = "E019"
 	ErrorUnresolvableExpression              = "E020"
 	ErrorForbiddenExpressionAction           = "E022"
-	ErrorIncorrectArguments                  = "E024"
 	ErrorInvalidSyntax                       = "E025"
 	ErrorExpressionTypeMismatch              = "E026"
 	ErrorForbiddenOperator                   = "E027"
@@ -113,6 +112,12 @@ func (v *ValidationErrors) AppendWarning(e *ValidationError) {
 
 func (v *ValidationErrors) AppendError(e *ValidationError) {
 	if e != nil {
+		v.Errors = append(v.Errors, e)
+	}
+}
+
+func (v *ValidationErrors) AppendErrors(errs []*ValidationError) {
+	for _, e := range errs {
 		v.Errors = append(v.Errors, e)
 	}
 }

--- a/schema/validation/errorhandling/errors.yml
+++ b/schema/validation/errorhandling/errors.yml
@@ -59,9 +59,6 @@ en:
   E022:
     message: "Operator '{{ .Operator }}' not permitted on {{ .Attribute }}"
     hint: "{{ .Suggestion }}"
-  E024:
-    message: "{{ .ActualArgsCount }} argument(s) provided to @{{ .AttributeName }} but expected {{ .ExpectedArgsCount }}"
-    hint: '{{ if eq .Signature "()" }}@{{ .AttributeName }} doesn''t accept any arguments{{ else }}the signature of this attribute is @{{ .AttributeName }}{{ .Signature }}{{ end }}'
   E025:
     message: "{{ .Message }}"
   E026:

--- a/schema/validation/orderby_attribute.go
+++ b/schema/validation/orderby_attribute.go
@@ -69,7 +69,7 @@ func OrderByAttributeRule(asts []*parser.AST, errs *errorhandling.ValidationErro
 				errs.AppendError(errorhandling.NewValidationErrorWithDetails(
 					errorhandling.AttributeArgumentError,
 					errorhandling.ErrorDetails{
-						Message: "@orderBy requires at least once argument",
+						Message: "@orderBy requires at least one argument",
 					},
 					attribute,
 				))

--- a/schema/validation/permission_attribute_arguments.go
+++ b/schema/validation/permission_attribute_arguments.go
@@ -47,34 +47,14 @@ func PermissionsAttributeArguments(asts []*parser.AST, errs *errorhandling.Valid
 			hasRoles := false
 
 			for _, arg := range attr.Arguments {
-				if arg.Label == nil || arg.Label.Value == "" {
-					errs.AppendError(errorhandling.NewValidationErrorWithDetails(
-						errorhandling.AttributeArgumentError,
-						errorhandling.ErrorDetails{
-							Message: "@permission requires all arguments to be named, for example @permission(roles: [MyRole])",
-						},
-						arg,
-					))
+				if arg.Label == nil {
+					// Argument validation happens elsewhere
 					continue
 				}
 
 				switch arg.Label.Value {
 				case "actions":
 					hasActions = true
-
-					if action != nil || job != nil {
-						errs.AppendError(errorhandling.NewValidationErrorWithDetails(
-							errorhandling.AttributeArgumentError,
-							errorhandling.ErrorDetails{
-								Message: fmt.Sprintf(
-									"cannot provide 'actions' arguments when using @permission in %s",
-									lo.Ternary(action != nil, "an action", "a job"),
-								),
-							},
-							arg.Label,
-						))
-						continue
-					}
 
 					errs.Concat(validateIdentArray(arg.Expression, []string{
 						parser.ActionTypeGet,
@@ -143,18 +123,6 @@ func PermissionsAttributeArguments(asts []*parser.AST, errs *errorhandling.Valid
 					}
 
 					errs.Concat(validateIdentArray(arg.Expression, roles, "role defined in your schema"))
-				default:
-					errs.AppendError(errorhandling.NewValidationErrorWithDetails(
-						errorhandling.AttributeArgumentError,
-						errorhandling.ErrorDetails{
-							Message: fmt.Sprintf(
-								"'%s' is not a valid argument for @permission",
-								arg.Label.Value,
-							),
-							Hint: "Did you mean one of 'actions', 'expression', or 'roles'?",
-						},
-						arg.Label,
-					))
 				}
 			}
 

--- a/schema/validation/rules/attribute/attribute.go
+++ b/schema/validation/rules/attribute/attribute.go
@@ -197,15 +197,8 @@ func validateActionAttributeWithExpression(
 	action *parser.ActionNode,
 	attr *parser.AttributeNode,
 ) (errs errorhandling.ValidationErrors) {
-	//argLength := len(attr.Arguments)
-
-	// if argLength == 1 {
-	// 	// Attribute required arguments are validated elsewhere
-	// 	return
-	// }
 
 	expr := attr.Arguments[0].Expression
-
 	rules := []expression.Rule{}
 
 	if attr.Name.Value == parser.AttributeSet {

--- a/schema/validation/rules/attribute/attribute.go
+++ b/schema/validation/rules/attribute/attribute.go
@@ -197,7 +197,6 @@ func validateActionAttributeWithExpression(
 	action *parser.ActionNode,
 	attr *parser.AttributeNode,
 ) (errs errorhandling.ValidationErrors) {
-
 	expr := attr.Arguments[0].Expression
 	rules := []expression.Rule{}
 

--- a/schema/validation/rules/attribute/attribute.go
+++ b/schema/validation/rules/attribute/attribute.go
@@ -2,7 +2,6 @@ package attribute
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/samber/lo"
 	"github.com/teamkeel/keel/formatting"
@@ -171,20 +170,6 @@ func validateModelFieldDefaultAttribute(
 		return
 	}
 
-	if argLength >= 2 {
-		errs.Append(
-			errorhandling.ErrorIncorrectArguments,
-			map[string]string{
-				"AttributeName":     attr.Name.Value,
-				"ActualArgsCount":   strconv.FormatInt(int64(argLength), 10),
-				"ExpectedArgsCount": "1",
-				"Signature":         "(expression)",
-			},
-			attr,
-		)
-		return
-	}
-
 	expr := attr.Arguments[0].Expression
 
 	rules := []expression.Rule{expression.ValueTypechecksRule}
@@ -212,21 +197,12 @@ func validateActionAttributeWithExpression(
 	action *parser.ActionNode,
 	attr *parser.AttributeNode,
 ) (errs errorhandling.ValidationErrors) {
-	argLength := len(attr.Arguments)
+	//argLength := len(attr.Arguments)
 
-	if argLength == 0 || argLength >= 2 {
-		errs.Append(
-			errorhandling.ErrorIncorrectArguments,
-			map[string]string{
-				"AttributeName":     attr.Name.Value,
-				"ActualArgsCount":   strconv.FormatInt(int64(argLength), 10),
-				"ExpectedArgsCount": "1",
-				"Signature":         "(expression)",
-			},
-			attr,
-		)
-		return
-	}
+	// if argLength == 1 {
+	// 	// Attribute required arguments are validated elsewhere
+	// 	return
+	// }
 
 	expr := attr.Arguments[0].Expression
 
@@ -313,26 +289,6 @@ func UniqueAttributeArgsRule(asts []*parser.AST) (errs errorhandling.ValidationE
 		if model.BuiltIn {
 			continue
 		}
-		// field level e.g. @unique
-		for _, field := range query.ModelFields(model) {
-			for _, attr := range field.Attributes {
-				if attr.Name.Value != parser.AttributeUnique {
-					continue
-				}
-
-				if len(attr.Arguments) > 0 {
-					errs.Append(errorhandling.ErrorIncorrectArguments,
-						map[string]string{
-							"AttributeName":     attr.Name.Value,
-							"ActualArgsCount":   strconv.FormatInt(int64(len(attr.Arguments)), 10),
-							"ExpectedArgsCount": "0",
-							"Signature":         "()",
-						},
-						attr,
-					)
-				}
-			}
-		}
 
 		// model level e.g. @unique([fieldOne, fieldTwo])
 		for _, attr := range query.ModelAttributes(model) {
@@ -341,15 +297,7 @@ func UniqueAttributeArgsRule(asts []*parser.AST) (errs errorhandling.ValidationE
 			}
 
 			if len(attr.Arguments) != 1 {
-				errs.Append(errorhandling.ErrorIncorrectArguments,
-					map[string]string{
-						"AttributeName":     attr.Name.Value,
-						"ActualArgsCount":   strconv.FormatInt(int64(len(attr.Arguments)), 10),
-						"ExpectedArgsCount": "1",
-						"Signature":         "([fieldName, otherFieldName])",
-					},
-					attr.Name,
-				)
+				// Attribute required arguments are validated elsewhere
 				continue
 			}
 

--- a/schema/validation/schedule_attribute.go
+++ b/schema/validation/schedule_attribute.go
@@ -15,29 +15,12 @@ func ScheduleAttributeRule(asts []*parser.AST, errs *errorhandling.ValidationErr
 				return
 			}
 
-			if len(attribute.Arguments) != 1 {
-				errs.AppendError(errorhandling.NewValidationErrorWithDetails(
-					errorhandling.AttributeArgumentError,
-					errorhandling.ErrorDetails{
-						Message: "@schedule must have exactly one argument",
-					},
-					attribute.Name,
-				))
+			if len(attribute.Arguments) == 0 {
+				// Argument validation is handled elsewhere
 				return
 			}
 
 			arg := attribute.Arguments[0]
-			if arg.Label != nil {
-				errs.AppendError(errorhandling.NewValidationErrorWithDetails(
-					errorhandling.AttributeArgumentError,
-					errorhandling.ErrorDetails{
-						Message: "argument to @schedule cannot be labelled",
-					},
-					arg.Label,
-				))
-				return
-			}
-
 			op, err := arg.Expression.ToValue()
 			if err != nil || op.String == nil {
 				errs.AppendError(errorhandling.NewValidationErrorWithDetails(

--- a/schema/validation/validation.go
+++ b/schema/validation/validation.go
@@ -72,6 +72,7 @@ var visitorFuncs = []VisitorFunc{
 	ConflictingInputsRule,
 	UniqueLookup,
 	InvalidWithUsage,
+	AttributeArgumentsRules,
 	UniqueAttributeRule,
 	OrderByAttributeRule,
 	SortableAttributeRule,


### PR DESCRIPTION
Moving the basics around attribute argument validation to one place.  Any special rules for an attribute still remain in their place.  Also improved the hint responses. 

I do think we can expand on this a lot more.  I will likely do so in the CEL work.