### PR TITLE
fix: generate related tools for delete actions

### DIFF
--- a/tools/generator.go
+++ b/tools/generator.go
@@ -197,10 +197,11 @@ func (g *Generator) decorateTools() error {
 
 // generateRelatedActionsLinks will traverse the tools and generate the RelatedActions links:
 //   - For LIST actions = other list actions for the same model
+//   - For DELETE actions = all list actions for the same model
 func (g *Generator) generateRelatedActionsLinks() {
 	for id, tool := range g.Tools {
 		displayOrder := 0
-		if !tool.Action.IsList() {
+		if !(tool.Action.IsList() || tool.Action.IsDelete()) {
 			continue
 		}
 

--- a/tools/proto/tools.pb.go
+++ b/tools/proto/tools.pb.go
@@ -262,11 +262,12 @@ type ActionConfig struct {
 	EntityPlural string `protobuf:"bytes,14,opt,name=entity_plural,json=entityPlural,proto3" json:"entity_plural,omitempty"`
 	// What features are enabled for this tool
 	Capabilities *Capabilities `protobuf:"bytes,15,opt,name=capabilities,proto3" json:"capabilities,omitempty"`
-	// Only for List actions; aka views.
+	// A list of ... list actions, aka views.
 	// E.g. For a listOrders action; these would be tabs that show filtered orders by status
 	// (Processed, Pending, Completed)
-	// For auto-generated configs, this is only populated for list actions, with links to other list
-	// actions for the same model.
+	// For auto-generated configs, this is only populated for:
+	// - list actions, with links to other list actions for the same model.
+	// - delete actions, with links to all list actions for the same model.
 	RelatedActions []*ActionLink `protobuf:"bytes,16,rep,name=related_actions,json=relatedActions,proto3" json:"related_actions,omitempty"`
 	// Only for List actions; Support offset and cursor
 	Pagination *CursorPaginationConfig `protobuf:"bytes,17,opt,name=pagination,proto3,oneof" json:"pagination,omitempty"`

--- a/tools/proto/tools.proto
+++ b/tools/proto/tools.proto
@@ -56,11 +56,12 @@ message ActionConfig {
 	// What features are enabled for this tool
 	Capabilities capabilities = 15;
 
-	// Only for List actions; aka views.
+	// A list of ... list actions, aka views.
 	// E.g. For a listOrders action; these would be tabs that show filtered orders by status 
 	// (Processed, Pending, Completed)
-	// For auto-generated configs, this is only populated for list actions, with links to other list 
-	// actions for the same model.
+	// For auto-generated configs, this is only populated for:
+	// - list actions, with links to other list actions for the same model.
+	// - delete actions, with links to all list actions for the same model.
 	repeated ActionLink related_actions = 16; 
 
 	// Only for List actions; Support offset and cursor

--- a/tools/testdata/blog/tools.json
+++ b/tools/testdata/blog/tools.json
@@ -293,7 +293,11 @@
       "title": { "template": "Delete post" },
       "entitySingle": "blog post",
       "entityPlural": "blog posts",
-      "capabilities": {}
+      "capabilities": {},
+      "relatedActions": [
+        { "toolId": "listPosts", "displayOrder": 1 },
+        { "toolId": "listPostsEmbeds", "displayOrder": 2 }
+      ]
     },
     {
       "id": "getCategory",


### PR DESCRIPTION
When generating tool configs, we are now generating `related_tools` for DELETE actions as well. These related tools are list actions that operate on the same model, with the intent of providing all the various list options for the model in question.