### PR TITLE
fix: set the default intervalstyle for all db connections

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -68,6 +68,11 @@ func New(ctx context.Context, connString string) (Database, error) {
 		return nil, err
 	}
 
+	// setting default intervalstyle to ISO_8601 for this connection.
+	if err := db.Exec(`SET "intervalstyle" = "iso_8601";`).Error; err != nil {
+		return nil, err
+	}
+
 	return &GormDB{db: db}, nil
 }
 

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -112,9 +112,6 @@ func (m *Migrations) Apply(ctx context.Context, dryRun bool) error {
 	sql.WriteString("CREATE TABLE IF NOT EXISTS keel_schema (schema TEXT NOT NULL);\n")
 	sql.WriteString("DELETE FROM keel_schema;\n")
 
-	// Interval output format
-	sql.WriteString("SET intervalstyle = \"iso_8601\";\n")
-
 	b, err := protojson.Marshal(m.Schema)
 	if err != nil {
 		return err


### PR DESCRIPTION
Setting the `intervalstyle` output as part of the migrations would not set it for subsequent db connections, as the `intervalstyle` option is a connection configuration which gets reset to the default `postgres` value on later new connections.