### PR TITLE
fix: bug with computed and one to one

### DIFF
--- a/integration/testdata/computed_fields_one_to_one/schema.keel
+++ b/integration/testdata/computed_fields_one_to_one/schema.keel
@@ -1,12 +1,12 @@
 model Company {
     fields {
-        companyProfile CompanyProfile @unique
-        activeEmployees Number @computed(company.companyProfile.employeeCount - company.retrenchments)
+        companyProf CompanyProfile @unique
+        activeEmployees Number @computed(company.companyProf.employeeCount - company.retrenchments)
         retrenchments Number @default(0)
-        taxNumber Number? @computed(company.companyProfile.taxProfile.taxNumber)
+        taxNumber Number? @computed(company.companyProf.taxProf.taxNumber)
     }
     actions {
-        create createCompany() with (companyProfile.id, retrenchments) {
+        create createCompany() with (companyProf.id, retrenchments) {
             @permission(expression: true)
         }
     }
@@ -15,11 +15,11 @@ model Company {
 model CompanyProfile {
     fields {
         employeeCount Number
-        taxProfile TaxProfile? @unique
+        taxProf TaxProfile? @unique
         company Company
     }
     actions {
-        create createCompanyProfile() with (employeeCount, taxProfile.id) {
+        create createCompanyProfile() with (employeeCount, taxProf.id) {
             @permission(expression: true)
         }
     }

--- a/integration/testdata/computed_fields_one_to_one/tests.test.ts
+++ b/integration/testdata/computed_fields_one_to_one/tests.test.ts
@@ -7,10 +7,10 @@ test("computed fields - one to one", async () => {
   const taxProfile = await actions.createTaxProfile({ taxNumber: 1234567890 });
   const companyProfile = await actions.createCompanyProfile({
     employeeCount: 100,
-    taxProfile: { id: taxProfile.id },
+    taxProf: { id: taxProfile.id },
   });
   const company = await actions.createCompany({
-    companyProfile: { id: companyProfile.id },
+    companyProf: { id: companyProfile.id },
     retrenchments: 8,
   });
   expect(company.activeEmployees).toEqual(92);

--- a/integration/testdata/computed_fields_self_referencing/main.test.ts
+++ b/integration/testdata/computed_fields_self_referencing/main.test.ts
@@ -1,0 +1,26 @@
+import { test, expect, beforeEach } from "vitest";
+import { models, resetDatabase, actions } from "@teamkeel/testing";
+
+beforeEach(resetDatabase);
+
+test("computed fields - self referencing", async () => {
+  const car = await actions.createCar({});
+
+  const mileage1 = await actions.createMileage({
+    car: { id: car.id },
+    miles: 100,
+    date: new Date(),
+    previous: null,
+  });
+
+  expect(mileage1.diffFromPrevious).toBe(null);
+
+  const mileage2 = await actions.createMileage({
+    car: { id: car.id },
+    miles: 155,
+    date: new Date(),
+    previous: { id: mileage1.id },
+  });
+
+  expect(mileage2.diffFromPrevious).toBe(55);
+});

--- a/integration/testdata/computed_fields_self_referencing/schema.keel
+++ b/integration/testdata/computed_fields_self_referencing/schema.keel
@@ -1,0 +1,28 @@
+model Car {
+    fields {
+        logs Mileage[]
+    }
+    actions {
+        create createCar() {
+            @permission(expression: true)
+        }
+        get getCar(id) {
+            @permission(expression: true)
+        }
+    }
+}
+
+model Mileage {
+    fields {
+        car Car
+        miles Number
+        date Date
+        previous Mileage?
+        diffFromPrevious Number? @computed(mileage.miles - mileage.previous.miles)
+    }
+    actions {
+        create createMileage() with (car.id, miles, date, previous.id) {
+            @permission(expression: true)
+        }
+    }
+}

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -761,10 +761,6 @@ func computedFieldsStmts(schema *proto.Schema, existingComputedFns []*FunctionRo
 		statements = append(statements, sql)
 	}
 
-	for _, s := range statements {
-		fmt.Println(s)
-	}
-
 	return
 }
 

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -761,6 +761,10 @@ func computedFieldsStmts(schema *proto.Schema, existingComputedFns []*FunctionRo
 		statements = append(statements, sql)
 	}
 
+	for _, s := range statements {
+		fmt.Println(s)
+	}
+
 	return
 }
 

--- a/runtime/actions/generate_computed.go
+++ b/runtime/actions/generate_computed.go
@@ -205,7 +205,6 @@ func (v *computedQueryGen) VisitIdent(ident *parser.ExpressionIdent) error {
 			query.Select(ExpressionField(fragments, fieldName, false))
 
 			// Filter by this model's row's ID
-			//relatedModelField := proto.FindField(v.schema.Models, v.model.Name, r.Name)
 			foreignKeyField := proto.GetForeignKeyFieldName(v.schema.Models, relatedModelField)
 
 			fk := fmt.Sprintf("r.\"%s\"", strcase.ToSnake(foreignKeyField))


### PR DESCRIPTION
Fixing the bug that Radu found when using a field name referencing a model which has a different name to the model.