### PR TITLE
fix: no identity exists error messsage in token exchange

### DIFF
--- a/runtime/apis/authapi/token_endpoint.go
+++ b/runtime/apis/authapi/token_endpoint.go
@@ -294,7 +294,7 @@ func TokenEndpointHandler(schema *proto.Schema) common.HandlerFunc {
 
 			if ident == nil {
 				if !createIfNotExists {
-					return jsonErrResponse(ctx, http.StatusUnauthorized, TokenErrInvalidClient, "possible causes may be that the identity does not exist or the id token is invalid, has expired, or has insufficient claims", err)
+					return jsonErrResponse(ctx, http.StatusUnauthorized, TokenErrInvalidClient, "the identity does not exist", err)
 				}
 
 				ident, err = actions.CreateIdentityWithClaims(ctx, schema, idToken.Subject, idToken.Issuer, &standardClaims, customClaims)

--- a/runtime/apis/authapi/token_endpoint.go
+++ b/runtime/apis/authapi/token_endpoint.go
@@ -268,7 +268,7 @@ func TokenEndpointHandler(schema *proto.Schema) common.HandlerFunc {
 			// Verify the ID token with the OIDC provider
 			idToken, err := oauth.VerifyIdToken(ctx, idTokenRaw)
 			if err != nil {
-				return jsonErrResponse(ctx, http.StatusUnauthorized, TokenErrInvalidClient, "possible causes may be that the identity does not exist or the id token is invalid, has expired, or has insufficient claims", err)
+				return jsonErrResponse(ctx, http.StatusUnauthorized, TokenErrInvalidClient, "access denied", err)
 			}
 
 			// Extract standardClaims

--- a/runtime/apis/authapi/token_endpoint_test.go
+++ b/runtime/apis/authapi/token_endpoint_test.go
@@ -1021,7 +1021,7 @@ func TestTokenExchangeGrant_BadIdToken(t *testing.T) {
 
 	require.Equal(t, http.StatusUnauthorized, httpResponse.StatusCode)
 	require.Equal(t, "invalid_client", errorResponse.Error)
-	require.Equal(t, "possible causes may be that the identity does not exist or the id token is invalid, has expired, or has insufficient claims", errorResponse.ErrorDescription)
+	require.Equal(t, "access denied", errorResponse.ErrorDescription)
 	require.True(t, common.HasContentType(httpResponse.Header, "application/json"))
 }
 

--- a/runtime/apis/authapi/token_endpoint_test.go
+++ b/runtime/apis/authapi/token_endpoint_test.go
@@ -653,7 +653,7 @@ func TestTokenExchangeCreateIfNotExistsFalse_IdentityNotExists(t *testing.T) {
 
 	require.Equal(t, http.StatusUnauthorized, httpResponse.StatusCode)
 	require.Equal(t, "invalid_client", errorResponse.Error)
-	require.Equal(t, "possible causes may be that the identity does not exist or the id token is invalid, has expired, or has insufficient claims", errorResponse.ErrorDescription)
+	require.Equal(t, "the identity does not exist", errorResponse.ErrorDescription)
 	require.True(t, common.HasContentType(httpResponse.Header, "application/json"))
 }
 

--- a/runtime/oauth/id_token.go
+++ b/runtime/oauth/id_token.go
@@ -56,8 +56,8 @@ func VerifyIdToken(ctx context.Context, idTokenRaw string) (*oidc.IDToken, error
 	if issuer == "" {
 		return nil, errors.New("iss claim cannot be an empty string")
 	}
-	span.AddEvent("Issuer extracted from ID Token")
 
+	span.AddEvent("Issuer extracted from ID Token")
 	span.SetAttributes(attribute.String("issuer", issuer))
 
 	authConfig, err := runtimectx.GetOAuthConfig(ctx)
@@ -79,11 +79,11 @@ func VerifyIdToken(ctx context.Context, idTokenRaw string) (*oidc.IDToken, error
 	if err != nil {
 		return nil, err
 	}
+
 	span.AddEvent("Provider's ODIC config fetched")
 
-	var verificationErrs error
-
 	// Verify against each configured provider with this issuer
+	var verificationErrs error
 	for _, p := range providers {
 		// Checking the clientId during verification ensures that the ID token was intended for this client,
 		// because it could have been stolen from any other application with an ID token from this same issuer.


### PR DESCRIPTION
Improving the error response message when in ID token exchange an identity does not exist and createIfNotExists is `false`.