### PR TITLE
feat: basic computed fields

### DIFF
--- a/expressions/options/options.go
+++ b/expressions/options/options.go
@@ -51,16 +51,16 @@ var typeCompatibilityMapping = map[string][][]*types.Type{
 		{typing.Date, typing.Timestamp, types.TimestampType},
 	},
 	operators.Add: {
-		{types.NewListType(types.IntType), types.NewListType(types.DoubleType), typing.Number, typing.Decimal},
+		{types.IntType, types.DoubleType, typing.Number, typing.Decimal},
 	},
 	operators.Subtract: {
-		{types.NewListType(types.IntType), types.NewListType(types.DoubleType), typing.Number, typing.Decimal},
+		{types.IntType, types.DoubleType, typing.Number, typing.Decimal},
 	},
 	operators.Multiply: {
-		{types.NewListType(types.IntType), types.NewListType(types.DoubleType), typing.Number, typing.Decimal},
+		{types.IntType, types.DoubleType, typing.Number, typing.Decimal},
 	},
 	operators.Divide: {
-		{types.NewListType(types.IntType), types.NewListType(types.DoubleType), typing.Number, typing.Decimal},
+		{types.IntType, types.DoubleType, typing.Number, typing.Decimal},
 	},
 }
 

--- a/expressions/parser.go
+++ b/expressions/parser.go
@@ -163,6 +163,8 @@ func typesAssignable(expected *types.Type, actual *types.Type) bool {
 		typing.Markdown.String():  {mapType(typing.Text.String()), mapType(typing.Markdown.String())},
 		typing.ID.String():        {mapType(typing.Text.String()), mapType(typing.ID.String())},
 		typing.Text.String():      {mapType(typing.Text.String()), mapType(typing.Markdown.String()), mapType(typing.ID.String())},
+		typing.Number.String():    {mapType(typing.Number.String()), mapType(typing.Decimal.String())},
+		typing.Decimal.String():   {mapType(typing.Number.String()), mapType(typing.Decimal.String())},
 	}
 
 	// Check if there are specific compatibility rules for the expected type

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.4
 	github.com/teamkeel/graphql v0.8.2-0.20230531102419-995b8ab035b6
+	github.com/test-go/testify v1.1.4
 	github.com/twitchtv/twirp v8.1.3+incompatible
 	github.com/vincent-petithory/dataurl v1.0.0
 	github.com/xeipuuv/gojsonschema v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -403,6 +403,8 @@ github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/teamkeel/graphql v0.8.2-0.20230531102419-995b8ab035b6 h1:q8ZbAgqr7jJlZNJ4WAI+QMuZrcCBDOw9k7orYuy+Vqs=
 github.com/teamkeel/graphql v0.8.2-0.20230531102419-995b8ab035b6/go.mod h1:5td34OA5ZUdckc2w3GgE7QQoaG8MK6hIVR3dFI+qaK4=
+github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE=
+github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
 github.com/thoas/go-funk v0.9.1 h1:O549iLZqPpTUQ10ykd26sZhzD+rmR5pWhuElrhbC20M=
 github.com/thoas/go-funk v0.9.1/go.mod h1:+IWnUfUmFO1+WVYQWQtIJHeRRdaIyyYglZN7xzUPe4Q=
 github.com/tkuchiki/go-timezone v0.2.0 h1:yyZVHtQRVZ+wvlte5HXvSpBkR0dPYnPEIgq9qqAqltk=

--- a/integration/testdata/computed_fields/schema.keel
+++ b/integration/testdata/computed_fields/schema.keel
@@ -1,0 +1,46 @@
+model ComputedDecimal {
+    fields {
+        price Decimal
+        quantity Number
+        total Decimal @computed(computedDecimal.quantity * computedDecimal.price)
+        totalWithShipping Decimal @computed(5 + computedDecimal.quantity * computedDecimal.price)
+        totalWithDiscount Decimal @computed(computedDecimal.quantity * (computedDecimal.price - (computedDecimal.price / 100 * 10)))
+    }
+}
+
+model ComputedNumber {
+    fields {
+        price Decimal
+        quantity Number
+        total Number @computed(computedNumber.quantity * computedNumber.price)
+        totalWithShipping Number @computed(5 + computedNumber.quantity * computedNumber.price)
+        totalWithDiscount Number @computed(computedNumber.quantity * (computedNumber.price - (computedNumber.price / 100 * 10)))
+    }
+}
+
+model ComputedBool {
+    fields {
+        price Decimal?
+        isActive Boolean
+        isExpensive Boolean @computed(computedBool.price > 100 && computedBool.isActive)
+        isCheap Boolean @computed(!computedBool.isExpensive)
+    }
+}
+
+model ComputedNulls {
+    fields {
+        price Decimal?
+        quantity Number?
+        total Decimal? @computed(computedNulls.quantity * computedNulls.price)
+    }
+}
+
+model ComputedDepends {
+    fields {
+        price Decimal
+        quantity Number
+        totalWithDiscount Decimal? @computed(computedDepends.totalWithShipping - (computedDepends.totalWithShipping / 100 * 10))
+        totalWithShipping Decimal? @computed(computedDepends.total + 5)
+        total Decimal? @computed(computedDepends.quantity * computedDepends.price)
+    }
+}

--- a/integration/testdata/computed_fields/tests.test.ts
+++ b/integration/testdata/computed_fields/tests.test.ts
@@ -1,0 +1,139 @@
+import { test, expect, beforeEach } from "vitest";
+import { models, resetDatabase } from "@teamkeel/testing";
+
+beforeEach(resetDatabase);
+
+test("computed fields - decimal", async () => {
+  const item = await models.computedDecimal.create({ price: 5, quantity: 2 });
+  expect(item.total).toEqual(10);
+  expect(item.totalWithShipping).toEqual(15);
+  expect(item.totalWithDiscount).toEqual(9);
+
+  const get = await models.computedDecimal.findOne({ id: item.id });
+  expect(get!.total).toEqual(10);
+  expect(get!.totalWithShipping).toEqual(15);
+  expect(get!.totalWithDiscount).toEqual(9);
+
+  const updatePrice = await models.computedDecimal.update(
+    { id: item.id },
+    { price: 10 }
+  );
+  expect(updatePrice.total).toEqual(20);
+  expect(updatePrice.totalWithShipping).toEqual(25);
+  expect(updatePrice.totalWithDiscount).toEqual(18);
+
+  const updateQuantity = await models.computedDecimal.update(
+    { id: item.id },
+    { quantity: 3 }
+  );
+  expect(updateQuantity.total).toEqual(30);
+  expect(updateQuantity.totalWithShipping).toEqual(35);
+  expect(updateQuantity.totalWithDiscount).toEqual(27);
+
+  const updateBoth = await models.computedDecimal.update(
+    { id: item.id },
+    { price: 12, quantity: 4 }
+  );
+  expect(updateBoth.total).toEqual(48);
+  expect(updateBoth.totalWithShipping).toEqual(53);
+  expect(updateBoth.totalWithDiscount).toEqual(43.2);
+});
+
+test("computed fields - number", async () => {
+  const item = await models.computedNumber.create({ price: 5, quantity: 2 });
+  expect(item.total).toEqual(10);
+  expect(item.totalWithShipping).toEqual(15);
+  expect(item.totalWithDiscount).toEqual(9);
+
+  const get = await models.computedNumber.findOne({ id: item.id });
+  expect(get!.total).toEqual(10);
+  expect(get!.totalWithShipping).toEqual(15);
+  expect(get!.totalWithDiscount).toEqual(9);
+
+  const updatePrice = await models.computedNumber.update(
+    { id: item.id },
+    { price: 10 }
+  );
+  expect(updatePrice.total).toEqual(20);
+  expect(updatePrice.totalWithShipping).toEqual(25);
+  expect(updatePrice.totalWithDiscount).toEqual(18);
+
+  const updateQuantity = await models.computedNumber.update(
+    { id: item.id },
+    { quantity: 3 }
+  );
+  expect(updateQuantity.total).toEqual(30);
+  expect(updateQuantity.totalWithShipping).toEqual(35);
+  expect(updateQuantity.totalWithDiscount).toEqual(27);
+
+  const updateBoth = await models.computedNumber.update(
+    { id: item.id },
+    { price: 12, quantity: 4 }
+  );
+  expect(updateBoth.total).toEqual(48);
+  expect(updateBoth.totalWithShipping).toEqual(53);
+  expect(updateBoth.totalWithDiscount).toEqual(43);
+});
+
+test("computed fields - boolean", async () => {
+  const expensive = await models.computedBool.create({
+    price: 200,
+    isActive: true,
+  });
+  expect(expensive.isExpensive).toBeTruthy();
+  expect(expensive.isCheap).toBeFalsy();
+
+  const notExpensive = await models.computedBool.create({
+    price: 90,
+    isActive: true,
+  });
+  expect(notExpensive.isExpensive).toBeFalsy();
+  expect(notExpensive.isCheap).toBeTruthy();
+
+  const notActive = await models.computedBool.create({
+    price: 200,
+    isActive: false,
+  });
+  expect(notActive.isExpensive).toBeFalsy();
+  expect(notActive.isCheap).toBeTruthy();
+});
+
+test("computed fields - with nulls", async () => {
+  const item = await models.computedNulls.create({ price: 5 });
+  expect(item.total).toBeNull();
+
+  const updateQty = await models.computedNulls.update(
+    { id: item.id },
+    { quantity: 10 }
+  );
+  expect(updateQty!.total).toEqual(50);
+
+  const updatePrice2 = await models.computedNulls.update(
+    { id: item.id },
+    { price: null }
+  );
+  expect(updatePrice2!.total).toBeNull();
+});
+
+test("computed fields - with dependencies", async () => {
+  const item = await models.computedDepends.create({ price: 5, quantity: 2 });
+  expect(item.total).toEqual(10);
+  expect(item.totalWithShipping).toEqual(15);
+  expect(item.totalWithDiscount).toEqual(13.5);
+
+  const updatedQty = await models.computedDepends.update(
+    { id: item.id },
+    { quantity: 10 }
+  );
+  expect(updatedQty.total).toEqual(50);
+  expect(updatedQty.totalWithShipping).toEqual(55);
+  expect(updatedQty.totalWithDiscount).toEqual(49.5);
+
+  const updatePrice = await models.computedDepends.update(
+    { id: item.id },
+    { price: 8 }
+  );
+  expect(updatePrice.total).toEqual(80);
+  expect(updatePrice.totalWithShipping).toEqual(85);
+  expect(updatePrice.totalWithDiscount).toEqual(76.5);
+});

--- a/migrations/computed_functions.sql
+++ b/migrations/computed_functions.sql
@@ -1,0 +1,8 @@
+SELECT
+    routine_name
+FROM 
+    information_schema.routines
+WHERE 
+    routine_type = 'FUNCTION'
+AND
+    routine_schema = 'public' AND routine_name LIKE '%__computed';

--- a/migrations/introspection.go
+++ b/migrations/introspection.go
@@ -22,6 +22,11 @@ func getColumns(database db.Database) ([]*ColumnRow, error) {
 	return rows, database.GetDB().Raw(columnsQuery).Scan(&rows).Error
 }
 
+func getComputedFunctions(database db.Database) ([]*FunctionRow, error) {
+	rows := []*FunctionRow{}
+	return rows, database.GetDB().Raw(computedFunctionsQuery).Scan(&rows).Error
+}
+
 var (
 	//go:embed columns.sql
 	columnsQuery string
@@ -31,6 +36,9 @@ var (
 
 	//go:embed triggers.sql
 	triggersQuery string
+
+	//go:embed computed_functions.sql
+	computedFunctionsQuery string
 )
 
 type ColumnRow struct {
@@ -79,4 +87,8 @@ type TriggerRow struct {
 	ActionStatement string `json:"action_statement"`
 	// e.g. AFTER
 	ActionTiming string `json:"action_timing"`
+}
+
+type FunctionRow struct {
+	RoutineName string `json:"routine_name"`
 }

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -108,7 +109,11 @@ func TestMigrations(t *testing.T) {
 			require.NoError(t, err)
 
 			// Assert correct SQL generated
-			assert.Equal(t, expectedSQL, m.SQL)
+			equal := assert.Equal(t, expectedSQL, m.SQL)
+
+			if !equal {
+				fmt.Println(m.SQL)
+			}
 
 			actualChanges, err := json.Marshal(m.Changes)
 			require.NoError(t, err)

--- a/migrations/testdata/computed_field_changed_expression.txt
+++ b/migrations/testdata/computed_field_changed_expression.txt
@@ -1,0 +1,35 @@
+model Item {
+    fields {
+        price Decimal
+        quantity Number
+        total Decimal @computed(item.quantity * item.price)
+    }
+}
+
+===
+
+model Item {
+    fields {
+        price Decimal
+        quantity Number
+        total Decimal @computed(item.price + 5)
+    }
+}
+
+===
+
+CREATE FUNCTION item__total__863346d0__computed(r item) RETURNS NUMERIC AS $$ BEGIN
+	RETURN r."price" + 5;
+END; $$ LANGUAGE plpgsql;
+DROP FUNCTION item__total__0614a79a__computed;
+CREATE OR REPLACE FUNCTION item__exec_computed_fns() RETURNS TRIGGER AS $$ BEGIN
+	NEW.total := item__total__863346d0__computed(NEW);
+	RETURN NEW;
+END; $$ LANGUAGE plpgsql;
+CREATE OR REPLACE TRIGGER item__computed_trigger BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE item__exec_computed_fns();
+
+===
+
+[
+    {"Model":"Item","Field":"total","Type":"MODIFIED"}
+]

--- a/migrations/testdata/computed_field_initial.txt
+++ b/migrations/testdata/computed_field_initial.txt
@@ -1,0 +1,78 @@
+===
+
+model Item {
+    fields {
+        price Decimal
+        quantity Number
+        total Decimal @computed(item.quantity * item.price)
+    }
+}
+
+===
+
+CREATE TABLE "identity" (
+"email" TEXT,
+"email_verified" BOOL NOT NULL DEFAULT false,
+"password" TEXT,
+"external_id" TEXT,
+"issuer" TEXT,
+"name" TEXT,
+"given_name" TEXT,
+"family_name" TEXT,
+"middle_name" TEXT,
+"nick_name" TEXT,
+"profile" TEXT,
+"picture" TEXT,
+"website" TEXT,
+"gender" TEXT,
+"zone_info" TEXT,
+"locale" TEXT,
+"id" TEXT NOT NULL DEFAULT ksuid(),
+"created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+"updated_at" TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+ALTER TABLE "identity" ADD CONSTRAINT identity_id_pkey PRIMARY KEY ("id");
+ALTER TABLE "identity" ADD CONSTRAINT identity_email_issuer_udx UNIQUE ("email", "issuer");
+CREATE TABLE "item" (
+"price" NUMERIC NOT NULL,
+"quantity" INTEGER NOT NULL,
+"total" NUMERIC NOT NULL,
+"id" TEXT NOT NULL DEFAULT ksuid(),
+"created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+"updated_at" TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+ALTER TABLE "item" ADD CONSTRAINT item_id_pkey PRIMARY KEY ("id");
+CREATE TABLE "keel_audit" (
+"id" TEXT NOT NULL DEFAULT ksuid(),
+"table_name" TEXT NOT NULL,
+"op" TEXT NOT NULL,
+"data" jsonb NOT NULL,
+"created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+"identity_id" TEXT,
+"trace_id" TEXT,
+"event_processed_at" TIMESTAMPTZ
+);
+ALTER TABLE "keel_audit" ADD CONSTRAINT keel_audit_id_pkey PRIMARY KEY ("id");
+CREATE TRIGGER item_create AFTER INSERT ON "item" REFERENCING NEW TABLE AS new_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
+CREATE TRIGGER item_update AFTER UPDATE ON "item" REFERENCING NEW TABLE AS new_table OLD TABLE AS old_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
+CREATE TRIGGER item_delete AFTER DELETE ON "item" REFERENCING OLD TABLE AS old_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
+CREATE TRIGGER item_updated_at BEFORE UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+CREATE TRIGGER identity_create AFTER INSERT ON "identity" REFERENCING NEW TABLE AS new_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
+CREATE TRIGGER identity_update AFTER UPDATE ON "identity" REFERENCING NEW TABLE AS new_table OLD TABLE AS old_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
+CREATE TRIGGER identity_delete AFTER DELETE ON "identity" REFERENCING OLD TABLE AS old_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
+CREATE TRIGGER identity_updated_at BEFORE UPDATE ON "identity" FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+CREATE FUNCTION item__total__0614a79a__computed(r item) RETURNS NUMERIC AS $$ BEGIN
+	RETURN r."quantity" * r."price";
+END; $$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION item__exec_computed_fns() RETURNS TRIGGER AS $$ BEGIN
+	NEW.total := item__total__0614a79a__computed(NEW);
+	RETURN NEW;
+END; $$ LANGUAGE plpgsql;
+CREATE OR REPLACE TRIGGER item__computed_trigger BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE item__exec_computed_fns();
+===
+
+[
+    {"Model":"Identity","Field":"","Type":"ADDED"},
+    {"Model":"Item","Field":"","Type":"ADDED"},
+    {"Model":"KeelAudit","Field":"","Type":"ADDED"}
+]

--- a/migrations/testdata/computed_field_multiple_depend.txt
+++ b/migrations/testdata/computed_field_multiple_depend.txt
@@ -1,0 +1,42 @@
+
+model Item {
+    fields {
+        price Decimal
+        quantity Number
+        totalWithShipping Decimal
+        total Decimal 
+    }
+}
+
+===
+
+model Item {
+    fields {
+        price Decimal
+        quantity Number
+        totalWithShipping Decimal @computed(item.total + 5)
+        total Decimal @computed(item.quantity * item.price)
+    }
+}
+
+===
+
+CREATE FUNCTION item__total__0614a79a__computed(r item) RETURNS NUMERIC AS $$ BEGIN
+	RETURN r."quantity" * r."price";
+END; $$ LANGUAGE plpgsql;
+CREATE FUNCTION item__total_with_shipping__53d0d09b__computed(r item) RETURNS NUMERIC AS $$ BEGIN
+	RETURN r."total" + 5;
+END; $$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION item__exec_computed_fns() RETURNS TRIGGER AS $$ BEGIN
+	NEW.total := item__total__0614a79a__computed(NEW);
+	NEW.total_with_shipping := item__total_with_shipping__53d0d09b__computed(NEW);
+	RETURN NEW;
+END; $$ LANGUAGE plpgsql;
+CREATE OR REPLACE TRIGGER item__computed_trigger BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE item__exec_computed_fns();
+
+===
+
+[
+    {"Model":"Item","Field":"total","Type":"MODIFIED"},
+    {"Model":"Item","Field":"totalWithShipping","Type":"MODIFIED"}
+]

--- a/migrations/testdata/computed_field_removed_attr.txt
+++ b/migrations/testdata/computed_field_removed_attr.txt
@@ -1,0 +1,29 @@
+model Item {
+    fields {
+        price Decimal
+        quantity Number
+        total Decimal @computed(item.quantity * item.price)
+    }
+}
+
+===
+
+model Item {
+    fields {
+        price Decimal
+        quantity Number
+        total Decimal
+    }
+}
+
+===
+
+DROP FUNCTION item__total__0614a79a__computed;
+DROP TRIGGER item__computed_trigger ON item;
+DROP FUNCTION item__exec_computed_fns;
+
+===
+
+[
+  {"Model":"Item","Field":"total","Type":"MODIFIED"}
+]

--- a/migrations/testdata/computed_field_removed_field.txt
+++ b/migrations/testdata/computed_field_removed_field.txt
@@ -1,0 +1,29 @@
+model Item {
+    fields {
+        price Decimal
+        quantity Number
+        total Decimal @computed(item.quantity * item.price)
+    }
+}
+
+===
+
+model Item {
+    fields {
+        price Decimal
+        quantity Number
+    }
+}
+
+===
+
+ALTER TABLE "item" DROP COLUMN "total";
+DROP FUNCTION item__total__0614a79a__computed;
+DROP TRIGGER item__computed_trigger ON item;
+DROP FUNCTION item__exec_computed_fns;
+
+===
+
+[
+  {"Model":"Item","Field":"total","Type":"REMOVED"}
+]

--- a/migrations/testdata/computed_field_renamed_field.txt
+++ b/migrations/testdata/computed_field_renamed_field.txt
@@ -1,0 +1,38 @@
+model Item {
+    fields {
+        price Decimal
+        quantity Number
+        total Decimal @computed(item.quantity * item.price)
+    }
+}
+
+===
+
+model Item {
+    fields {
+        price Decimal
+        quantity Number
+        newTotal Decimal @computed(item.quantity * item.price)
+    }
+}
+
+===
+
+ALTER TABLE "item" ADD COLUMN "new_total" NUMERIC NOT NULL;
+ALTER TABLE "item" DROP COLUMN "total";
+CREATE FUNCTION item__new_total__0614a79a__computed(r item) RETURNS NUMERIC AS $$ BEGIN
+	RETURN r."quantity" * r."price";
+END; $$ LANGUAGE plpgsql;
+DROP FUNCTION item__total__0614a79a__computed;
+CREATE OR REPLACE FUNCTION item__exec_computed_fns() RETURNS TRIGGER AS $$ BEGIN
+	NEW.new_total := item__new_total__0614a79a__computed(NEW);
+	RETURN NEW;
+END; $$ LANGUAGE plpgsql;
+CREATE OR REPLACE TRIGGER item__computed_trigger BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE item__exec_computed_fns();
+
+===
+
+[
+    {"Model":"Item","Field":"newTotal","Type":"ADDED"},
+    {"Model":"Item","Field":"total","Type":"REMOVED"}
+]

--- a/migrations/testdata/computed_field_unchanged.txt
+++ b/migrations/testdata/computed_field_unchanged.txt
@@ -1,0 +1,24 @@
+model Item {
+    fields {
+        price Decimal
+        quantity Number
+        total Decimal @computed(item.quantity * item.price)
+    }
+}
+
+===
+
+model Item {
+    fields {
+        price Decimal
+        quantity Number
+        total Decimal @computed(item.quantity * item.price)
+    }
+}
+
+===
+
+===
+
+[]
+

--- a/node/codegen.go
+++ b/node/codegen.go
@@ -342,7 +342,7 @@ func writeCreateValuesType(w *codegen.Writer, schema *proto.Schema, model *proto
 		}
 
 		w.Write(field.Name)
-		if field.Optional || field.DefaultValue != nil || field.IsHasMany() {
+		if field.Optional || field.DefaultValue != nil || field.IsHasMany() || field.ComputedExpression != nil {
 			w.Write("?")
 		}
 
@@ -431,7 +431,7 @@ func writeFindManyParamsInterface(w *codegen.Writer, model *proto.Model) {
 
 		switch f.Type.Type {
 		// scalar types are only permitted to sort by
-		case proto.Type_TYPE_BOOL, proto.Type_TYPE_DATE, proto.Type_TYPE_DATETIME, proto.Type_TYPE_INT, proto.Type_TYPE_STRING, proto.Type_TYPE_ENUM, proto.Type_TYPE_TIMESTAMP, proto.Type_TYPE_ID:
+		case proto.Type_TYPE_BOOL, proto.Type_TYPE_DATE, proto.Type_TYPE_DATETIME, proto.Type_TYPE_INT, proto.Type_TYPE_STRING, proto.Type_TYPE_ENUM, proto.Type_TYPE_TIMESTAMP, proto.Type_TYPE_ID, proto.Type_TYPE_DECIMAL:
 			return true
 		default:
 			// includes types such as password, secret, model etc
@@ -678,7 +678,7 @@ func writeModelAPIDeclaration(w *codegen.Writer, model *proto.Model) {
 	w.Indent()
 
 	nonOptionalFields := lo.Filter(model.Fields, func(f *proto.Field, _ int) bool {
-		return !f.Optional && f.DefaultValue == nil
+		return !f.Optional && f.DefaultValue == nil && f.ComputedExpression == nil
 	})
 
 	tsDocComment(w, func(w *codegen.Writer) {

--- a/node/codegen_test.go
+++ b/node/codegen_test.go
@@ -42,6 +42,7 @@ model Person {
 		height Decimal
 		bio Markdown
 		file File
+		heightInMetres Decimal @computed(person.height * 0.3048)
 	}
 }`
 
@@ -59,6 +60,7 @@ export interface PersonTable {
 	height: number
 	bio: string
 	file: FileDbRecord
+	heightInMetres: number
 	id: Generated<string>
 	createdAt: Generated<Date>
 	updatedAt: Generated<Date>
@@ -106,6 +108,7 @@ export interface Person {
 	height: number
 	bio: string
 	file: runtime.File
+	heightInMetres: number
 	id: string
 	createdAt: Date
 	updatedAt: Date
@@ -131,6 +134,7 @@ export type PersonCreateValues = {
 	height: number
 	bio: string
 	file: runtime.InlineFile | runtime.File
+	heightInMetres?: number
 	id?: string
 	createdAt?: Date
 	updatedAt?: Date
@@ -180,6 +184,7 @@ export interface PersonWhereConditions {
 	tags?: string[] | runtime.StringArrayWhereCondition;
 	height?: number | runtime.NumberWhereCondition;
 	bio?: string | runtime.StringWhereCondition;
+	heightInMetres?: number | runtime.NumberWhereCondition;
 	id?: string | runtime.IDWhereCondition;
 	createdAt?: Date | runtime.DateWhereCondition;
 	updatedAt?: Date | runtime.DateWhereCondition;
@@ -314,6 +319,8 @@ export type PersonOrderBy = {
 	dateOfBirth?: runtime.SortDirection,
 	gender?: runtime.SortDirection,
 	hasChildren?: runtime.SortDirection,
+	height?: runtime.SortDirection,
+	heightInMetres?: runtime.SortDirection,
 	id?: runtime.SortDirection,
 	createdAt?: runtime.SortDirection,
 	updatedAt?: runtime.SortDirection

--- a/node/templates/client/core.ts
+++ b/node/templates/client/core.ts
@@ -150,7 +150,9 @@ export class Core {
     /**
      * A promise that resolves when the session is refreshed.
      */
-    refreshingPromise: undefined as Promise<APIResult<AuthenticationResponse>> | undefined,
+    refreshingPromise: undefined as
+      | Promise<APIResult<AuthenticationResponse>>
+      | undefined,
 
     /**
      * Returns data field set to the list of supported authentication providers and their SSO login URLs.
@@ -324,10 +326,10 @@ export class Core {
 
       // If refreshing already, wait for the existing refreshing promisee
       if (!this.auth.refreshingPromise) {
-          this.auth.refreshingPromise = this.auth.requestToken({
-            grant_type: "refresh_token",
-            refresh_token: refreshToken,
-          });
+        this.auth.refreshingPromise = this.auth.requestToken({
+          grant_type: "refresh_token",
+          refresh_token: refreshToken,
+        });
       }
 
       const authResponse = await this.auth.refreshingPromise;

--- a/proto/model.go
+++ b/proto/model.go
@@ -46,3 +46,14 @@ func (m *Model) PrimaryKeyFieldName() string {
 	}
 	return ""
 }
+
+// GetComputedFields returns all the computed fields on the given model.
+func (m *Model) GetComputedFields() []*Field {
+	fields := []*Field{}
+	for _, f := range m.Fields {
+		if f.ComputedExpression != nil {
+			fields = append(fields, f)
+		}
+	}
+	return fields
+}

--- a/runtime/actions/generate_computed.go
+++ b/runtime/actions/generate_computed.go
@@ -1,0 +1,119 @@
+package actions
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/google/cel-go/common/operators"
+	"github.com/iancoleman/strcase"
+	"github.com/teamkeel/keel/expressions/resolve"
+	"github.com/teamkeel/keel/proto"
+
+	"github.com/teamkeel/keel/schema/parser"
+)
+
+// GenerateComputedFunction visits the expression and generates a SQL expression
+func GenerateComputedFunction(schema *proto.Schema, model *proto.Model, field *proto.Field) resolve.Visitor[string] {
+	return &computedQueryGen{
+		schema: schema,
+		model:  model,
+		field:  field,
+		sql:    "",
+	}
+}
+
+var _ resolve.Visitor[string] = new(computedQueryGen)
+
+type computedQueryGen struct {
+	schema *proto.Schema
+	model  *proto.Model
+	field  *proto.Field
+	sql    string
+}
+
+func (v *computedQueryGen) StartCondition(nested bool) error {
+	if nested {
+		v.sql += "("
+	}
+	return nil
+}
+
+func (v *computedQueryGen) EndCondition(nested bool) error {
+	if nested {
+		v.sql += ")"
+	}
+	return nil
+}
+
+func (v *computedQueryGen) VisitAnd() error {
+	v.sql += " AND "
+	return nil
+}
+
+func (v *computedQueryGen) VisitOr() error {
+	v.sql += " OR "
+	return nil
+}
+
+func (v *computedQueryGen) VisitNot() error {
+	v.sql += " NOT "
+	return nil
+}
+
+func (v *computedQueryGen) VisitOperator(op string) error {
+	// Map CEL operators to SQL operators
+	sqlOp := map[string]string{
+		operators.Add:           "+",
+		operators.Subtract:      "-",
+		operators.Multiply:      "*",
+		operators.Divide:        "/",
+		operators.Equals:        "IS NOT DISTINCT FROM",
+		operators.NotEquals:     "IS DISTINCT FROM",
+		operators.Greater:       ">",
+		operators.GreaterEquals: ">=",
+		operators.Less:          "<",
+		operators.LessEquals:    "<=",
+	}[op]
+
+	if sqlOp == "" {
+		return fmt.Errorf("unsupported operator: %s", op)
+	}
+
+	v.sql += " " + sqlOp + " "
+	return nil
+}
+
+func (v *computedQueryGen) VisitLiteral(value any) error {
+	switch val := value.(type) {
+	case int64:
+		v.sql += fmt.Sprintf("%v", val)
+	case float64:
+		v.sql += fmt.Sprintf("%v", val)
+	case string:
+		v.sql += fmt.Sprintf("\"%v\"", val)
+	case bool:
+		v.sql += fmt.Sprintf("%t", val)
+	case nil:
+		v.sql += "NULL"
+	default:
+		return fmt.Errorf("unsupported literal type: %T", value)
+	}
+	return nil
+}
+
+func (v *computedQueryGen) VisitIdent(ident *parser.ExpressionIdent) error {
+	v.sql += "r." + sqlQuote(strcase.ToSnake(ident.Fragments[len(ident.Fragments)-1]))
+	return nil
+}
+
+func (v *computedQueryGen) VisitIdentArray(idents []*parser.ExpressionIdent) error {
+	return errors.New("ident arrays not supported in computed expressions")
+}
+
+func (v *computedQueryGen) Result() (string, error) {
+	// Remove multiple whitespaces and trim
+	re := regexp.MustCompile(`\s+`)
+	return re.ReplaceAllString(strings.TrimSpace(v.sql), " "), nil
+}

--- a/runtime/actions/generate_computed_test.go
+++ b/runtime/actions/generate_computed_test.go
@@ -1,0 +1,171 @@
+package actions_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/teamkeel/keel/expressions/resolve"
+	"github.com/teamkeel/keel/proto"
+	"github.com/teamkeel/keel/runtime/actions"
+	"github.com/teamkeel/keel/schema"
+	"github.com/teamkeel/keel/schema/parser"
+	"github.com/teamkeel/keel/schema/reader"
+	"github.com/test-go/testify/assert"
+)
+
+const testSchema = `
+model Item {
+	fields {
+		product Text
+		price Decimal?
+		quantity Number
+		isActive Boolean
+		#placeholder#
+	}
+}`
+
+type computedTestCase struct {
+	// Name given to the test case
+	name string
+	// Valid keel schema for this test case
+	keelSchema string
+	// action name to run test upon
+	field string
+	// Input map for action
+	expectedSql string
+}
+
+var computedTestCases = []computedTestCase{
+
+	{
+		name:        "adding field with literal",
+		keelSchema:  testSchema,
+		field:       "total Decimal @computed(item.price + 100)",
+		expectedSql: `r."price" + 100`,
+	},
+	{
+		name:        "subtracting field with literal",
+		keelSchema:  testSchema,
+		field:       "total Decimal @computed(item.price - 100)",
+		expectedSql: `r."price" - 100`,
+	},
+	{
+		name:        "dividing field with literal",
+		keelSchema:  testSchema,
+		field:       "total Decimal @computed(item.price / 100)",
+		expectedSql: `r."price" / 100`,
+	},
+	{
+		name:        "multiplying field with literal",
+		keelSchema:  testSchema,
+		field:       "total Decimal @computed(item.price * 100)",
+		expectedSql: `r."price" * 100`,
+	},
+	{
+		name:        "multiply fields on same model",
+		keelSchema:  testSchema,
+		field:       "total Decimal @computed(item.price * item.quantity)",
+		expectedSql: `r."price" * r."quantity"`,
+	},
+	{
+		name:        "parenthesis",
+		keelSchema:  testSchema,
+		field:       "total Decimal @computed(item.quantity * (1 + item.quantity) / (100 * (item.price + 1)))",
+		expectedSql: `r."quantity" * (1 + r."quantity") / (100 * (r."price" + 1))`,
+	},
+	{
+		name:        "no parenthesis",
+		keelSchema:  testSchema,
+		field:       "total Decimal @computed(item.quantity * 1 + item.quantity / 100 * item.price + 1)",
+		expectedSql: `r."quantity" * 1 + r."quantity" / 100 * r."price" + 1`,
+	},
+	{
+		name:        "bool greater than",
+		keelSchema:  testSchema,
+		field:       "isExpensive Boolean @computed(item.price > 100)",
+		expectedSql: `r."price" > 100`,
+	},
+	{
+		name:        "bool greater or equals",
+		keelSchema:  testSchema,
+		field:       "isExpensive Boolean @computed(item.price >= 100)",
+		expectedSql: `r."price" >= 100`,
+	},
+	{
+		name:        "bool less than",
+		keelSchema:  testSchema,
+		field:       "isCheap Boolean @computed(item.price < 100)",
+		expectedSql: `r."price" < 100`,
+	},
+	{
+		name:        "bool less or equals",
+		keelSchema:  testSchema,
+		field:       "isCheap Boolean @computed(item.price <= 100)",
+		expectedSql: `r."price" <= 100`,
+	},
+	{
+		name:        "bool is not null",
+		keelSchema:  testSchema,
+		field:       "hasPrice Boolean @computed(item.price != null)",
+		expectedSql: `r."price" IS DISTINCT FROM NULL`,
+	},
+	{
+		name:        "bool is null",
+		keelSchema:  testSchema,
+		field:       "noPrice Boolean @computed(item.price == null)",
+		expectedSql: `r."price" IS NOT DISTINCT FROM NULL`,
+	},
+	{
+		name:        "bool with and",
+		keelSchema:  testSchema,
+		field:       "isExpensive Boolean @computed(item.price > 100 && item.isActive)",
+		expectedSql: `r."price" > 100 AND r."is_active"`,
+	},
+	{
+		name:        "bool with or",
+		keelSchema:  testSchema,
+		field:       "isExpensive Boolean @computed(item.price > 100 || item.isActive)",
+		expectedSql: `(r."price" > 100 OR r."is_active")`,
+	},
+	{
+		name:        "negation",
+		keelSchema:  testSchema,
+		field:       "isExpensive Boolean @computed(item.price > 100 || !item.isActive)",
+		expectedSql: `(r."price" > 100 OR NOT r."is_active")`,
+	},
+}
+
+func TestGeneratedComputed(t *testing.T) {
+	t.Parallel()
+	for _, testCase := range computedTestCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			raw := strings.Replace(testCase.keelSchema, "#placeholder#", testCase.field, 1)
+
+			schemaFiles :=
+				&reader.Inputs{
+					SchemaFiles: []*reader.SchemaFile{
+						{
+							Contents: raw,
+							FileName: "schema.keel",
+						},
+					},
+				}
+
+			builder := &schema.Builder{}
+			schema, err := builder.MakeFromInputs(schemaFiles)
+			assert.NoError(t, err)
+
+			model := schema.Models[0]
+			fieldName := strings.Split(testCase.field, " ")[0]
+			field := proto.FindField(schema.Models, model.Name, fieldName)
+
+			expression, err := parser.ParseExpression(field.ComputedExpression.Source)
+			assert.NoError(t, err)
+
+			sql, err := resolve.RunCelVisitor(expression, actions.GenerateComputedFunction(schema, model, field))
+			assert.NoError(t, err)
+
+			assert.Equal(t, testCase.expectedSql, sql, "expected `%s` but got `%s`", testCase.expectedSql, sql)
+		})
+	}
+}

--- a/runtime/actions/generate_filter.go
+++ b/runtime/actions/generate_filter.go
@@ -52,6 +52,7 @@ func (v *whereQueryGen) StartCondition(nested bool) error {
 
 	return nil
 }
+
 func (v *whereQueryGen) EndCondition(nested bool) error {
 	if _, ok := v.operators.Peek(); ok && v.operands.Size() == 2 {
 		operator, _ := v.operators.Pop()

--- a/runtime/actions/query.go
+++ b/runtime/actions/query.go
@@ -1474,7 +1474,7 @@ func (query *QueryBuilder) generateConditionTemplate(lhs *QueryOperand, operator
 	case AllGreaterThanEquals, AllOnOrAfter:
 		template = fmt.Sprintf("%s <= ALL(%s)", rhsSqlOperand, lhsSqlOperand)
 
-	/* All relative date operators */
+	/* Relative date operators */
 	case BeforeRelative:
 		template = fmt.Sprintf("%s < %s", lhsSqlOperand, rhsSqlOperand)
 	case AfterRelative:
@@ -1498,6 +1498,7 @@ func (query *QueryBuilder) generateConditionTemplate(lhs *QueryOperand, operator
 		}
 
 		template = fmt.Sprintf("%s >= %s AND %s < %s", lhsSqlOperand, rhsSqlOperand, lhsSqlOperand, end)
+
 	default:
 		return "", nil, fmt.Errorf("operator: %v is not yet supported", operator)
 	}

--- a/runtime/actions/query_test.go
+++ b/runtime/actions/query_test.go
@@ -3778,7 +3778,7 @@ var testCases = []testCase{
 				"thing"
 			WHERE
 				"thing"."id" IS NOT DISTINCT FROM ? AND 
-				NOT (("thing"."is_active" IS NOT DISTINCT FROM ? OR "thing"."number" IS DISTINCT FROM ?))`,
+				NOT ("thing"."is_active" IS NOT DISTINCT FROM ? OR "thing"."number" IS DISTINCT FROM ?)`,
 		expectedArgs: []any{"123", true, int64(0)},
 	},
 }
@@ -3787,6 +3787,7 @@ func TestQueryBuilder(t *testing.T) {
 	t.Parallel()
 	for _, testCase := range testCases {
 		testCase := testCase
+
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()

--- a/runtime/actions/update.go
+++ b/runtime/actions/update.go
@@ -64,9 +64,6 @@ func Update(scope *Scope, input map[string]any) (res map[string]any, err error) 
 			return nil, common.NewPermissionError()
 		}
 	}
-	if err != nil {
-		return nil, err
-	}
 
 	// Execute database request, expecting a single result
 	res, err = statement.ExecuteToSingle(scope.Context)

--- a/schema/attributes/default_test.go
+++ b/schema/attributes/default_test.go
@@ -97,7 +97,7 @@ func TestDefault_ValidNumber(t *testing.T) {
 	require.Empty(t, issues)
 }
 
-func TestDefault_InvalidNumber(t *testing.T) {
+func TestDefault_ValidNumberFromDecimal(t *testing.T) {
 	schema := parse(t, &reader.SchemaFile{FileName: "test.keel", Contents: `
 	model Person {
 		fields {
@@ -111,8 +111,24 @@ func TestDefault_InvalidNumber(t *testing.T) {
 
 	issues, err := attributes.ValidateDefaultExpression(schema, field, expression)
 	require.NoError(t, err)
-	require.Len(t, issues, 1)
-	require.Equal(t, "expression expected to resolve to type Number but it is Decimal", issues[0].Message)
+	require.Len(t, issues, 0)
+}
+
+func TestDefault_ValidDecimalFromNumber(t *testing.T) {
+	schema := parse(t, &reader.SchemaFile{FileName: "test.keel", Contents: `
+	model Person {
+		fields {
+			age Decimal @default(1)
+		}
+	}`})
+
+	model := query.Model(schema, "Person")
+	field := query.Field(model, "age")
+	expression := field.Attributes[0].Arguments[0].Expression
+
+	issues, err := attributes.ValidateDefaultExpression(schema, field, expression)
+	require.NoError(t, err)
+	require.Len(t, issues, 0)
 }
 
 func TestDefault_ValidID(t *testing.T) {

--- a/schema/completions/completions.go
+++ b/schema/completions/completions.go
@@ -254,6 +254,7 @@ func getBlockCompletions(asts []*parser.AST, tokenAtPos *TokensAtPosition, keywo
 			parser.AttributeUnique,
 			parser.AttributeDefault,
 			parser.AttributeRelation,
+			parser.AttributeComputed,
 		})
 	}
 
@@ -323,6 +324,7 @@ func getBlockCompletions(asts []*parser.AST, tokenAtPos *TokensAtPosition, keywo
 				parser.AttributeUnique,
 				parser.AttributeDefault,
 				parser.AttributeRelation,
+				parser.AttributeComputed,
 			})
 		}
 
@@ -644,7 +646,7 @@ func getAttributeArgCompletions(asts []*parser.AST, t *TokensAtPosition, cfg *co
 	enclosingBlock := getTypeOfEnclosingBlock(t)
 
 	switch attrName {
-	case parser.AttributeSet, parser.AttributeWhere, parser.AttributeValidate:
+	case parser.AttributeSet, parser.AttributeWhere, parser.AttributeValidate, parser.AttributeComputed:
 		return getExpressionCompletions(asts, t, cfg)
 	case parser.AttributePermission:
 		return getPermissionArgCompletions(asts, t, cfg)

--- a/schema/completions/completions_test.go
+++ b/schema/completions/completions_test.go
@@ -434,7 +434,7 @@ func TestFieldCompletions(t *testing.T) {
 					}
 				}
 			}`,
-			expected: []string{"@unique", "@default", "@relation"},
+			expected: []string{"@unique", "@default", "@relation", "@computed"},
 		},
 		{
 			name: "field-attributes-bare-at",
@@ -443,7 +443,7 @@ func TestFieldCompletions(t *testing.T) {
 					name Text @<Cursor>
 				}
 			}`,
-			expected: []string{"@unique", "@default", "@relation"},
+			expected: []string{"@unique", "@default", "@relation", "@computed"},
 		},
 		{
 			name: "field-attributes-whitespace",
@@ -453,7 +453,7 @@ func TestFieldCompletions(t *testing.T) {
 					name Text <Cursor>
 				}
 			}`,
-			expected: []string{"@unique", "@default", "@relation"},
+			expected: []string{"@unique", "@default", "@relation", "@computed"},
 		},
 	}
 
@@ -1083,6 +1083,37 @@ func TestSetAttributeCompletions(t *testing.T) {
 				}
 			}`,
 			expected: []string{"createdAt", "email", "emailVerified", "externalId", "familyName", "gender", "givenName", "id", "issuer", "locale", "middleName", "name", "nickName", "password", "picture", "profile", "updatedAt", "user", "website", "zoneInfo"},
+		},
+	}
+
+	runTestsCases(t, cases)
+}
+
+func TestComputedAttributeCompletions(t *testing.T) {
+	cases := []testCase{
+		{
+			name: "computed-attribute-operands",
+			schema: `
+			model Item {
+				fields {
+					price Decimal
+					quantity Decimal
+					total Decimal @computed(<Cursor>)
+				}
+			}`,
+			expected: []string{"ctx", "item"},
+		},
+		{
+			name: "computed-attribute-model-fields",
+			schema: `
+			model Item {
+				fields {
+					price Decimal
+					quantity Decimal
+					total Decimal @computed(item.<Cursor>)
+				}
+			}`,
+			expected: []string{"createdAt", "id", "price", "quantity", "total", "updatedAt"},
 		},
 	}
 

--- a/schema/parser/expressions.go
+++ b/schema/parser/expressions.go
@@ -49,27 +49,6 @@ func (e *Expression) Parse(lex *lexer.PeekingLexer) error {
 	}
 }
 
-// func (e *Expression) String() string {
-// 	if len(e.Tokens) == 0 {
-// 		return ""
-// 	}
-
-// 	var result strings.Builder
-// 	currentColumn := e.Pos.Column
-
-// 	// Handle tokens without preserving line breaks
-// 	for _, token := range e.Tokens {
-// 		// Add spaces to reach the correct column position
-// 		if token.Pos.Column > currentColumn {
-// 			result.WriteString(strings.Repeat(" ", token.Pos.Column-currentColumn))
-// 		}
-// 		result.WriteString(token.Value)
-// 		currentColumn = token.Pos.Column + len(token.Value)
-// 	}
-
-// 	return result.String()
-// }
-
 func (e *Expression) String() string {
 	if len(e.Tokens) == 0 {
 		return ""

--- a/schema/query/query.go
+++ b/schema/query/query.go
@@ -350,6 +350,10 @@ func FieldIsUnique(field *parser.FieldNode) bool {
 	return FieldHasAttribute(field, parser.AttributePrimaryKey) || FieldHasAttribute(field, parser.AttributeUnique)
 }
 
+func FieldIsComputed(field *parser.FieldNode) bool {
+	return FieldHasAttribute(field, parser.AttributeComputed)
+}
+
 // CompositeUniqueFields returns the model's fields that make up a composite unique attribute
 func CompositeUniqueFields(model *parser.ModelNode, attribute *parser.AttributeNode) []*parser.FieldNode {
 	if attribute.Name.Value != parser.AttributeUnique {

--- a/schema/testdata/errors/attribute_computed.keel
+++ b/schema/testdata/errors/attribute_computed.keel
@@ -2,6 +2,9 @@ model Item {
     fields {
         //expect-error:23:32:AttributeArgumentError:0 argument(s) provided to @computed but expected 1
         total Decimal @computed
+        //expect-error:26:47:AttributeNotAllowedError:@computed cannot be used on repeated fields
+        //expect-error:36:46:AttributeExpressionError:expression expected to resolve to type Decimal[] but it is Decimal
+        totals Decimal[] @computed(item.total)
         //expect-error:19:36:AttributeNotAllowedError:@computed cannot be used on field of type File
         file File @computed("file")
         //expect-error:23:42:AttributeNotAllowedError:@computed cannot be used on field of type Vector

--- a/schema/testdata/errors/attribute_computed_expression.keel
+++ b/schema/testdata/errors/attribute_computed_expression.keel
@@ -21,7 +21,8 @@ model Item {
         ctx Boolean @computed(ctx.isAuthenticated)
         //expect-error:27:50:AttributeNotAllowedError:@computed cannot be used on field of type Identity
         identity Identity @computed(ctx.identity)
-
+        //expect-error:33:43:AttributeArgumentError:@computed expressions cannot reference itself
+        total Decimal @computed(item.total * 5)
     }
     actions {
         get getItem(id) 

--- a/schema/testdata/proto/array_fields/proto.json
+++ b/schema/testdata/proto/array_fields/proto.json
@@ -103,9 +103,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "issuer"
-          ]
+          "uniqueWith": ["issuer"]
         },
         {
           "modelName": "Identity",
@@ -142,9 +140,7 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": [
-            "email"
-          ]
+          "uniqueWith": ["email"]
         },
         {
           "modelName": "Identity",
@@ -376,9 +372,7 @@
             "fieldName": "texts",
             "repeated": true
           },
-          "target": [
-            "texts"
-          ]
+          "target": ["texts"]
         },
         {
           "messageName": "CreateThingInput",
@@ -389,9 +383,7 @@
             "fieldName": "numbers",
             "repeated": true
           },
-          "target": [
-            "numbers"
-          ]
+          "target": ["numbers"]
         },
         {
           "messageName": "CreateThingInput",
@@ -402,9 +394,7 @@
             "fieldName": "booleans",
             "repeated": true
           },
-          "target": [
-            "booleans"
-          ]
+          "target": ["booleans"]
         },
         {
           "messageName": "CreateThingInput",
@@ -415,9 +405,7 @@
             "fieldName": "dates",
             "repeated": true
           },
-          "target": [
-            "dates"
-          ]
+          "target": ["dates"]
         },
         {
           "messageName": "CreateThingInput",
@@ -428,9 +416,7 @@
             "fieldName": "timestamps",
             "repeated": true
           },
-          "target": [
-            "timestamps"
-          ]
+          "target": ["timestamps"]
         }
       ]
     },
@@ -1093,9 +1079,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "StringArrayQueryInput"
           },
-          "target": [
-            "texts"
-          ]
+          "target": ["texts"]
         },
         {
           "messageName": "ListThingsWhere",
@@ -1104,9 +1088,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "IntArrayQueryInput"
           },
-          "target": [
-            "numbers"
-          ]
+          "target": ["numbers"]
         },
         {
           "messageName": "ListThingsWhere",
@@ -1115,9 +1097,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "BooleanArrayQueryInput"
           },
-          "target": [
-            "booleans"
-          ]
+          "target": ["booleans"]
         },
         {
           "messageName": "ListThingsWhere",
@@ -1126,9 +1106,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "DateArrayQueryInput"
           },
-          "target": [
-            "dates"
-          ]
+          "target": ["dates"]
         },
         {
           "messageName": "ListThingsWhere",
@@ -1137,9 +1115,7 @@
             "type": "TYPE_MESSAGE",
             "messageName": "TimestampArrayQueryInput"
           },
-          "target": [
-            "timestamps"
-          ]
+          "target": ["timestamps"]
         }
       ]
     },

--- a/schema/testdata/proto/attribute_computed/proto.json
+++ b/schema/testdata/proto/attribute_computed/proto.json
@@ -1,83 +1,8 @@
 {
   "models": [
     {
-      "name": "Invoice",
-      "fields": [
-        {
-          "modelName": "Invoice",
-          "name": "items",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "Item",
-            "repeated": true
-          },
-          "inverseFieldName": "invoice"
-        },
-        {
-          "modelName": "Invoice",
-          "name": "id",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "unique": true,
-          "primaryKey": true,
-          "defaultValue": {
-            "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "Invoice",
-          "name": "createdAt",
-          "type": {
-            "type": "TYPE_DATETIME"
-          },
-          "defaultValue": {
-            "useZeroValue": true
-          }
-        },
-        {
-          "modelName": "Invoice",
-          "name": "updatedAt",
-          "type": {
-            "type": "TYPE_DATETIME"
-          },
-          "defaultValue": {
-            "useZeroValue": true
-          }
-        }
-      ]
-    },
-    {
       "name": "Item",
       "fields": [
-        {
-          "modelName": "Item",
-          "name": "invoice",
-          "type": {
-            "type": "TYPE_MODEL",
-            "modelName": "Invoice"
-          },
-          "foreignKeyFieldName": "invoiceId",
-          "inverseFieldName": "items"
-        },
-        {
-          "modelName": "Item",
-          "name": "invoiceId",
-          "type": {
-            "type": "TYPE_ID"
-          },
-          "foreignKeyInfo": {
-            "relatedModelName": "Invoice",
-            "relatedModelField": "id"
-          }
-        },
-        {
-          "modelName": "Item",
-          "name": "description",
-          "type": {
-            "type": "TYPE_STRING"
-          }
-        },
         {
           "modelName": "Item",
           "name": "price",
@@ -87,9 +12,9 @@
         },
         {
           "modelName": "Item",
-          "name": "quantity",
+          "name": "units",
           "type": {
-            "type": "TYPE_INT"
+            "type": "TYPE_DECIMAL"
           }
         },
         {
@@ -99,7 +24,7 @@
             "type": "TYPE_DECIMAL"
           },
           "computedExpression": {
-            "source": "item.price * item.quantity"
+            "source": "item.price * item.units"
           }
         },
         {
@@ -133,6 +58,15 @@
           "defaultValue": {
             "useZeroValue": true
           }
+        }
+      ],
+      "actions": [
+        {
+          "modelName": "Item",
+          "name": "createItem",
+          "type": "ACTION_TYPE_CREATE",
+          "implementation": "ACTION_IMPLEMENTATION_AUTO",
+          "inputMessageName": "CreateItemInput"
         }
       ]
     },
@@ -331,10 +265,12 @@
       "name": "Api",
       "apiModels": [
         {
-          "modelName": "Invoice"
-        },
-        {
-          "modelName": "Item"
+          "modelName": "Item",
+          "modelActions": [
+            {
+              "actionName": "createItem"
+            }
+          ]
         },
         {
           "modelName": "Identity",
@@ -397,6 +333,31 @@
     },
     {
       "name": "ResetPasswordResponse"
+    },
+    {
+      "name": "CreateItemInput",
+      "fields": [
+        {
+          "messageName": "CreateItemInput",
+          "name": "price",
+          "type": {
+            "type": "TYPE_DECIMAL",
+            "modelName": "Item",
+            "fieldName": "price"
+          },
+          "target": ["price"]
+        },
+        {
+          "messageName": "CreateItemInput",
+          "name": "units",
+          "type": {
+            "type": "TYPE_DECIMAL",
+            "modelName": "Item",
+            "fieldName": "units"
+          },
+          "target": ["units"]
+        }
+      ]
     }
   ]
 }

--- a/schema/testdata/proto/attribute_computed/schema.keel
+++ b/schema/testdata/proto/attribute_computed/schema.keel
@@ -1,0 +1,10 @@
+model Item {
+    fields {
+        price Decimal
+        units Decimal
+        total Decimal @computed(item.price * item.units)
+    }
+    actions {
+        create createItem() with (price, units) 
+    }
+}

--- a/schema/validation/rules/actions/create_required.go
+++ b/schema/validation/rules/actions/create_required.go
@@ -65,13 +65,15 @@ func checkField(
 // - relationship repeated fields
 // - fields which have a default
 // - built-in fields like CreatedAt, Id etc.
+// - computed fields
 func isNotNeeded(asts []*parser.AST, model *parser.ModelNode, f *parser.FieldNode) bool {
 	switch {
 	case f.Optional,
 		(f.Repeated && !f.IsScalar()),
 		query.FieldHasAttribute(f, parser.AttributeDefault),
 		query.IsBelongsToModelField(asts, model, f),
-		f.BuiltIn:
+		f.BuiltIn,
+		query.FieldIsComputed(f):
 		return true
 	default:
 		return false


### PR DESCRIPTION
`@computed` for fields on the same model
===

This adds `@computed` support for `Decimal`, `Number` and `Boolean` fields and only those on the same model.  For example,

```
model Item {
    fields {
        price Decimal
        units Number
        total Decimal @computed(item.price * item.units)
        isDeleted Boolean
        isActive Boolean @computed(item.units >= 0 && !item.isDeleted)
    }
}
```

Implementation highlights
---

 - Support for `Decimal`, `Number` and `Boolean` fields and only those on the same model
 - Support for arithmetic operators `+`, `-`, `*`, `/` in `@computed` expressions.
 - Support for logical operations for `Boolean` fields; `&&`, `||` and `!`
 - Support for all the equality operations (`==`, `!=`, `>`, etc.) with the exception of `in`
 - Postgres functions and triggers are creating during migrations.  The actual computed functions are named with a short hash of the expression which means we can be smart about when to update the function logic.
 - Computed fields are optional in Model API create functions.
 - Computed fields are not required in create actions.
 - Improvements to operator precedence logic in the expression visitor.
 - Code completions
 - Schema validation check for computed attributes referencing their own fields
