### PR TITLE
feat: computed fields and many to one relationships

### DIFF
--- a/expressions/resolve/field_lookups.go
+++ b/expressions/resolve/field_lookups.go
@@ -36,11 +36,11 @@ type fieldLookupsGen struct {
 	anyNull            bool
 }
 
-func (v *fieldLookupsGen) StartCondition(parenthesis bool) error {
+func (v *fieldLookupsGen) StartTerm(parenthesis bool) error {
 	return nil
 }
 
-func (v *fieldLookupsGen) EndCondition(parenthesis bool) error {
+func (v *fieldLookupsGen) EndTerm(parenthesis bool) error {
 	if v.operator == operators.Equals && !v.anyNull {
 		if v.operands != nil {
 			if len(v.uniqueLookupGroups) == 0 {

--- a/expressions/resolve/ident.go
+++ b/expressions/resolve/ident.go
@@ -28,11 +28,11 @@ type identGen struct {
 	ident *parser.ExpressionIdent
 }
 
-func (v *identGen) StartCondition(parenthesis bool) error {
+func (v *identGen) StartTerm(parenthesis bool) error {
 	return nil
 }
 
-func (v *identGen) EndCondition(parenthesis bool) error {
+func (v *identGen) EndTerm(parenthesis bool) error {
 	return nil
 }
 

--- a/expressions/resolve/ident_array.go
+++ b/expressions/resolve/ident_array.go
@@ -29,11 +29,11 @@ type identArrayGen struct {
 	idents []*parser.ExpressionIdent
 }
 
-func (v *identArrayGen) StartCondition(parenthesis bool) error {
+func (v *identArrayGen) StartTerm(parenthesis bool) error {
 	return nil
 }
 
-func (v *identArrayGen) EndCondition(parenthesis bool) error {
+func (v *identArrayGen) EndTerm(parenthesis bool) error {
 	return nil
 }
 

--- a/expressions/resolve/operands.go
+++ b/expressions/resolve/operands.go
@@ -24,11 +24,11 @@ type operandsResolver struct {
 	idents []*parser.ExpressionIdent
 }
 
-func (v *operandsResolver) StartCondition(parenthesis bool) error {
+func (v *operandsResolver) StartTerm(parenthesis bool) error {
 	return nil
 }
 
-func (v *operandsResolver) EndCondition(parenthesis bool) error {
+func (v *operandsResolver) EndTerm(parenthesis bool) error {
 	return nil
 }
 

--- a/expressions/resolve/visitor.go
+++ b/expressions/resolve/visitor.go
@@ -17,10 +17,10 @@ var (
 )
 
 type Visitor[T any] interface {
-	// StartCondition is called when a new condition is visited
-	StartCondition(nested bool) error
-	// EndCondition is called when a condition is finished
-	EndCondition(nested bool) error
+	// StartTerm is called when a new term is visited
+	StartTerm(nested bool) error
+	// EndTerm is called when a term is finished
+	EndTerm(nested bool) error
 	// VisitAnd is called when an 'and' operator is visited between conditions
 	VisitAnd() error
 	// VisitAnd is called when an 'or' operator is visited between conditions
@@ -87,7 +87,7 @@ func (w *CelVisitor[T]) eval(expr *exprpb.Expr, nested bool, inBinary bool) erro
 	switch expr.ExprKind.(type) {
 	case *exprpb.Expr_ConstExpr, *exprpb.Expr_ListExpr, *exprpb.Expr_SelectExpr, *exprpb.Expr_IdentExpr:
 		if !inBinary {
-			err := w.visitor.StartCondition(false)
+			err := w.visitor.StartTerm(false)
 			if err != nil {
 				return err
 			}
@@ -96,7 +96,7 @@ func (w *CelVisitor[T]) eval(expr *exprpb.Expr, nested bool, inBinary bool) erro
 
 	switch expr.ExprKind.(type) {
 	case *exprpb.Expr_CallExpr:
-		err = w.visitor.StartCondition(nested)
+		err = w.visitor.StartTerm(nested)
 		if err != nil {
 			return err
 		}
@@ -106,7 +106,7 @@ func (w *CelVisitor[T]) eval(expr *exprpb.Expr, nested bool, inBinary bool) erro
 			return err
 		}
 
-		err = w.visitor.EndCondition(nested)
+		err = w.visitor.EndTerm(nested)
 		if err != nil {
 			return err
 		}
@@ -137,7 +137,7 @@ func (w *CelVisitor[T]) eval(expr *exprpb.Expr, nested bool, inBinary bool) erro
 	switch expr.ExprKind.(type) {
 	case *exprpb.Expr_ConstExpr, *exprpb.Expr_ListExpr, *exprpb.Expr_SelectExpr, *exprpb.Expr_IdentExpr:
 		if !inBinary {
-			err := w.visitor.EndCondition(false)
+			err := w.visitor.EndTerm(false)
 			if err != nil {
 				return err
 			}

--- a/integration/testdata/computed_fields/schema.keel
+++ b/integration/testdata/computed_fields/schema.keel
@@ -39,7 +39,7 @@ model ComputedDepends {
     fields {
         price Decimal
         quantity Number
-        totalWithDiscount Decimal? @computed(computedDepends.totalWithShipping - (computedDepends.totalWithShipping / 100 * 10))
+        totalWithDiscount Decimal? @computed(computedDepends.totalWithShipping - (computedDepends.total / 100 * 10))
         totalWithShipping Decimal? @computed(computedDepends.total + 5)
         total Decimal? @computed(computedDepends.quantity * computedDepends.price)
     }

--- a/integration/testdata/computed_fields/tests.test.ts
+++ b/integration/testdata/computed_fields/tests.test.ts
@@ -119,21 +119,21 @@ test("computed fields - with dependencies", async () => {
   const item = await models.computedDepends.create({ price: 5, quantity: 2 });
   expect(item.total).toEqual(10);
   expect(item.totalWithShipping).toEqual(15);
-  expect(item.totalWithDiscount).toEqual(13.5);
+  expect(item.totalWithDiscount).toEqual(14);
 
   const updatedQty = await models.computedDepends.update(
     { id: item.id },
-    { quantity: 10 }
+    { quantity: 11 }
   );
-  expect(updatedQty.total).toEqual(50);
-  expect(updatedQty.totalWithShipping).toEqual(55);
-  expect(updatedQty.totalWithDiscount).toEqual(49.5);
+  expect(updatedQty.total).toEqual(55);
+  expect(updatedQty.totalWithShipping).toEqual(60);
+  expect(updatedQty.totalWithDiscount).toEqual(54.5);
 
   const updatePrice = await models.computedDepends.update(
     { id: item.id },
     { price: 8 }
   );
-  expect(updatePrice.total).toEqual(80);
-  expect(updatePrice.totalWithShipping).toEqual(85);
-  expect(updatePrice.totalWithDiscount).toEqual(76.5);
+  expect(updatePrice.total).toEqual(88);
+  expect(updatePrice.totalWithShipping).toEqual(93);
+  expect(updatePrice.totalWithDiscount).toEqual(84.2);
 });

--- a/integration/testdata/computed_fields_many_to_one/schema.keel
+++ b/integration/testdata/computed_fields_many_to_one/schema.keel
@@ -1,0 +1,39 @@
+model Item {
+    fields {
+        product Product
+        quantity Number
+        total Decimal? @computed(item.quantity * item.product.standardPrice + item.product.agent.commission)
+        totalWithShipping Decimal? @computed(item.total + 5)
+        totalWithDiscount Decimal? @computed(item.totalWithShipping - (item.total / 100 * 10))
+    }
+    actions {
+        create createItem() with (quantity, product.standardPrice, product.agent.commission) {
+            @permission(expression: true)
+        }
+    }
+}
+
+model Product {
+    fields {
+        standardPrice Decimal
+        items Item[]
+        agent Agent?
+    }
+    actions {
+        create createProduct() with (standardPrice, items.quantity, agent.commission) {
+            @permission(expression: true)
+        }
+    }
+}
+
+model Agent {
+    fields {
+        commission Decimal
+        products Product[]
+    }
+    actions {
+        create createAgent() with (commission, products.standardPrice, products.items.quantity){
+            @permission(expression: true)
+        }
+    }
+}

--- a/integration/testdata/computed_fields_many_to_one/tests.test.ts
+++ b/integration/testdata/computed_fields_many_to_one/tests.test.ts
@@ -1,0 +1,184 @@
+import { test, expect, beforeEach } from "vitest";
+import { models, resetDatabase, actions } from "@teamkeel/testing";
+
+beforeEach(resetDatabase);
+
+test("computed fields - many to one", async () => {
+  const agent = await models.agent.create({ commission: 2.5 });
+  const product = await models.product.create({
+    standardPrice: 5,
+    agentId: agent.id,
+  });
+  const item = await models.item.create({
+    productId: product.id,
+    quantity: 2,
+  });
+  expect(item.total).toEqual(12.5);
+  expect(item.totalWithShipping).toEqual(17.5);
+  expect(item.totalWithDiscount).toEqual(16.25);
+
+  await models.product.update({ id: product.id }, { standardPrice: 10 });
+  const getUpdatedPrice = await models.item.findOne({ id: item.id });
+  expect(getUpdatedPrice!.total).toEqual(22.5);
+  expect(getUpdatedPrice!.totalWithShipping).toEqual(27.5);
+  expect(getUpdatedPrice!.totalWithDiscount).toEqual(25.25);
+
+  const updateQuantity = await models.item.update(
+    { id: item.id },
+    { quantity: 3 }
+  );
+  expect(updateQuantity.total).toEqual(32.5);
+  expect(updateQuantity.totalWithShipping).toEqual(37.5);
+  expect(updateQuantity.totalWithDiscount).toEqual(34.25);
+
+  await models.agent.update({ id: agent.id }, { commission: 10 });
+  const getUpdatedPrice2 = await models.item.findOne({ id: item.id });
+  expect(getUpdatedPrice2!.total).toEqual(40);
+  expect(getUpdatedPrice2!.totalWithShipping).toEqual(45);
+  expect(getUpdatedPrice2!.totalWithDiscount).toEqual(41);
+
+  const newAgent = await models.agent.create({ commission: 0.75 });
+  await models.product.update({ id: product.id }, { agentId: newAgent.id });
+  const getUpdatedPrice3 = await models.item.findOne({ id: item.id });
+  expect(getUpdatedPrice3!.total).toEqual(30.75);
+  expect(getUpdatedPrice3!.totalWithShipping).toEqual(35.75);
+  expect(getUpdatedPrice3!.totalWithDiscount).toEqual(32.675);
+
+  const newProduct = await models.product.create({
+    standardPrice: 8,
+    agentId: agent.id,
+  });
+  const getUpdatedPrice4 = await models.item.update(
+    { id: item.id },
+    { productId: newProduct.id }
+  );
+  expect(getUpdatedPrice4!.total).toEqual(34);
+  expect(getUpdatedPrice4!.totalWithShipping).toEqual(39);
+  expect(getUpdatedPrice4!.totalWithDiscount).toEqual(35.6);
+});
+
+test("computed fields - many to one cascading update", async () => {
+  const agent1 = await models.agent.create({ commission: 2.5 });
+  const agent2 = await models.agent.create({ commission: 0.75 });
+
+  const product1 = await models.product.create({
+    standardPrice: 5,
+    agentId: agent1.id,
+  });
+  const item1 = await models.item.create({
+    productId: product1.id,
+    quantity: 2,
+  });
+  expect(item1.total).toEqual(12.5);
+
+  const product2 = await models.product.create({
+    standardPrice: 7,
+    agentId: agent1.id,
+  });
+  const item2 = await models.item.create({
+    productId: product2.id,
+    quantity: 2,
+  });
+  expect(item2.total).toEqual(16.5);
+
+  const product3 = await models.product.create({
+    standardPrice: 9,
+    agentId: agent2.id,
+  });
+  const item3 = await models.item.create({
+    productId: product3.id,
+    quantity: 2,
+  });
+  expect(item3.total).toEqual(18.75);
+
+  const product4 = await models.product.create({
+    standardPrice: 10,
+    agentId: agent2.id,
+  });
+  const item4 = await models.item.create({
+    productId: product4.id,
+    quantity: 2,
+  });
+  expect(item4.total).toEqual(20.75);
+  const item5 = await models.item.create({
+    productId: product4.id,
+    quantity: 3,
+  });
+  expect(item5.total).toEqual(30.75);
+
+  await models.agent.update({ id: agent2.id }, { commission: 1 });
+
+  const getItem1 = await models.item.findOne({ id: item1.id });
+  expect(getItem1!.total).toEqual(12.5);
+
+  const getItem2 = await models.item.findOne({ id: item2.id });
+  expect(getItem2!.total).toEqual(16.5);
+
+  const getItem3 = await models.item.findOne({ id: item3.id });
+  expect(getItem3!.total).toEqual(19);
+
+  const getItem4 = await models.item.findOne({ id: item4.id });
+  expect(getItem4!.total).toEqual(21);
+
+  const getItem5 = await models.item.findOne({ id: item5.id });
+  expect(getItem5!.total).toEqual(31);
+});
+
+test("computed fields - many to one with nested create", async () => {
+  const item = await actions.createItem({
+    quantity: 2,
+    product: {
+      standardPrice: 5,
+      agent: {
+        commission: 2.5,
+      },
+    },
+  });
+
+  expect(item.total).toEqual(12.5);
+});
+
+test("computed fields - many to one with nested create from related model", async () => {
+  const product = await actions.createProduct({
+    standardPrice: 5,
+    items: [
+      {
+        quantity: 2,
+      },
+      {
+        quantity: 5,
+      },
+    ],
+    agent: {
+      commission: 2.5,
+    },
+  });
+
+  const items = await models.item.findMany({
+    where: { productId: product.id },
+    orderBy: { total: "asc" },
+  });
+
+  expect(items[0].total).toEqual(12.5);
+  expect(items[1].total).toEqual(27.5);
+  expect(items).length(2);
+});
+
+test("computed fields - many to one with nested create from nested related model", async () => {
+  const agent = await actions.createAgent({
+    commission: 2.5,
+    products: [{ standardPrice: 5, items: [{ quantity: 2 }, { quantity: 5 }] }],
+  });
+  const products = await models.product.findMany({
+    where: { agentId: agent.id },
+  });
+
+  const items = await models.item.findMany({
+    where: { productId: products[0].id },
+    orderBy: { total: "asc" },
+  });
+
+  expect(items[0].total).toEqual(12.5);
+  expect(items[1].total).toEqual(27.5);
+  expect(items).length(2);
+});

--- a/migrations/computed_functions.sql
+++ b/migrations/computed_functions.sql
@@ -5,4 +5,4 @@ FROM
 WHERE 
     routine_type = 'FUNCTION'
 AND
-    routine_schema = 'public' AND routine_name LIKE '%__computed';
+    routine_schema = 'public' AND routine_name LIKE '%__computed' OR routine_name LIKE '%__computed_dependency';

--- a/migrations/computed_functions.sql
+++ b/migrations/computed_functions.sql
@@ -5,4 +5,4 @@ FROM
 WHERE 
     routine_type = 'FUNCTION'
 AND
-    routine_schema = 'public' AND routine_name LIKE '%__computed' OR routine_name LIKE '%__computed_dependency';
+    routine_schema = 'public' AND routine_name LIKE '%__comp' OR routine_name LIKE '%__comp_dep';

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -453,14 +453,14 @@ func compositeUniqueConstraints(schema *proto.Schema, model *proto.Model, constr
 	return statements, nil
 }
 
-type pair struct {
-	ident *parser.ExpressionIdent
+type depPair struct {
 	field *proto.Field
+	ident *parser.ExpressionIdent
 }
 
 // computedFieldDependencies returns a map of computed fields and every field it depends on
-func computedFieldDependencies(schema *proto.Schema) (map[*proto.Field][]*pair, error) {
-	dependencies := map[*proto.Field][]*pair{}
+func computedFieldDependencies(schema *proto.Schema) (map[*proto.Field][]*depPair, error) {
+	dependencies := map[*proto.Field][]*depPair{}
 
 	for _, model := range schema.Models {
 		for _, field := range model.Fields {
@@ -490,12 +490,12 @@ func computedFieldDependencies(schema *proto.Schema) (map[*proto.Field][]*pair, 
 						continue
 					}
 
-					p := pair{
+					dep := depPair{
 						ident: ident,
 						field: currField,
 					}
 
-					dependencies[field] = append(dependencies[field], &p)
+					dependencies[field] = append(dependencies[field], &dep)
 				}
 			}
 		}

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -46,9 +46,6 @@ func TestMigrations(t *testing.T) {
 	}()
 
 	for _, testCase := range testCases {
-		if testCase.Name() != "computed_field_many_to_one_changed.txt" {
-			continue
-		}
 		t.Run(strings.TrimSuffix(testCase.Name(), ".txt"), func(t *testing.T) {
 			// Make a database name for this test
 			re := regexp.MustCompile(`[^\w]`)

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -46,6 +46,9 @@ func TestMigrations(t *testing.T) {
 	}()
 
 	for _, testCase := range testCases {
+		if testCase.Name() != "computed_field_many_to_one_changed.txt" {
+			continue
+		}
 		t.Run(strings.TrimSuffix(testCase.Name(), ".txt"), func(t *testing.T) {
 			// Make a database name for this test
 			re := regexp.MustCompile(`[^\w]`)

--- a/migrations/sql.go
+++ b/migrations/sql.go
@@ -231,11 +231,15 @@ func alterColumnStmt(modelName string, field *proto.Field, column *ColumnRow) (s
 	return strings.Join(stmts, "\n"), nil
 }
 
+func hashOfExpression(expression string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(expression)))[:8]
+}
+
 // computedFieldFuncName generates the name of the a computed field's function
-func computedFieldFuncName(model *proto.Model, field *proto.Field) string {
+func computedFieldFuncName(field *proto.Field) string {
 	// shortened alphanumeric hash from an expression
-	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(field.ComputedExpression.Source)))[:8]
-	return fmt.Sprintf("%s__%s__%s__computed", strcase.ToSnake(model.Name), strcase.ToSnake(field.Name), hash)
+	hash := hashOfExpression(field.ComputedExpression.Source)
+	return fmt.Sprintf("%s__%s__%s__computed", strcase.ToSnake(field.ModelName), strcase.ToSnake(field.Name), hash)
 }
 
 // computedExecFuncName generates the name for the table function which executed all computed functions
@@ -246,6 +250,12 @@ func computedExecFuncName(model *proto.Model) string {
 // computedTriggerName generates the name for the trigger which runs the function which executes computed functions
 func computedTriggerName(model *proto.Model) string {
 	return fmt.Sprintf("%s__computed_trigger", strcase.ToSnake(model.Name))
+}
+
+func computedDependencyFuncName(model *proto.Model, dependentModel *proto.Model, fragments []string) string {
+	// shortened alphanumeric hash from the operand idents
+	hash := hashOfExpression(strings.Join(fragments, "."))
+	return fmt.Sprintf("%s__to__%s__%s__computed_dependency", strcase.ToSnake(dependentModel.Name), strcase.ToSnake(model.Name), hash)
 }
 
 // fieldFromComputedFnName determines the field from computed function name
@@ -281,7 +291,7 @@ func addComputedFieldFuncStmt(schema *proto.Schema, model *proto.Model, field *p
 		return "", "", err
 	}
 
-	fn := computedFieldFuncName(model, field)
+	fn := computedFieldFuncName(field)
 	sql := fmt.Sprintf("CREATE FUNCTION %s(r %s) RETURNS %s AS $$ BEGIN\n\tRETURN %s;\nEND; $$ LANGUAGE plpgsql;",
 		fn,
 		strcase.ToSnake(model.Name),

--- a/migrations/sql.go
+++ b/migrations/sql.go
@@ -239,23 +239,23 @@ func hashOfExpression(expression string) string {
 func computedFieldFuncName(field *proto.Field) string {
 	// shortened alphanumeric hash from an expression
 	hash := hashOfExpression(field.ComputedExpression.Source)
-	return fmt.Sprintf("%s__%s__%s__computed", strcase.ToSnake(field.ModelName), strcase.ToSnake(field.Name), hash)
+	return fmt.Sprintf("%s__%s__%s__comp", strcase.ToSnake(field.ModelName), strcase.ToSnake(field.Name), hash)
 }
 
 // computedExecFuncName generates the name for the table function which executed all computed functions
 func computedExecFuncName(model *proto.Model) string {
-	return fmt.Sprintf("%s__exec_computed_fns", strcase.ToSnake(model.Name))
+	return fmt.Sprintf("%s__exec_comp_fns", strcase.ToSnake(model.Name))
 }
 
 // computedTriggerName generates the name for the trigger which runs the function which executes computed functions
 func computedTriggerName(model *proto.Model) string {
-	return fmt.Sprintf("%s__computed_trigger", strcase.ToSnake(model.Name))
+	return fmt.Sprintf("%s__comp", strcase.ToSnake(model.Name))
 }
 
 func computedDependencyFuncName(model *proto.Model, dependentModel *proto.Model, fragments []string) string {
 	// shortened alphanumeric hash from the operand idents
 	hash := hashOfExpression(strings.Join(fragments, "."))
-	return fmt.Sprintf("%s__to__%s__%s__computed_dependency", strcase.ToSnake(dependentModel.Name), strcase.ToSnake(model.Name), hash)
+	return fmt.Sprintf("%s__to__%s__%s__comp_dep", strcase.ToSnake(dependentModel.Name), strcase.ToSnake(model.Name), hash)
 }
 
 // fieldFromComputedFnName determines the field from computed function name
@@ -302,11 +302,11 @@ func addComputedFieldFuncStmt(schema *proto.Schema, model *proto.Model, field *p
 }
 
 func dropComputedExecFunctionStmt(model *proto.Model) string {
-	return fmt.Sprintf("DROP FUNCTION %s__exec_computed_fns;", strcase.ToSnake(model.Name))
+	return fmt.Sprintf("DROP FUNCTION %s__exec_comp_fns;", strcase.ToSnake(model.Name))
 }
 
 func dropComputedTriggerStmt(model *proto.Model) string {
-	return fmt.Sprintf("DROP TRIGGER %s__computed_trigger ON %s;", strcase.ToSnake(model.Name), strcase.ToSnake(model.Name))
+	return fmt.Sprintf("DROP TRIGGER %s__comp ON %s;", strcase.ToSnake(model.Name), strcase.ToSnake(model.Name))
 }
 
 func fieldDefinition(field *proto.Field) (string, error) {

--- a/migrations/testdata/computed_field_changed_expression.txt
+++ b/migrations/testdata/computed_field_changed_expression.txt
@@ -18,15 +18,15 @@ model Item {
 
 ===
 
-CREATE FUNCTION item__total__863346d0__computed(r item) RETURNS NUMERIC AS $$ BEGIN
+CREATE FUNCTION item__total__863346d0__comp(r item) RETURNS NUMERIC AS $$ BEGIN
 	RETURN r."price" + 5;
 END; $$ LANGUAGE plpgsql;
-DROP FUNCTION item__total__0614a79a__computed;
-CREATE OR REPLACE FUNCTION item__exec_computed_fns() RETURNS TRIGGER AS $$ BEGIN
-	NEW.total := item__total__863346d0__computed(NEW);
+DROP FUNCTION item__total__0614a79a__comp;
+CREATE OR REPLACE FUNCTION item__exec_comp_fns() RETURNS TRIGGER AS $$ BEGIN
+	NEW.total := item__total__863346d0__comp(NEW);
 	RETURN NEW;
 END; $$ LANGUAGE plpgsql;
-CREATE OR REPLACE TRIGGER item__computed_trigger BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE item__exec_computed_fns();
+CREATE OR REPLACE TRIGGER item__comp BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE item__exec_comp_fns();
 
 ===
 

--- a/migrations/testdata/computed_field_initial.txt
+++ b/migrations/testdata/computed_field_initial.txt
@@ -61,14 +61,14 @@ CREATE TRIGGER identity_create AFTER INSERT ON "identity" REFERENCING NEW TABLE 
 CREATE TRIGGER identity_update AFTER UPDATE ON "identity" REFERENCING NEW TABLE AS new_table OLD TABLE AS old_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
 CREATE TRIGGER identity_delete AFTER DELETE ON "identity" REFERENCING OLD TABLE AS old_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
 CREATE TRIGGER identity_updated_at BEFORE UPDATE ON "identity" FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
-CREATE FUNCTION item__total__0614a79a__computed(r item) RETURNS NUMERIC AS $$ BEGIN
+CREATE FUNCTION item__total__0614a79a__comp(r item) RETURNS NUMERIC AS $$ BEGIN
 	RETURN r."quantity" * r."price";
 END; $$ LANGUAGE plpgsql;
-CREATE OR REPLACE FUNCTION item__exec_computed_fns() RETURNS TRIGGER AS $$ BEGIN
-	NEW.total := item__total__0614a79a__computed(NEW);
+CREATE OR REPLACE FUNCTION item__exec_comp_fns() RETURNS TRIGGER AS $$ BEGIN
+	NEW.total := item__total__0614a79a__comp(NEW);
 	RETURN NEW;
 END; $$ LANGUAGE plpgsql;
-CREATE OR REPLACE TRIGGER item__computed_trigger BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE item__exec_computed_fns();
+CREATE OR REPLACE TRIGGER item__comp BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE item__exec_comp_fns();
 ===
 
 [

--- a/migrations/testdata/computed_field_many_to_one.txt
+++ b/migrations/testdata/computed_field_many_to_one.txt
@@ -98,24 +98,24 @@ CREATE TRIGGER identity_create AFTER INSERT ON "identity" REFERENCING NEW TABLE 
 CREATE TRIGGER identity_update AFTER UPDATE ON "identity" REFERENCING NEW TABLE AS new_table OLD TABLE AS old_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
 CREATE TRIGGER identity_delete AFTER DELETE ON "identity" REFERENCING OLD TABLE AS old_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
 CREATE TRIGGER identity_updated_at BEFORE UPDATE ON "identity" FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
-CREATE FUNCTION item__total__8f543d38__computed(r item) RETURNS NUMERIC AS $$ BEGIN
+CREATE FUNCTION item__total__8f543d38__comp(r item) RETURNS NUMERIC AS $$ BEGIN
 	RETURN r."quantity" * (SELECT "product"."price" FROM "product" WHERE "product"."id" IS NOT DISTINCT FROM r."product_id") + (SELECT "product$agent"."commission" FROM "product" LEFT JOIN "agent" AS "product$agent" ON "product$agent"."id" = "product"."agent_id" WHERE "product"."id" IS NOT DISTINCT FROM r."product_id");
 END; $$ LANGUAGE plpgsql;
-CREATE OR REPLACE FUNCTION item__exec_computed_fns() RETURNS TRIGGER AS $$ BEGIN
-	NEW.total := item__total__8f543d38__computed(NEW);
+CREATE OR REPLACE FUNCTION item__exec_comp_fns() RETURNS TRIGGER AS $$ BEGIN
+	NEW.total := item__total__8f543d38__comp(NEW);
 	RETURN NEW;
 END; $$ LANGUAGE plpgsql;
-CREATE OR REPLACE TRIGGER item__computed_trigger BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE item__exec_computed_fns();
-CREATE OR REPLACE FUNCTION agent__to__item__26590ccb__computed_dependency() RETURNS TRIGGER AS $$ BEGIN
+CREATE OR REPLACE TRIGGER item__comp BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE item__exec_comp_fns();
+CREATE OR REPLACE FUNCTION agent__to__item__26590ccb__comp_dep() RETURNS TRIGGER AS $$ BEGIN
 	UPDATE "item" SET "id" = "item"."id" WHERE "item"."id" IN (SELECT "item"."id" FROM "item" JOIN "product" AS "item$product" ON "item$product"."id" = "item"."product_id" JOIN "agent" AS "item$product$agent" ON "item$product$agent"."id" = "item$product"."agent_id" WHERE "item$product$agent"."id" IS NOT DISTINCT FROM NEW.id);
 	RETURN NULL;
 END; $$ LANGUAGE plpgsql;
-CREATE OR REPLACE TRIGGER agent__to__item__26590ccb__computed_dependency_trigger AFTER INSERT OR DELETE OR UPDATE ON "agent" FOR EACH ROW EXECUTE PROCEDURE agent__to__item__26590ccb__computed_dependency();
-CREATE OR REPLACE FUNCTION product__to__item__9454cd1f__computed_dependency() RETURNS TRIGGER AS $$ BEGIN
+CREATE OR REPLACE TRIGGER agent__to__item__26590ccb__comp_dep AFTER INSERT OR DELETE OR UPDATE ON "agent" FOR EACH ROW EXECUTE PROCEDURE agent__to__item__26590ccb__comp_dep();
+CREATE OR REPLACE FUNCTION product__to__item__9454cd1f__comp_dep() RETURNS TRIGGER AS $$ BEGIN
 	UPDATE "item" SET "id" = "item"."id" WHERE "item"."id" IN (SELECT "item"."id" FROM "item" JOIN "product" AS "item$product" ON "item$product"."id" = "item"."product_id" WHERE "item$product"."id" IS NOT DISTINCT FROM NEW.id);
 	RETURN NULL;
 END; $$ LANGUAGE plpgsql;
-CREATE OR REPLACE TRIGGER product__to__item__9454cd1f__computed_dependency_trigger AFTER INSERT OR DELETE OR UPDATE ON "product" FOR EACH ROW EXECUTE PROCEDURE product__to__item__9454cd1f__computed_dependency();
+CREATE OR REPLACE TRIGGER product__to__item__9454cd1f__comp_dep AFTER INSERT OR DELETE OR UPDATE ON "product" FOR EACH ROW EXECUTE PROCEDURE product__to__item__9454cd1f__comp_dep();
 
 ===
 

--- a/migrations/testdata/computed_field_many_to_one.txt
+++ b/migrations/testdata/computed_field_many_to_one.txt
@@ -1,0 +1,128 @@
+===
+
+model Item {
+    fields {
+        product Product
+        quantity Number
+        total Decimal @computed(item.quantity * item.product.price + item.product.agent.commission)
+    }
+}
+
+model Product {
+    fields {
+        price Decimal
+        agent Agent?
+    }
+}
+
+model Agent {
+    fields {
+        commission Decimal
+    }
+}
+
+===
+CREATE TABLE "agent" (
+"commission" NUMERIC NOT NULL,
+"id" TEXT NOT NULL DEFAULT ksuid(),
+"created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+"updated_at" TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+ALTER TABLE "agent" ADD CONSTRAINT agent_id_pkey PRIMARY KEY ("id");
+CREATE TABLE "identity" (
+"email" TEXT,
+"email_verified" BOOL NOT NULL DEFAULT false,
+"password" TEXT,
+"external_id" TEXT,
+"issuer" TEXT,
+"name" TEXT,
+"given_name" TEXT,
+"family_name" TEXT,
+"middle_name" TEXT,
+"nick_name" TEXT,
+"profile" TEXT,
+"picture" TEXT,
+"website" TEXT,
+"gender" TEXT,
+"zone_info" TEXT,
+"locale" TEXT,
+"id" TEXT NOT NULL DEFAULT ksuid(),
+"created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+"updated_at" TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+ALTER TABLE "identity" ADD CONSTRAINT identity_id_pkey PRIMARY KEY ("id");
+ALTER TABLE "identity" ADD CONSTRAINT identity_email_issuer_udx UNIQUE ("email", "issuer");
+CREATE TABLE "item" (
+"product_id" TEXT NOT NULL,
+"quantity" INTEGER NOT NULL,
+"total" NUMERIC NOT NULL,
+"id" TEXT NOT NULL DEFAULT ksuid(),
+"created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+"updated_at" TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+ALTER TABLE "item" ADD CONSTRAINT item_id_pkey PRIMARY KEY ("id");
+CREATE TABLE "keel_audit" (
+"id" TEXT NOT NULL DEFAULT ksuid(),
+"table_name" TEXT NOT NULL,
+"op" TEXT NOT NULL,
+"data" jsonb NOT NULL,
+"created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+"identity_id" TEXT,
+"trace_id" TEXT,
+"event_processed_at" TIMESTAMPTZ
+);
+ALTER TABLE "keel_audit" ADD CONSTRAINT keel_audit_id_pkey PRIMARY KEY ("id");
+CREATE TABLE "product" (
+"price" NUMERIC NOT NULL,
+"agent_id" TEXT,
+"id" TEXT NOT NULL DEFAULT ksuid(),
+"created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+"updated_at" TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+ALTER TABLE "product" ADD CONSTRAINT product_id_pkey PRIMARY KEY ("id");
+ALTER TABLE "item" ADD FOREIGN KEY ("product_id") REFERENCES "product"("id") ON DELETE CASCADE;
+ALTER TABLE "product" ADD FOREIGN KEY ("agent_id") REFERENCES "agent"("id") ON DELETE SET NULL;
+CREATE TRIGGER item_create AFTER INSERT ON "item" REFERENCING NEW TABLE AS new_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
+CREATE TRIGGER item_update AFTER UPDATE ON "item" REFERENCING NEW TABLE AS new_table OLD TABLE AS old_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
+CREATE TRIGGER item_delete AFTER DELETE ON "item" REFERENCING OLD TABLE AS old_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
+CREATE TRIGGER item_updated_at BEFORE UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+CREATE TRIGGER product_create AFTER INSERT ON "product" REFERENCING NEW TABLE AS new_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
+CREATE TRIGGER product_update AFTER UPDATE ON "product" REFERENCING NEW TABLE AS new_table OLD TABLE AS old_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
+CREATE TRIGGER product_delete AFTER DELETE ON "product" REFERENCING OLD TABLE AS old_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
+CREATE TRIGGER product_updated_at BEFORE UPDATE ON "product" FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+CREATE TRIGGER agent_create AFTER INSERT ON "agent" REFERENCING NEW TABLE AS new_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
+CREATE TRIGGER agent_update AFTER UPDATE ON "agent" REFERENCING NEW TABLE AS new_table OLD TABLE AS old_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
+CREATE TRIGGER agent_delete AFTER DELETE ON "agent" REFERENCING OLD TABLE AS old_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
+CREATE TRIGGER agent_updated_at BEFORE UPDATE ON "agent" FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+CREATE TRIGGER identity_create AFTER INSERT ON "identity" REFERENCING NEW TABLE AS new_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
+CREATE TRIGGER identity_update AFTER UPDATE ON "identity" REFERENCING NEW TABLE AS new_table OLD TABLE AS old_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
+CREATE TRIGGER identity_delete AFTER DELETE ON "identity" REFERENCING OLD TABLE AS old_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
+CREATE TRIGGER identity_updated_at BEFORE UPDATE ON "identity" FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+CREATE FUNCTION item__total__8f543d38__computed(r item) RETURNS NUMERIC AS $$ BEGIN
+	RETURN r."quantity" * (SELECT "product"."price" FROM "product" WHERE "product"."id" IS NOT DISTINCT FROM r."product_id") + (SELECT "product$agent"."commission" FROM "product" LEFT JOIN "agent" AS "product$agent" ON "product$agent"."id" = "product"."agent_id" WHERE "product"."id" IS NOT DISTINCT FROM r."product_id");
+END; $$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION item__exec_computed_fns() RETURNS TRIGGER AS $$ BEGIN
+	NEW.total := item__total__8f543d38__computed(NEW);
+	RETURN NEW;
+END; $$ LANGUAGE plpgsql;
+CREATE OR REPLACE TRIGGER item__computed_trigger BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE item__exec_computed_fns();
+CREATE OR REPLACE FUNCTION agent__to__item__26590ccb__computed_dependency() RETURNS TRIGGER AS $$ BEGIN
+	UPDATE "item" SET "id" = "item"."id" WHERE "item"."id" IN (SELECT "item"."id" FROM "item" JOIN "product" AS "item$product" ON "item$product"."id" = "item"."product_id" JOIN "agent" AS "item$product$agent" ON "item$product$agent"."id" = "item$product"."agent_id" WHERE "item$product$agent"."id" IS NOT DISTINCT FROM NEW.id);
+	RETURN NULL;
+END; $$ LANGUAGE plpgsql;
+CREATE OR REPLACE TRIGGER agent__to__item__26590ccb__computed_dependency_trigger AFTER INSERT OR DELETE OR UPDATE ON "agent" FOR EACH ROW EXECUTE PROCEDURE agent__to__item__26590ccb__computed_dependency();
+CREATE OR REPLACE FUNCTION product__to__item__9454cd1f__computed_dependency() RETURNS TRIGGER AS $$ BEGIN
+	UPDATE "item" SET "id" = "item"."id" WHERE "item"."id" IN (SELECT "item"."id" FROM "item" JOIN "product" AS "item$product" ON "item$product"."id" = "item"."product_id" WHERE "item$product"."id" IS NOT DISTINCT FROM NEW.id);
+	RETURN NULL;
+END; $$ LANGUAGE plpgsql;
+CREATE OR REPLACE TRIGGER product__to__item__9454cd1f__computed_dependency_trigger AFTER INSERT OR DELETE OR UPDATE ON "product" FOR EACH ROW EXECUTE PROCEDURE product__to__item__9454cd1f__computed_dependency();
+
+===
+
+[
+    {"Model":"Agent","Field":"","Type":"ADDED"},
+    {"Model":"Identity","Field":"","Type":"ADDED"},
+    {"Model":"Item","Field":"","Type":"ADDED"},
+    {"Model":"KeelAudit","Field":"","Type":"ADDED"},
+    {"Model":"Product","Field":"","Type":"ADDED"}
+]

--- a/migrations/testdata/computed_field_many_to_one_changed.txt
+++ b/migrations/testdata/computed_field_many_to_one_changed.txt
@@ -1,0 +1,63 @@
+model Item {
+    fields {
+        product Product
+        quantity Number
+        total Decimal @computed(item.quantity * item.product.price + item.product.agent.commission)
+    }
+}
+
+model Product {
+    fields {
+        price Decimal
+        agent Agent?
+    }
+}
+
+model Agent {
+    fields {
+        commission Decimal
+    }
+}
+
+===
+
+model Item {
+    fields {
+        product Product
+        quantity Number
+        total Decimal @computed(item.quantity * item.product.price)
+    }
+}
+
+model Product {
+    fields {
+        price Decimal
+        agent Agent?
+    }
+}
+
+model Agent {
+    fields {
+        commission Decimal
+    }
+}
+
+===
+
+CREATE FUNCTION item__total__5474c2e0__computed(r item) RETURNS NUMERIC AS $$ BEGIN
+	RETURN r."quantity" * (SELECT "product"."price" FROM "product" WHERE "product"."id" IS NOT DISTINCT FROM r."product_id");
+END; $$ LANGUAGE plpgsql;
+DROP FUNCTION item__total__8f543d38__computed;
+CREATE OR REPLACE FUNCTION item__exec_computed_fns() RETURNS TRIGGER AS $$ BEGIN
+	NEW.total := item__total__5474c2e0__computed(NEW);
+	RETURN NEW;
+END; $$ LANGUAGE plpgsql;
+CREATE OR REPLACE TRIGGER item__computed_trigger BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE item__exec_computed_fns();
+DROP TRIGGER agent__to__item__26590ccb__computed_dependency_trigger ON agent;
+DROP FUNCTION agent__to__item__26590ccb__computed_dependency;
+
+===
+
+[
+    {"Model":"Item","Field":"total","Type":"MODIFIED"}
+]

--- a/migrations/testdata/computed_field_many_to_one_changed.txt
+++ b/migrations/testdata/computed_field_many_to_one_changed.txt
@@ -44,17 +44,17 @@ model Agent {
 
 ===
 
-CREATE FUNCTION item__total__5474c2e0__computed(r item) RETURNS NUMERIC AS $$ BEGIN
+CREATE FUNCTION item__total__5474c2e0__comp(r item) RETURNS NUMERIC AS $$ BEGIN
 	RETURN r."quantity" * (SELECT "product"."price" FROM "product" WHERE "product"."id" IS NOT DISTINCT FROM r."product_id");
 END; $$ LANGUAGE plpgsql;
-DROP FUNCTION item__total__8f543d38__computed;
-CREATE OR REPLACE FUNCTION item__exec_computed_fns() RETURNS TRIGGER AS $$ BEGIN
-	NEW.total := item__total__5474c2e0__computed(NEW);
+DROP FUNCTION item__total__8f543d38__comp;
+CREATE OR REPLACE FUNCTION item__exec_comp_fns() RETURNS TRIGGER AS $$ BEGIN
+	NEW.total := item__total__5474c2e0__comp(NEW);
 	RETURN NEW;
 END; $$ LANGUAGE plpgsql;
-CREATE OR REPLACE TRIGGER item__computed_trigger BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE item__exec_computed_fns();
-DROP TRIGGER agent__to__item__26590ccb__computed_dependency_trigger ON agent;
-DROP FUNCTION agent__to__item__26590ccb__computed_dependency;
+CREATE OR REPLACE TRIGGER item__comp BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE item__exec_comp_fns();
+DROP TRIGGER agent__to__item__26590ccb__comp_dep ON agent;
+DROP FUNCTION agent__to__item__26590ccb__comp_dep;
 
 ===
 

--- a/migrations/testdata/computed_field_multiple_depend.txt
+++ b/migrations/testdata/computed_field_multiple_depend.txt
@@ -21,18 +21,18 @@ model Item {
 
 ===
 
-CREATE FUNCTION item__total__0614a79a__computed(r item) RETURNS NUMERIC AS $$ BEGIN
+CREATE FUNCTION item__total__0614a79a__comp(r item) RETURNS NUMERIC AS $$ BEGIN
 	RETURN r."quantity" * r."price";
 END; $$ LANGUAGE plpgsql;
-CREATE FUNCTION item__total_with_shipping__53d0d09b__computed(r item) RETURNS NUMERIC AS $$ BEGIN
+CREATE FUNCTION item__total_with_shipping__53d0d09b__comp(r item) RETURNS NUMERIC AS $$ BEGIN
 	RETURN r."total" + 5;
 END; $$ LANGUAGE plpgsql;
-CREATE OR REPLACE FUNCTION item__exec_computed_fns() RETURNS TRIGGER AS $$ BEGIN
-	NEW.total := item__total__0614a79a__computed(NEW);
-	NEW.total_with_shipping := item__total_with_shipping__53d0d09b__computed(NEW);
+CREATE OR REPLACE FUNCTION item__exec_comp_fns() RETURNS TRIGGER AS $$ BEGIN
+	NEW.total := item__total__0614a79a__comp(NEW);
+	NEW.total_with_shipping := item__total_with_shipping__53d0d09b__comp(NEW);
 	RETURN NEW;
 END; $$ LANGUAGE plpgsql;
-CREATE OR REPLACE TRIGGER item__computed_trigger BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE item__exec_computed_fns();
+CREATE OR REPLACE TRIGGER item__comp BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE item__exec_comp_fns();
 
 ===
 

--- a/migrations/testdata/computed_field_removed_attr.txt
+++ b/migrations/testdata/computed_field_removed_attr.txt
@@ -18,9 +18,9 @@ model Item {
 
 ===
 
-DROP FUNCTION item__total__0614a79a__computed;
-DROP TRIGGER item__computed_trigger ON item;
-DROP FUNCTION item__exec_computed_fns;
+DROP FUNCTION item__total__0614a79a__comp;
+DROP TRIGGER item__comp ON item;
+DROP FUNCTION item__exec_comp_fns;
 
 ===
 

--- a/migrations/testdata/computed_field_removed_field.txt
+++ b/migrations/testdata/computed_field_removed_field.txt
@@ -18,9 +18,9 @@ model Item {
 ===
 
 ALTER TABLE "item" DROP COLUMN "total";
-DROP FUNCTION item__total__0614a79a__computed;
-DROP TRIGGER item__computed_trigger ON item;
-DROP FUNCTION item__exec_computed_fns;
+DROP FUNCTION item__total__0614a79a__comp;
+DROP TRIGGER item__comp ON item;
+DROP FUNCTION item__exec_comp_fns;
 
 ===
 

--- a/migrations/testdata/computed_field_renamed_field.txt
+++ b/migrations/testdata/computed_field_renamed_field.txt
@@ -20,15 +20,15 @@ model Item {
 
 ALTER TABLE "item" ADD COLUMN "new_total" NUMERIC NOT NULL;
 ALTER TABLE "item" DROP COLUMN "total";
-CREATE FUNCTION item__new_total__0614a79a__computed(r item) RETURNS NUMERIC AS $$ BEGIN
+CREATE FUNCTION item__new_total__0614a79a__comp(r item) RETURNS NUMERIC AS $$ BEGIN
 	RETURN r."quantity" * r."price";
 END; $$ LANGUAGE plpgsql;
-DROP FUNCTION item__total__0614a79a__computed;
-CREATE OR REPLACE FUNCTION item__exec_computed_fns() RETURNS TRIGGER AS $$ BEGIN
-	NEW.new_total := item__new_total__0614a79a__computed(NEW);
+DROP FUNCTION item__total__0614a79a__comp;
+CREATE OR REPLACE FUNCTION item__exec_comp_fns() RETURNS TRIGGER AS $$ BEGIN
+	NEW.new_total := item__new_total__0614a79a__comp(NEW);
 	RETURN NEW;
 END; $$ LANGUAGE plpgsql;
-CREATE OR REPLACE TRIGGER item__computed_trigger BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE item__exec_computed_fns();
+CREATE OR REPLACE TRIGGER item__comp BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE item__exec_comp_fns();
 
 ===
 

--- a/permissions/permissions.go
+++ b/permissions/permissions.go
@@ -51,13 +51,13 @@ func gen(schema *proto.Schema, model *proto.Model, action *proto.Action, stmt *s
 	}
 }
 
-func (v *permissionGen) StartCondition(nested bool) error {
+func (v *permissionGen) StartTerm(nested bool) error {
 	if nested {
 		v.stmt.expression += "("
 	}
 	return nil
 }
-func (v *permissionGen) EndCondition(nested bool) error {
+func (v *permissionGen) EndTerm(nested bool) error {
 	if nested {
 		v.stmt.expression += ")"
 	}

--- a/proto/model.go
+++ b/proto/model.go
@@ -57,3 +57,13 @@ func (m *Model) GetComputedFields() []*Field {
 	}
 	return fields
 }
+
+// GetComputedFields returns all the computed fields on the given model.
+func (m *Model) FindField(name string) *Field {
+	for _, f := range m.Fields {
+		if f.Name == name {
+			return f
+		}
+	}
+	return nil
+}

--- a/runtime/actions/evaluation.go
+++ b/runtime/actions/evaluation.go
@@ -21,7 +21,7 @@ type OperandResolver struct {
 func (a *OperandResolver) ResolveName(name string) (any, bool) {
 	fragments := strings.Split(name, ".")
 
-	fragments, err := normalisedFragments(a.schema, fragments)
+	fragments, err := NormalisedFragments(a.schema, fragments)
 	if err != nil {
 		return nil, false
 	}

--- a/runtime/actions/expression.go
+++ b/runtime/actions/expression.go
@@ -23,7 +23,7 @@ func (query *QueryBuilder) AddJoinFromFragments(schema *proto.Schema, fragments 
 		return nil
 	}
 
-	fragments, err := normalisedFragments(schema, fragments)
+	fragments, err := NormalisedFragments(schema, fragments)
 	if err != nil {
 		return err
 	}
@@ -67,7 +67,7 @@ func (query *QueryBuilder) AddJoinFromFragments(schema *proto.Schema, fragments 
 }
 
 func generateOperand(ctx context.Context, schema *proto.Schema, model *proto.Model, action *proto.Action, inputs map[string]any, fragments []string) (*QueryOperand, error) {
-	ident, err := normalisedFragments(schema, fragments)
+	ident, err := NormalisedFragments(schema, fragments)
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +191,7 @@ func generateOperand(ctx context.Context, schema *proto.Schema, model *proto.Mod
 	return queryOperand, nil
 }
 
-func normalisedFragments(schema *proto.Schema, fragments []string) ([]string, error) {
+func NormalisedFragments(schema *proto.Schema, fragments []string) ([]string, error) {
 	isModelField := false
 	isCtx := fragments[0] == "ctx"
 
@@ -210,7 +210,6 @@ func normalisedFragments(schema *proto.Schema, fragments []string) ([]string, er
 	if modelTarget == nil {
 		// If it's not the model, then it could be an input
 		return fragments, nil
-		//return nil, fmt.Errorf("model '%s' does not exist in schema", casing.ToCamel(fragments[0]))
 	}
 
 	var fieldTarget *proto.Field
@@ -276,7 +275,7 @@ func normalisedFragments(schema *proto.Schema, fragments []string) ([]string, er
 // Constructs a QueryOperand from a splice of fragments, representing an expression operand or implicit input.
 // The fragment slice must include the base model as the first fragment, for example: post.author.publisher.isActive
 func operandFromFragments(schema *proto.Schema, fragments []string) (*QueryOperand, error) {
-	fragments, err := normalisedFragments(schema, fragments)
+	fragments, err := NormalisedFragments(schema, fragments)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/actions/generate_computed.go
+++ b/runtime/actions/generate_computed.go
@@ -33,14 +33,14 @@ type computedQueryGen struct {
 	sql    string
 }
 
-func (v *computedQueryGen) StartCondition(nested bool) error {
+func (v *computedQueryGen) StartTerm(nested bool) error {
 	if nested {
 		v.sql += "("
 	}
 	return nil
 }
 
-func (v *computedQueryGen) EndCondition(nested bool) error {
+func (v *computedQueryGen) EndTerm(nested bool) error {
 	if nested {
 		v.sql += ")"
 	}
@@ -104,7 +104,37 @@ func (v *computedQueryGen) VisitLiteral(value any) error {
 }
 
 func (v *computedQueryGen) VisitIdent(ident *parser.ExpressionIdent) error {
-	v.sql += "r." + sqlQuote(strcase.ToSnake(ident.Fragments[len(ident.Fragments)-1]))
+	model := v.schema.FindModel(strcase.ToCamel(ident.Fragments[0]))
+	field := proto.FindField(v.schema.Models, model.Name, ident.Fragments[1])
+
+	if len(ident.Fragments) == 2 {
+		v.sql += "r." + sqlQuote(strcase.ToSnake(field.Name))
+	} else if len(ident.Fragments) > 2 {
+		model = v.schema.FindModel(field.Type.ModelName.Value)
+
+		// v.sql = `(SELECT "product"."standard_price" FROM "product" WHERE "product"."id" IS NOT DISTINCT FROM r."product_id" ) * r."quantity"`
+		// return nil
+		fieldName := ident.Fragments[len(ident.Fragments)-1]
+
+		query := NewQuery(model, WithValuesAsArgs(false))
+
+		//	fg := ident.Fragments[1:]
+		err := query.AddJoinFromFragments(v.schema, ident.Fragments[1:])
+		if err != nil {
+			return err
+		}
+		m := ident.Fragments[1 : len(ident.Fragments)-1]
+		query.Select(ExpressionField(m, fieldName, false))
+
+		err = query.Where(IdField(), Equals, Raw("r.\"product_id\""))
+		if err != nil {
+			return err
+		}
+
+		stmt := query.SelectStatement()
+
+		v.sql += fmt.Sprintf("(%s)", stmt.SqlTemplate())
+	}
 	return nil
 }
 

--- a/runtime/actions/generate_computed.go
+++ b/runtime/actions/generate_computed.go
@@ -110,7 +110,7 @@ func (v *computedQueryGen) VisitIdent(ident *parser.ExpressionIdent) error {
 	} else if len(ident.Fragments) > 2 {
 		// Join together all the tables based on the ident fragments
 		model = v.schema.FindModel(field.Type.ModelName.Value)
-		query := NewQuery(model, WithValuesAsArgs(false))
+		query := NewQuery(model)
 		err := query.AddJoinFromFragments(v.schema, ident.Fragments[1:])
 		if err != nil {
 			return err

--- a/runtime/actions/generate_computed.go
+++ b/runtime/actions/generate_computed.go
@@ -3,8 +3,6 @@ package actions
 import (
 	"errors"
 	"fmt"
-	"regexp"
-	"strings"
 
 	"github.com/google/cel-go/common/operators"
 	"github.com/iancoleman/strcase"
@@ -110,29 +108,29 @@ func (v *computedQueryGen) VisitIdent(ident *parser.ExpressionIdent) error {
 	if len(ident.Fragments) == 2 {
 		v.sql += "r." + sqlQuote(strcase.ToSnake(field.Name))
 	} else if len(ident.Fragments) > 2 {
+		// Join together all the tables based on the ident fragments
 		model = v.schema.FindModel(field.Type.ModelName.Value)
-
-		// v.sql = `(SELECT "product"."standard_price" FROM "product" WHERE "product"."id" IS NOT DISTINCT FROM r."product_id" ) * r."quantity"`
-		// return nil
-		fieldName := ident.Fragments[len(ident.Fragments)-1]
-
 		query := NewQuery(model, WithValuesAsArgs(false))
-
-		//	fg := ident.Fragments[1:]
 		err := query.AddJoinFromFragments(v.schema, ident.Fragments[1:])
 		if err != nil {
 			return err
 		}
-		m := ident.Fragments[1 : len(ident.Fragments)-1]
-		query.Select(ExpressionField(m, fieldName, false))
 
-		err = query.Where(IdField(), Equals, Raw("r.\"product_id\""))
+		// Select the column as specified in the last ident fragment
+		fieldName := ident.Fragments[len(ident.Fragments)-1]
+		fragments := ident.Fragments[1 : len(ident.Fragments)-1]
+		query.Select(ExpressionField(fragments, fieldName, false))
+
+		// Filter by this model's row's ID
+		relatedModelField := proto.FindField(v.schema.Models, v.model.Name, ident.Fragments[1])
+		foreignKeyField := proto.GetForeignKeyFieldName(v.schema.Models, relatedModelField)
+		fk := fmt.Sprintf("r.\"%s\"", strcase.ToSnake(foreignKeyField))
+		err = query.Where(IdField(), Equals, Raw(fk))
 		if err != nil {
 			return err
 		}
 
 		stmt := query.SelectStatement()
-
 		v.sql += fmt.Sprintf("(%s)", stmt.SqlTemplate())
 	}
 	return nil
@@ -143,7 +141,5 @@ func (v *computedQueryGen) VisitIdentArray(idents []*parser.ExpressionIdent) err
 }
 
 func (v *computedQueryGen) Result() (string, error) {
-	// Remove multiple whitespaces and trim
-	re := regexp.MustCompile(`\s+`)
-	return re.ReplaceAllString(strings.TrimSpace(v.sql), " "), nil
+	return cleanSql(v.sql), nil
 }

--- a/runtime/actions/generate_filter.go
+++ b/runtime/actions/generate_filter.go
@@ -39,7 +39,7 @@ type whereQueryGen struct {
 	operands  *arraystack.Stack
 }
 
-func (v *whereQueryGen) StartCondition(nested bool) error {
+func (v *whereQueryGen) StartTerm(nested bool) error {
 	if op, ok := v.operators.Peek(); ok && op == Not {
 		_, _ = v.operators.Pop()
 		v.query.Not()
@@ -53,7 +53,7 @@ func (v *whereQueryGen) StartCondition(nested bool) error {
 	return nil
 }
 
-func (v *whereQueryGen) EndCondition(nested bool) error {
+func (v *whereQueryGen) EndTerm(nested bool) error {
 	if _, ok := v.operators.Peek(); ok && v.operands.Size() == 2 {
 		operator, _ := v.operators.Pop()
 

--- a/runtime/actions/generate_select.go
+++ b/runtime/actions/generate_select.go
@@ -34,11 +34,11 @@ type setQueryGen struct {
 	inputs  map[string]any
 }
 
-func (v *setQueryGen) StartCondition(parenthesis bool) error {
+func (v *setQueryGen) StartTerm(parenthesis bool) error {
 	return nil
 }
 
-func (v *setQueryGen) EndCondition(parenthesis bool) error {
+func (v *setQueryGen) EndTerm(parenthesis bool) error {
 	return nil
 }
 

--- a/runtime/actions/writeinputs.go
+++ b/runtime/actions/writeinputs.go
@@ -30,7 +30,7 @@ func (query *QueryBuilder) captureSetValues(scope *Scope, args map[string]any) e
 			return err
 		}
 
-		ident, err := normalisedFragments(scope.Schema, target.Fragments)
+		ident, err := NormalisedFragments(scope.Schema, target.Fragments)
 		if err != nil {
 			return err
 		}

--- a/schema/attributes/where.go
+++ b/schema/attributes/where.go
@@ -17,8 +17,6 @@ func ValidateWhereExpression(schema []*parser.AST, action *parser.ActionNode, ex
 		options.WithSchemaTypes(schema),
 		options.WithActionInputs(schema, action),
 		options.WithVariable(strcase.ToLowerCamel(model.Name.Value), model.Name.Value, false),
-		options.WithVariable("_", model.Name.Value, false),
-		options.WithConstant("$", model.Name.Value),
 		options.WithComparisonOperators(),
 		options.WithLogicalOperators(),
 		options.WithReturnTypeAssertion(parser.FieldTypeBoolean, false),

--- a/schema/attributes/where.go
+++ b/schema/attributes/where.go
@@ -17,6 +17,8 @@ func ValidateWhereExpression(schema []*parser.AST, action *parser.ActionNode, ex
 		options.WithSchemaTypes(schema),
 		options.WithActionInputs(schema, action),
 		options.WithVariable(strcase.ToLowerCamel(model.Name.Value), model.Name.Value, false),
+		options.WithVariable("_", model.Name.Value, false),
+		options.WithConstant("$", model.Name.Value),
 		options.WithComparisonOperators(),
 		options.WithLogicalOperators(),
 		options.WithReturnTypeAssertion(parser.FieldTypeBoolean, false),

--- a/schema/attributes/where_test.go
+++ b/schema/attributes/where_test.go
@@ -18,7 +18,7 @@ func TestWhere_Valid(t *testing.T) {
 			}
 			actions {
 				list listPeople(name) {
-					@where(person.name == "Keel")
+					@where(_.name == "Keel")
 				}
 			}
 		}`})

--- a/schema/attributes/where_test.go
+++ b/schema/attributes/where_test.go
@@ -18,7 +18,7 @@ func TestWhere_Valid(t *testing.T) {
 			}
 			actions {
 				list listPeople(name) {
-					@where(_.name == "Keel")
+					@where(person.name == "Keel")
 				}
 			}
 		}`})


### PR DESCRIPTION
`@computed` and M:1 relationships
===

This PR provides support for referencing fields in a M:1 relationship in a `@computed`  expressions.  For example:

```
model Item {
    fields {
        quantity Number
        product Product
        total Decimal @computed(item.quantity * item.product.price)
    }
}

model Product {
    fields {
        name Text
        price Decimal
    }
}
````