### PR TITLE
fix: generate the client api with proxy that calls into rawrequest to save bundle size

### DIFF
--- a/node/client.go
+++ b/node/client.go
@@ -54,7 +54,6 @@ func generateClientSdkFile(schema *proto.Schema, api *proto.Api) codegen.Generat
 	client.Writeln("// API")
 	client.Writeln("")
 
-	writeClientApiInterface(client, schema, api)
 	writeClientApiClass(client, schema, api)
 
 	return []*codegen.GeneratedFile{
@@ -117,6 +116,8 @@ func generateClientSdkPackage(schema *proto.Schema, api *proto.Api) codegen.Gene
 }
 
 func writeClientApiClass(w *codegen.Writer, schema *proto.Schema, api *proto.Api) {
+	writeClientApiInterface(w, schema, api)
+
 	w.Writeln("export class APIClient extends Core {")
 
 	w.Indent()

--- a/node/client.go
+++ b/node/client.go
@@ -54,6 +54,7 @@ func generateClientSdkFile(schema *proto.Schema, api *proto.Api) codegen.Generat
 	client.Writeln("// API")
 	client.Writeln("")
 
+	writeClientApiInterface(client, schema, api)
 	writeClientApiClass(client, schema, api)
 
 	return []*codegen.GeneratedFile{
@@ -126,22 +127,20 @@ func writeClientApiClass(w *codegen.Writer, schema *proto.Schema, api *proto.Api
 	w.Writeln("}")
 	w.Writeln("")
 
-	w.Writeln("private actions = {")
-	w.Indent()
-
-	writeClientActions(w, schema, api)
-
-	w.Dedent()
-	w.Writeln("};")
-	w.Writeln("")
-
 	w.Writeln("api = {")
 	w.Indent()
-
-	writeClientApiDefinition(w, schema, api)
-
+	w.Writeln("queries: new Proxy({}, {")
+	w.Indent()
+	w.Writeln("get: (_, fn: string) => (i: any) => this.client.rawRequest(fn, i),")
 	w.Dedent()
-	w.Writeln("};")
+	w.Writeln("}),")
+	w.Writeln("mutations: new Proxy({}, {")
+	w.Indent()
+	w.Writeln("get: (_, fn: string) => (i: any) => this.client.rawRequest(fn, i),")
+	w.Dedent()
+	w.Writeln("})")
+	w.Dedent()
+	w.Writeln("} as KeelAPI;")
 
 	w.Dedent()
 	w.Writeln("}")
@@ -151,75 +150,69 @@ func writeClientApiClass(w *codegen.Writer, schema *proto.Schema, api *proto.Api
 	writeClientTypes(w, schema, api)
 }
 
-func writeClientActions(w *codegen.Writer, schema *proto.Schema, api *proto.Api) {
-	for _, a := range proto.GetActionNamesForApi(schema, api) {
-		action := schema.FindAction(a)
-		msg := schema.FindMessage(action.InputMessageName)
-
-		w.Writef("%s: (i", action.Name)
-
-		// Check that all of the top level fields in the matching message are optional
-		// If so, then we can make it so you don't even need to specify the key
-		// example, this allows for:
-		// await actions.listActivePublishersWithActivePosts();
-		// instead of:
-		// const { results: publishers } =
-		// await actions.listActivePublishersWithActivePosts({ where: {} });
-		if lo.EveryBy(msg.Fields, func(f *proto.MessageField) bool {
-			return f.Optional
-		}) {
-			w.Write("?")
-		}
-
-		inputType := action.InputMessageName
-		if inputType == parser.MessageFieldTypeAny {
-			inputType = "any"
-		}
-
-		w.Writef(`: %s) `, inputType)
-		w.Writeln("=> {")
-
-		w.Indent()
-
-		model := schema.FindModel(action.ModelName)
-		w.Writef(`return this.client.rawRequest<%s>("%s", i)`, toClientActionReturnType(model, action), action.Name)
-
-		w.Writeln(";")
-		w.Dedent()
-		w.Writeln("},")
-	}
-}
-
-func writeClientApiDefinition(w *codegen.Writer, schema *proto.Schema, api *proto.Api) {
-	queries := []string{}
-	mutations := []string{}
+func writeClientApiInterface(w *codegen.Writer, schema *proto.Schema, api *proto.Api) {
+	queries := []*proto.Action{}
+	mutations := []*proto.Action{}
 
 	for _, a := range proto.GetActionNamesForApi(schema, api) {
 		action := schema.FindAction(a)
 		if action.Type == proto.ActionType_ACTION_TYPE_GET || action.Type == proto.ActionType_ACTION_TYPE_LIST || action.Type == proto.ActionType_ACTION_TYPE_READ {
-			queries = append(queries, action.Name)
+			queries = append(queries, action)
 		} else {
-			mutations = append(mutations, action.Name)
+			mutations = append(mutations, action)
 		}
 	}
 
+	w.Writeln("interface KeelAPI {")
+	w.Indent()
 	w.Writeln("queries: {")
 	w.Indent()
+
 	for _, fn := range queries {
-		w.Writef(`%s: this.actions.%s`, fn, fn)
-		w.Writeln(",")
+		writeClientActionType(w, schema, fn)
 	}
+
 	w.Dedent()
 	w.Writeln("},")
 
 	w.Writeln("mutations: {")
 	w.Indent()
+
 	for _, fn := range mutations {
-		w.Writef(`%s: this.actions.%s`, fn, fn)
-		w.Writeln(",")
+		writeClientActionType(w, schema, fn)
 	}
+
 	w.Dedent()
 	w.Writeln("}")
+
+	w.Dedent()
+	w.Writeln("}")
+	w.Writeln("")
+}
+
+func writeClientActionType(w *codegen.Writer, schema *proto.Schema, action *proto.Action) {
+	msg := schema.FindMessage(action.InputMessageName)
+
+	w.Writef("%s: (i", action.Name)
+
+	// Check that all of the top level fields in the matching message are optional
+	if lo.EveryBy(msg.Fields, func(f *proto.MessageField) bool {
+		return f.Optional
+	}) {
+		w.Write("?")
+	}
+
+	inputType := action.InputMessageName
+	if inputType == parser.MessageFieldTypeAny {
+		inputType = "any"
+	}
+
+	w.Writef(`: %s) => `, inputType)
+
+	model := schema.FindModel(action.ModelName)
+	w.Writef(`Promise<APIResult<%s>>`, toClientActionReturnType(model, action))
+
+	w.Writeln(";")
 }
 
 func writeClientTypes(w *codegen.Writer, schema *proto.Schema, api *proto.Api) {

--- a/node/client_test.go
+++ b/node/client_test.go
@@ -27,13 +27,17 @@ api Api {
 }`
 
 	expected := `
-getPerson: (i: GetPersonInput) => {
-	return this.client.rawRequest<Person | null>("getPerson", i);
+interface KeelAPI {
+	queries: {
+		getPerson: (i: GetPersonInput) => Promise<APIResult<Person | null>>;
+	},
+	mutations: {
+	}
 }`
 
 	runWriterTest(t, schema, expected, func(s *proto.Schema, w *codegen.Writer) {
 		api := proto.FindApi(s, "Api")
-		writeClientActions(w, s, api)
+		writeClientApiInterface(w, s, api)
 	})
 }
 
@@ -54,7 +58,7 @@ model Company {
 
 api Api {
 	models {
-		Person 
+		Person
 		Company {
 			actions {
 				getCompany
@@ -64,16 +68,18 @@ api Api {
 }`
 
 	expected := `
-getPerson: (i: GetPersonInput) => {
-	return this.client.rawRequest<Person | null>("getPerson", i);
-},
-getCompany: (i: GetCompanyInput) => {
-	return this.client.rawRequest<Company | null>("getCompany", i);
-},`
+interface KeelAPI {
+	queries: {
+		getPerson: (i: GetPersonInput) => Promise<APIResult<Person | null>>;
+		getCompany: (i: GetCompanyInput) => Promise<APIResult<Company | null>>;
+	},
+	mutations: {
+	}
+}`
 
 	runWriterTest(t, schema, expected, func(s *proto.Schema, w *codegen.Writer) {
 		api := proto.FindApi(s, "Api")
-		writeClientActions(w, s, api)
+		writeClientApiInterface(w, s, api)
 	})
 }
 
@@ -93,13 +99,17 @@ api Web {
 }`
 
 	expected := `
-getPerson: (i: GetPersonInput) => {
-	return this.client.rawRequest<Person | null>("getPerson", i);
+interface KeelAPI {
+	queries: {
+		getPerson: (i: GetPersonInput) => Promise<APIResult<Person | null>>;
+	},
+	mutations: {
+	}
 }`
 
 	runWriterTest(t, schema, expected, func(s *proto.Schema, w *codegen.Writer) {
 		api := proto.FindApi(s, "Web")
-		writeClientActions(w, s, api)
+		writeClientApiInterface(w, s, api)
 	})
 }
 
@@ -116,13 +126,19 @@ model Person {
 }`
 
 	expected := `
-getPerson: (i: GetPersonInput) => {
-	return this.client.rawRequest<Person | null>("getPerson", i);
+interface KeelAPI {
+	queries: {
+		getPerson: (i: GetPersonInput) => Promise<APIResult<Person | null>>;
+	},
+	mutations: {
+		requestPasswordReset: (i: RequestPasswordResetInput) => Promise<APIResult<RequestPasswordResetResponse>>;
+		resetPassword: (i: ResetPasswordInput) => Promise<APIResult<ResetPasswordResponse>>;
+	}
 }`
 
 	runWriterTest(t, schema, expected, func(s *proto.Schema, w *codegen.Writer) {
 		api := proto.FindApi(s, "Api")
-		writeClientActions(w, s, api)
+		writeClientApiInterface(w, s, api)
 	})
 }
 
@@ -139,13 +155,19 @@ model Person {
 }`
 
 	expected := `
-createPerson: (i: CreatePersonInput) => {
-	return this.client.rawRequest<Person>("createPerson", i);
+interface KeelAPI {
+	queries: {
+	},
+	mutations: {
+		createPerson: (i: CreatePersonInput) => Promise<APIResult<Person>>;
+		requestPasswordReset: (i: RequestPasswordResetInput) => Promise<APIResult<RequestPasswordResetResponse>>;
+		resetPassword: (i: ResetPasswordInput) => Promise<APIResult<ResetPasswordResponse>>;
+	}
 }`
 
 	runWriterTest(t, schema, expected, func(s *proto.Schema, w *codegen.Writer) {
 		api := proto.FindApi(s, "Api")
-		writeClientActions(w, s, api)
+		writeClientApiInterface(w, s, api)
 	})
 }
 
@@ -162,13 +184,19 @@ model Person {
 }`
 
 	expected := `
-updatePerson: (i: UpdatePersonInput) => {
-	return this.client.rawRequest<Person>("updatePerson", i);
+interface KeelAPI {
+	queries: {
+	},
+	mutations: {
+		updatePerson: (i: UpdatePersonInput) => Promise<APIResult<Person>>;
+		requestPasswordReset: (i: RequestPasswordResetInput) => Promise<APIResult<RequestPasswordResetResponse>>;
+		resetPassword: (i: ResetPasswordInput) => Promise<APIResult<ResetPasswordResponse>>;
+	}
 }`
 
 	runWriterTest(t, schema, expected, func(s *proto.Schema, w *codegen.Writer) {
 		api := proto.FindApi(s, "Api")
-		writeClientActions(w, s, api)
+		writeClientApiInterface(w, s, api)
 	})
 }
 
@@ -185,13 +213,19 @@ model Person {
 }`
 
 	expected := `
-deletePerson: (i: DeletePersonInput) => {
-	return this.client.rawRequest<string>("deletePerson", i);
+interface KeelAPI {
+	queries: {
+	},
+	mutations: {
+		deletePerson: (i: DeletePersonInput) => Promise<APIResult<string>>;
+		requestPasswordReset: (i: RequestPasswordResetInput) => Promise<APIResult<RequestPasswordResetResponse>>;
+		resetPassword: (i: ResetPasswordInput) => Promise<APIResult<ResetPasswordResponse>>;
+	}
 }`
 
 	runWriterTest(t, schema, expected, func(s *proto.Schema, w *codegen.Writer) {
 		api := proto.FindApi(s, "Api")
-		writeClientActions(w, s, api)
+		writeClientApiInterface(w, s, api)
 	})
 }
 
@@ -208,13 +242,19 @@ model Person {
 }`
 
 	expected := `
-listPeople: (i: ListPeopleInput) => {
-	return this.client.rawRequest<{ results: Person[], pageInfo: PageInfo }>("listPeople", i);
-},`
+interface KeelAPI {
+	queries: {
+		listPeople: (i: ListPeopleInput) => Promise<APIResult<{ results: Person[], pageInfo: PageInfo }>>;
+	},
+	mutations: {
+		requestPasswordReset: (i: RequestPasswordResetInput) => Promise<APIResult<RequestPasswordResetResponse>>;
+		resetPassword: (i: ResetPasswordInput) => Promise<APIResult<ResetPasswordResponse>>;
+	}
+}`
 
 	runWriterTest(t, schema, expected, func(s *proto.Schema, w *codegen.Writer) {
 		api := proto.FindApi(s, "Api")
-		writeClientActions(w, s, api)
+		writeClientApiInterface(w, s, api)
 	})
 }
 
@@ -232,16 +272,20 @@ model Person {
 }`
 
 	expected := `
-createPerson: (i?: CreatePersonInput) => {
-	return this.client.rawRequest<Person>("createPerson", i);
-},
-listPeople: (i?: ListPeopleInput) => {
-	return this.client.rawRequest<{ results: Person[], pageInfo: PageInfo }>("listPeople", i);
+interface KeelAPI {
+	queries: {
+		listPeople: (i?: ListPeopleInput) => Promise<APIResult<{ results: Person[], pageInfo: PageInfo }>>;
+	},
+	mutations: {
+		createPerson: (i?: CreatePersonInput) => Promise<APIResult<Person>>;
+		requestPasswordReset: (i: RequestPasswordResetInput) => Promise<APIResult<RequestPasswordResetResponse>>;
+		resetPassword: (i: ResetPasswordInput) => Promise<APIResult<ResetPasswordResponse>>;
+	}
 }`
 
 	runWriterTest(t, schema, expected, func(s *proto.Schema, w *codegen.Writer) {
 		api := proto.FindApi(s, "Api")
-		writeClientActions(w, s, api)
+		writeClientApiInterface(w, s, api)
 	})
 }
 
@@ -259,13 +303,19 @@ model Person {
 }`
 
 	expected := `
-listPeople: (i?: ListPeopleInput) => {
-	return this.client.rawRequest<{ results: Person[], pageInfo: PageInfo }>("listPeople", i);
+interface KeelAPI {
+	queries: {
+		listPeople: (i?: ListPeopleInput) => Promise<APIResult<{ results: Person[], pageInfo: PageInfo }>>;
+	},
+	mutations: {
+		requestPasswordReset: (i: RequestPasswordResetInput) => Promise<APIResult<RequestPasswordResetResponse>>;
+		resetPassword: (i: ResetPasswordInput) => Promise<APIResult<ResetPasswordResponse>>;
+	}
 }`
 
 	runWriterTest(t, schema, expected, func(s *proto.Schema, w *codegen.Writer) {
 		api := proto.FindApi(s, "Api")
-		writeClientActions(w, s, api)
+		writeClientApiInterface(w, s, api)
 	})
 }
 
@@ -283,13 +333,19 @@ model Person {
 }`
 
 	expected := `
-listPeople: (i: ListPeopleInput) => {
-	return this.client.rawRequest<{ results: Person[], pageInfo: PageInfo }>("listPeople", i);
-},`
+interface KeelAPI {
+	queries: {
+		listPeople: (i: ListPeopleInput) => Promise<APIResult<{ results: Person[], pageInfo: PageInfo }>>;
+	},
+	mutations: {
+		requestPasswordReset: (i: RequestPasswordResetInput) => Promise<APIResult<RequestPasswordResetResponse>>;
+		resetPassword: (i: ResetPasswordInput) => Promise<APIResult<ResetPasswordResponse>>;
+	}
+}`
 
 	runWriterTest(t, schema, expected, func(s *proto.Schema, w *codegen.Writer) {
 		api := proto.FindApi(s, "Api")
-		writeClientActions(w, s, api)
+		writeClientApiInterface(w, s, api)
 	})
 }
 
@@ -311,13 +367,19 @@ message People {
 }`
 
 	expected := `
-readPeople: (i: ReadPeopleInput) => {
-	return this.client.rawRequest<People>("readPeople", i);
+interface KeelAPI {
+	queries: {
+		readPeople: (i: ReadPeopleInput) => Promise<APIResult<People>>;
+	},
+	mutations: {
+		requestPasswordReset: (i: RequestPasswordResetInput) => Promise<APIResult<RequestPasswordResetResponse>>;
+		resetPassword: (i: ResetPasswordInput) => Promise<APIResult<ResetPasswordResponse>>;
+	}
 }`
 
 	runWriterTest(t, schema, expected, func(s *proto.Schema, w *codegen.Writer) {
 		api := proto.FindApi(s, "Api")
-		writeClientActions(w, s, api)
+		writeClientApiInterface(w, s, api)
 	})
 }
 
@@ -339,13 +401,19 @@ message People {
 }`
 
 	expected := `
-writePeople: (i: WritePeopleInput) => {
-	return this.client.rawRequest<People>("writePeople", i);
+interface KeelAPI {
+	queries: {
+	},
+	mutations: {
+		writePeople: (i: WritePeopleInput) => Promise<APIResult<People>>;
+		requestPasswordReset: (i: RequestPasswordResetInput) => Promise<APIResult<RequestPasswordResetResponse>>;
+		resetPassword: (i: ResetPasswordInput) => Promise<APIResult<ResetPasswordResponse>>;
+	}
 }`
 
 	runWriterTest(t, schema, expected, func(s *proto.Schema, w *codegen.Writer) {
 		api := proto.FindApi(s, "Api")
-		writeClientActions(w, s, api)
+		writeClientApiInterface(w, s, api)
 	})
 }
 
@@ -367,13 +435,19 @@ message People {
 }`
 
 	expected := `
-readPeople: (i: SearchParams) => {
-	return this.client.rawRequest<People>("readPeople", i);
+interface KeelAPI {
+	queries: {
+		readPeople: (i: SearchParams) => Promise<APIResult<People>>;
+	},
+	mutations: {
+		requestPasswordReset: (i: RequestPasswordResetInput) => Promise<APIResult<RequestPasswordResetResponse>>;
+		resetPassword: (i: ResetPasswordInput) => Promise<APIResult<ResetPasswordResponse>>;
+	}
 }`
 
 	runWriterTest(t, schema, expected, func(s *proto.Schema, w *codegen.Writer) {
 		api := proto.FindApi(s, "Api")
-		writeClientActions(w, s, api)
+		writeClientApiInterface(w, s, api)
 	})
 }
 
@@ -387,13 +461,19 @@ model Person {
 }`
 
 	expected := `
-readPeople: (i?: any) => {
-	return this.client.rawRequest<any>("readPeople", i);
+interface KeelAPI {
+	queries: {
+		readPeople: (i?: any) => Promise<APIResult<any>>;
+	},
+	mutations: {
+		requestPasswordReset: (i: RequestPasswordResetInput) => Promise<APIResult<RequestPasswordResetResponse>>;
+		resetPassword: (i: ResetPasswordInput) => Promise<APIResult<ResetPasswordResponse>>;
+	}
 }`
 
 	runWriterTest(t, schema, expected, func(s *proto.Schema, w *codegen.Writer) {
 		api := proto.FindApi(s, "Api")
-		writeClientActions(w, s, api)
+		writeClientApiInterface(w, s, api)
 	})
 }
 
@@ -415,22 +495,24 @@ model Person {
 }`
 
 	expected := `
-queries: {
-	getPerson: this.actions.getPerson,
-	listPeople: this.actions.listPeople,
-	readPeople: this.actions.readPeople,
-},
-mutations: {
-	createPerson: this.actions.createPerson,
-	updatePerson: this.actions.updatePerson,
-	deletePerson: this.actions.deletePerson,
-	requestPasswordReset: this.actions.requestPasswordReset,
-	resetPassword: this.actions.resetPassword,
+interface KeelAPI {
+	queries: {
+		getPerson: (i: GetPersonInput) => Promise<APIResult<Person | null>>;
+		listPeople: (i: ListPeopleInput) => Promise<APIResult<{ results: Person[], pageInfo: PageInfo }>>;
+		readPeople: (i?: any) => Promise<APIResult<any>>;
+	},
+	mutations: {
+		createPerson: (i: CreatePersonInput) => Promise<APIResult<Person>>;
+		updatePerson: (i: UpdatePersonInput) => Promise<APIResult<Person>>;
+		deletePerson: (i: DeletePersonInput) => Promise<APIResult<string>>;
+		requestPasswordReset: (i: RequestPasswordResetInput) => Promise<APIResult<RequestPasswordResetResponse>>;
+		resetPassword: (i: ResetPasswordInput) => Promise<APIResult<ResetPasswordResponse>>;
+	}
 }`
 
 	runWriterTest(t, schema, expected, func(s *proto.Schema, w *codegen.Writer) {
 		api := proto.FindApi(s, "Api")
-		writeClientApiDefinition(w, s, api)
+		writeClientApiInterface(w, s, api)
 	})
 }
 
@@ -532,32 +614,29 @@ model Person {
 }`
 
 	expected := `
+interface KeelAPI {
+	queries: {
+		getPerson: (i: GetPersonInput) => Promise<APIResult<Person | null>>;
+	},
+	mutations: {
+		requestPasswordReset: (i: RequestPasswordResetInput) => Promise<APIResult<RequestPasswordResetResponse>>;
+		resetPassword: (i: ResetPasswordInput) => Promise<APIResult<ResetPasswordResponse>>;
+	}
+}
+
 export class APIClient extends Core {
 	constructor(config: Config) {
 		super(config);
 	}
 
-	private actions = {
-		getPerson: (i: GetPersonInput) => {
-			return this.client.rawRequest<Person | null>("getPerson", i);
-		},
-		requestPasswordReset: (i: RequestPasswordResetInput) => {
-			return this.client.rawRequest<RequestPasswordResetResponse>("requestPasswordReset", i);
-		},
-		resetPassword: (i: ResetPasswordInput) => {
-			return this.client.rawRequest<ResetPasswordResponse>("resetPassword", i);
-		},
-	};
-
 	api = {
-		queries: {
-			getPerson: this.actions.getPerson,
-		},
-		mutations: {
-			requestPasswordReset: this.actions.requestPasswordReset,
-			resetPassword: this.actions.resetPassword,
-		}
-	};
+		queries: new Proxy({}, {
+			get: (_, fn: string) => (i: any) => this.client.rawRequest(fn, i),
+		}),
+		mutations: new Proxy({}, {
+			get: (_, fn: string) => (i: any) => this.client.rawRequest(fn, i),
+		})
+	} as KeelAPI;
 }`
 
 	runWriterTest(t, schema, expected, func(s *proto.Schema, w *codegen.Writer) {


### PR DESCRIPTION
This changes the generated APIClient to not need to include all of the actions on the JavaScript object. The generated actions were all doing exactly the same thing, calling `rawRequest` with its own function name and a single parameter. So this makes the APIClient a Proxy which for any child name returns a function that calls `rawRequest` with that name. And it still generates all the types so the Proxy has the exact same type shape as the APIClient did before.

This reduces bundle size significantly, especially with large API surfaces. Rather than scaling with the number of actions it is now just a constant sized small Proxy object. For example the APIClient in Bravely has 213 actions, and the generated APIClient (after types compiled out) was 41kb (4kb gzipped). Now it's 343 bytes (195 bytes gzipped).