### PR TITLE
fix: default cannot be used on computed fields

### DIFF
--- a/schema/testdata/errors/attribute_computed.keel
+++ b/schema/testdata/errors/attribute_computed.keel
@@ -13,6 +13,8 @@ model Item {
         password Password @computed("password")
         //expect-error:23:42:AttributeNotAllowedError:@computed cannot be used on field of type Secret
         secret Secret @computed("secret")
+        //expect-error:28:39:AttributeExpressionError:@default cannot be used with computed fields
+        withDefault Number @default(1) @computed(1 + 1)
     }
     actions {
         get getItem(id) {

--- a/schema/testdata/errors/enum_default_no_expression.keel
+++ b/schema/testdata/errors/enum_default_no_expression.keel
@@ -1,6 +1,6 @@
 model Post {
     fields {
-        //expect-error:23:31:AttributeArgumentError:default requires an expression
+        //expect-error:23:31:AttributeArgumentError:@default requires an expression
         type PostType @default
     }
 }

--- a/schema/validation/default_attribute.go
+++ b/schema/validation/default_attribute.go
@@ -25,12 +25,25 @@ func DefaultAttributeExpressionRules(asts []*parser.AST, errs *errorhandling.Val
 				return
 			}
 
+			for _, attr := range field.Attributes {
+				if attr.Name.Value == parser.AttributeComputed {
+					errs.AppendError(errorhandling.NewValidationErrorWithDetails(
+						errorhandling.AttributeExpressionError,
+						errorhandling.ErrorDetails{
+							Message: "@default cannot be used with computed fields",
+							Hint:    "Either remove the @default attribute or remove the @computed attribute",
+						},
+						a,
+					))
+				}
+			}
+
 			typesWithZeroValue := []string{"Text", "Number", "Boolean", "ID", "Timestamp"}
 			if len(a.Arguments) == 0 && !lo.Contains(typesWithZeroValue, field.Type.Value) {
 				errs.AppendError(errorhandling.NewValidationErrorWithDetails(
 					errorhandling.AttributeArgumentError,
 					errorhandling.ErrorDetails{
-						Message: "default requires an expression",
+						Message: "@default requires an expression",
 						Hint:    "Try @default(MyDefaultValue) instead",
 					},
 					a,


### PR DESCRIPTION
Validation against using `@default` and `@computed` together