### PR TITLE
fix: fix storage of files on S3

### DIFF
--- a/packages/functions-runtime/src/File.js
+++ b/packages/functions-runtime/src/File.js
@@ -215,10 +215,10 @@ async function storeFile(contents, key, filename, contentType, expires) {
       Body: contents,
       ContentType: contentType,
       ContentDisposition: `attachment; filename="${encodeURIComponent(
-        this.filename
+        filename
       )}"`,
       Metadata: {
-        filename: this.filename,
+        filename: filename,
       },
       ACL: "private",
     };


### PR DESCRIPTION
Fix typo which was referencing `this.filename` outside of an object, when storing files in s3 via the custom functions env