### PR TITLE
fix: required computed fields and null constraint

### DIFF
--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -297,10 +297,7 @@ func New(ctx context.Context, schema *proto.Schema, database db.Database) (*Migr
 					statements = append(statements, fkConstraint(field, model))
 				}
 				continue
-			} //else if column.NotNull && field.Optional && !field.Optional {
-
-			//statements = append(statements, fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s DROP NOT NULL;", Identifier(model.Name), Identifier(field.Name)))
-			//}
+			}
 
 			// Column already exists - see if any changes need to be applied
 			hasChanged := false
@@ -401,15 +398,11 @@ func New(ctx context.Context, schema *proto.Schema, database db.Database) (*Migr
 		changes = append(changes, computedChanges...)
 	}
 
-	// Add any new models
+	// For required computed fields, we need to set the NOT NULL constraint as this was deferred
+	// to the end of the migration because we may have needed to populate existing rows first.
 	for _, modelName := range modelNames {
 		model := schema.FindModel(modelName)
 		for _, field := range model.Fields {
-			// Add any new models
-			// col, exists := lo.Find(columns, func(c *ColumnRow) bool {
-			// 	return c.TableName == casing.ToSnake(model.Name) && c.ColumnName == casing.ToSnake(field.Name)
-			// })
-
 			column, has := lo.Find(columns, func(c *ColumnRow) bool {
 				return c.TableName == casing.ToSnake(model.Name) && c.ColumnName == casing.ToSnake(field.Name)
 			})
@@ -420,12 +413,6 @@ func New(ctx context.Context, schema *proto.Schema, database db.Database) (*Migr
 
 			if !has {
 				statements = append(statements, fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s SET NOT NULL;", Identifier(model.Name), Identifier(field.Name)))
-
-				// changes = append(changes, &DatabaseChange{
-				// 	Model: model.Name,
-				// 	Field: field.Name,
-				// 	Type:  ChangeTypeModified,
-				// })
 				continue
 			}
 
@@ -442,30 +429,9 @@ func New(ctx context.Context, schema *proto.Schema, database db.Database) (*Migr
 					Field: field.Name,
 					Type:  ChangeTypeModified,
 				})
-
 			}
 		}
 	}
-
-	// // For required computed fields in new models, we need to set the NOT NULL constraint which has been deferred
-	// for _, m := range modelsAdded {
-	// 	for _, f := range m.Fields {
-	// 		if f.ComputedExpression != nil && !f.Optional {
-	// 			statements = append(statements, fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s SET NOT NULL;", Identifier(m.Name), Identifier(f.Name)))
-	// 		}
-	// 	}
-	// }
-
-	// // For required computed fields added to existing models, we need to set the NOT NULL constraint which has been deferred
-	// for _, change := range computedChanges {
-	// 	if (change.Type == ChangeTypeAdded || change.Type == ChangeTypeModified) && change.Model != "" && change.Field != "" {
-	// 		f := proto.FindField(schema.Models, change.Model, change.Field)
-	// 		if !f.Optional && f.ComputedExpression != nil {
-	// 			setNotNullStmt := fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s SET NOT NULL;", Identifier(change.Model), Identifier(change.Field))
-	// 			statements = append(statements, setNotNullStmt)
-	// 		}
-	// 	}
-	// }
 
 	stringChanges := lo.Map(changes, func(c *DatabaseChange, _ int) string { return c.String() })
 	span.SetAttributes(attribute.StringSlice("migration", stringChanges))
@@ -588,7 +554,7 @@ func computedFieldsStmts(schema *proto.Schema, existingComputedFns []*FunctionRo
 	fns := map[string]string{}
 	fieldsFns := map[*proto.Field]string{}
 	changedFields := map[*proto.Field]bool{}
-	recompute := map[*proto.Model][]*proto.Field{}
+	recompute := []*proto.Model{}
 
 	// Adding computed field triggers and functions
 	for _, model := range schema.Models {
@@ -627,8 +593,8 @@ func computedFieldsStmts(schema *proto.Schema, existingComputedFns []*FunctionRo
 			})
 			changedFields[f] = true
 
-			if !lo.Contains(recompute[model], f) {
-				recompute[model] = append(recompute[model], f)
+			if !lo.Contains(recompute, model) {
+				recompute = append(recompute, model)
 			}
 		}
 
@@ -826,26 +792,10 @@ func computedFieldsStmts(schema *proto.Schema, existingComputedFns []*FunctionRo
 
 	// If a computed field has been added or modified, we need to recompute all existing data.
 	// This is done by fake updating each row on the table which will cause the triggers to run.
-	for m, _ := range recompute {
-
-		sql := fmt.Sprintf("UPDATE \"%s\" SET id = id;", strcase.ToSnake(m.Name))
+	for _, model := range recompute {
+		sql := fmt.Sprintf("UPDATE \"%s\" SET id = id;", strcase.ToSnake(model.Name))
 		statements = append(statements, sql)
-
-		// First, set
-		// for _, f := range fields {
-		// 	if !f.Optional {
-		// 		setNotNullStmt := fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s DROP NOT NULL;", Identifier(m.Name), Identifier(f.Name))
-		// 		statements = append(statements, setNotNullStmt)
-		// 	}
-		// }
 	}
-	// 	for _, f := range fields {
-	// 		if !f.Optional {
-	// 			setNotNullStmt := fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s SET NOT NULL;", Identifier(m.Name), Identifier(f.Name))
-	// 			statements = append(statements, setNotNullStmt)
-	// 		}
-	// 	}
-	// }
 
 	return
 }

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -46,6 +46,10 @@ func TestMigrations(t *testing.T) {
 	}()
 
 	for _, testCase := range testCases {
+		if testCase.Name() != "computed_field_changed_expression.txt" {
+			continue
+		}
+
 		t.Run(strings.TrimSuffix(testCase.Name(), ".txt"), func(t *testing.T) {
 			// Make a database name for this test
 			re := regexp.MustCompile(`[^\w]`)

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -46,10 +46,6 @@ func TestMigrations(t *testing.T) {
 	}()
 
 	for _, testCase := range testCases {
-		if testCase.Name() != "computed_field_changed_expression.txt" {
-			continue
-		}
-
 		t.Run(strings.TrimSuffix(testCase.Name(), ".txt"), func(t *testing.T) {
 			// Make a database name for this test
 			re := regexp.MustCompile(`[^\w]`)

--- a/migrations/sql.go
+++ b/migrations/sql.go
@@ -207,11 +207,9 @@ func alterColumnStmt(modelName string, field *proto.Field, column *ColumnRow) (s
 		}
 	}
 
-	// if field.ComputedExpression != nil {
-	// 	stmts = append(stmts, fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s DROP NOT NULL;", Identifier(modelName), Identifier(column.ColumnName)))
+	// these two flags are opposites of each other, so if they are both true
+	// or both false then there is a change to be applied
 	if field.Optional == column.NotNull {
-		// these two flags are opposites of each other, so if they are both true
-		// or both false then there is a change to be applied
 		var change string
 		if field.Optional && column.NotNull {
 			change = "DROP NOT NULL"

--- a/migrations/sql.go
+++ b/migrations/sql.go
@@ -207,14 +207,20 @@ func alterColumnStmt(modelName string, field *proto.Field, column *ColumnRow) (s
 		}
 	}
 
-	// these two flags are opposites of each other, so if they are both true
-	// or both false then there is a change to be applied
+	// if field.ComputedExpression != nil {
+	// 	stmts = append(stmts, fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s DROP NOT NULL;", Identifier(modelName), Identifier(column.ColumnName)))
 	if field.Optional == column.NotNull {
+		// these two flags are opposites of each other, so if they are both true
+		// or both false then there is a change to be applied
 		var change string
 		if field.Optional && column.NotNull {
 			change = "DROP NOT NULL"
 		} else {
-			change = "SET NOT NULL"
+			// If computed, then we don't set the NOT NULL constraint yet
+			// This is because we may still need to populate existing rows
+			if field.ComputedExpression == nil {
+				change = "SET NOT NULL"
+			}
 
 			// Update all existing rows to the default value if they are null
 			if field.DefaultValue != nil {
@@ -226,7 +232,9 @@ func alterColumnStmt(modelName string, field *proto.Field, column *ColumnRow) (s
 				stmts = append(stmts, update)
 			}
 		}
-		stmts = append(stmts, fmt.Sprintf("%s %s;", alterColumnStmtPrefix, change))
+		if change != "" {
+			stmts = append(stmts, fmt.Sprintf("%s %s;", alterColumnStmtPrefix, change))
+		}
 	}
 
 	return strings.Join(stmts, "\n"), nil
@@ -329,7 +337,9 @@ func fieldDefinition(field *proto.Field) (string, error) {
 
 	output := fmt.Sprintf("%s %s", columnName, fieldType)
 
-	if !field.Optional {
+	// If computed, then we don't set the NOT NULL constraint yet
+	// This is because we may still need to populate existing rows
+	if !field.Optional && field.ComputedExpression == nil {
 		output += " NOT NULL"
 	}
 

--- a/migrations/testdata/computed_field_add_required.txt
+++ b/migrations/testdata/computed_field_add_required.txt
@@ -2,7 +2,6 @@ model Item {
     fields {
         price Decimal
         quantity Number
-        total Decimal @computed(item.quantity * item.price)
     }
 }
 
@@ -12,25 +11,26 @@ model Item {
     fields {
         price Decimal
         quantity Number
-        total Decimal @computed(item.price + 5)
+        total Decimal @computed(item.quantity * item.price)
     }
 }
 
 ===
 
-CREATE FUNCTION "item__total__863346d0__comp"(r "item") RETURNS NUMERIC AS $$ BEGIN
-	RETURN r."price" + 5;
+ALTER TABLE "item" ADD COLUMN "total" NUMERIC;
+CREATE FUNCTION "item__total__0614a79a__comp"(r "item") RETURNS NUMERIC AS $$ BEGIN
+	RETURN r."quantity" * r."price";
 END; $$ LANGUAGE plpgsql;
-DROP FUNCTION "item__total__0614a79a__comp";
 CREATE OR REPLACE FUNCTION "item__exec_comp_fns"() RETURNS TRIGGER AS $$ BEGIN
-	NEW.total := item__total__863346d0__comp(NEW);
+	NEW.total := item__total__0614a79a__comp(NEW);
 	RETURN NEW;
 END; $$ LANGUAGE plpgsql;
 CREATE OR REPLACE TRIGGER "item__comp" BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE "item__exec_comp_fns"();
 UPDATE "item" SET id = id;
+ALTER TABLE "item" ALTER COLUMN "total" SET NOT NULL;
 
 ===
 
 [
-    {"Model":"Item","Field":"total","Type":"MODIFIED"}
+    {"Model":"Item","Field":"total","Type":"ADDED"}
 ]

--- a/migrations/testdata/computed_field_add_required.txt
+++ b/migrations/testdata/computed_field_add_required.txt
@@ -22,7 +22,7 @@ CREATE FUNCTION "item__total__0614a79a__comp"(r "item") RETURNS NUMERIC AS $$ BE
 	RETURN r."quantity" * r."price";
 END; $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION "item__exec_comp_fns"() RETURNS TRIGGER AS $$ BEGIN
-	NEW.total := item__total__0614a79a__comp(NEW);
+	NEW."total" := item__total__0614a79a__comp(NEW);
 	RETURN NEW;
 END; $$ LANGUAGE plpgsql;
 CREATE OR REPLACE TRIGGER "item__comp" BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE "item__exec_comp_fns"();

--- a/migrations/testdata/computed_field_changed_expression.txt
+++ b/migrations/testdata/computed_field_changed_expression.txt
@@ -23,7 +23,7 @@ CREATE FUNCTION "item__total__863346d0__comp"(r "item") RETURNS NUMERIC AS $$ BE
 END; $$ LANGUAGE plpgsql;
 DROP FUNCTION "item__total__0614a79a__comp";
 CREATE OR REPLACE FUNCTION "item__exec_comp_fns"() RETURNS TRIGGER AS $$ BEGIN
-	NEW.total := item__total__863346d0__comp(NEW);
+	NEW."total" := item__total__863346d0__comp(NEW);
 	RETURN NEW;
 END; $$ LANGUAGE plpgsql;
 CREATE OR REPLACE TRIGGER "item__comp" BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE "item__exec_comp_fns"();

--- a/migrations/testdata/computed_field_changed_expression.txt
+++ b/migrations/testdata/computed_field_changed_expression.txt
@@ -18,6 +18,7 @@ model Item {
 
 ===
 
+ALTER TABLE "item" ALTER COLUMN "total" SET NOT NULL;
 CREATE FUNCTION "item__total__863346d0__comp"(r "item") RETURNS NUMERIC AS $$ BEGIN
 	RETURN r."price" + 5;
 END; $$ LANGUAGE plpgsql;

--- a/migrations/testdata/computed_field_changed_to_computed.txt
+++ b/migrations/testdata/computed_field_changed_to_computed.txt
@@ -2,7 +2,7 @@ model Item {
     fields {
         price Decimal
         quantity Number
-        total Decimal @computed(item.quantity * item.price)
+        total Decimal? 
     }
 }
 
@@ -12,22 +12,22 @@ model Item {
     fields {
         price Decimal
         quantity Number
-        total Decimal @computed(item.price + 5)
+        total Decimal @computed(item.quantity * item.price)
     }
 }
 
 ===
 
-CREATE FUNCTION "item__total__863346d0__comp"(r "item") RETURNS NUMERIC AS $$ BEGIN
-	RETURN r."price" + 5;
+CREATE FUNCTION "item__total__0614a79a__comp"(r "item") RETURNS NUMERIC AS $$ BEGIN
+	RETURN r."quantity" * r."price";
 END; $$ LANGUAGE plpgsql;
-DROP FUNCTION "item__total__0614a79a__comp";
 CREATE OR REPLACE FUNCTION "item__exec_comp_fns"() RETURNS TRIGGER AS $$ BEGIN
-	NEW.total := item__total__863346d0__comp(NEW);
+	NEW.total := item__total__0614a79a__comp(NEW);
 	RETURN NEW;
 END; $$ LANGUAGE plpgsql;
 CREATE OR REPLACE TRIGGER "item__comp" BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE "item__exec_comp_fns"();
 UPDATE "item" SET id = id;
+ALTER TABLE "item" ALTER COLUMN "total" SET NOT NULL;
 
 ===
 

--- a/migrations/testdata/computed_field_changed_to_computed.txt
+++ b/migrations/testdata/computed_field_changed_to_computed.txt
@@ -22,7 +22,7 @@ CREATE FUNCTION "item__total__0614a79a__comp"(r "item") RETURNS NUMERIC AS $$ BE
 	RETURN r."quantity" * r."price";
 END; $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION "item__exec_comp_fns"() RETURNS TRIGGER AS $$ BEGIN
-	NEW.total := item__total__0614a79a__comp(NEW);
+	NEW."total" := item__total__0614a79a__comp(NEW);
 	RETURN NEW;
 END; $$ LANGUAGE plpgsql;
 CREATE OR REPLACE TRIGGER "item__comp" BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE "item__exec_comp_fns"();

--- a/migrations/testdata/computed_field_changed_to_required.txt
+++ b/migrations/testdata/computed_field_changed_to_required.txt
@@ -2,7 +2,7 @@ model Item {
     fields {
         price Decimal
         quantity Number
-        total Decimal @computed(item.quantity * item.price)
+        total Decimal? 
     }
 }
 
@@ -12,22 +12,22 @@ model Item {
     fields {
         price Decimal
         quantity Number
-        total Decimal @computed(item.price + 5)
+        total Decimal @computed(item.quantity * item.price)
     }
 }
 
 ===
 
-CREATE FUNCTION "item__total__863346d0__comp"(r "item") RETURNS NUMERIC AS $$ BEGIN
-	RETURN r."price" + 5;
+CREATE FUNCTION "item__total__0614a79a__comp"(r "item") RETURNS NUMERIC AS $$ BEGIN
+	RETURN r."quantity" * r."price";
 END; $$ LANGUAGE plpgsql;
-DROP FUNCTION "item__total__0614a79a__comp";
 CREATE OR REPLACE FUNCTION "item__exec_comp_fns"() RETURNS TRIGGER AS $$ BEGIN
-	NEW.total := item__total__863346d0__comp(NEW);
+	NEW.total := item__total__0614a79a__comp(NEW);
 	RETURN NEW;
 END; $$ LANGUAGE plpgsql;
 CREATE OR REPLACE TRIGGER "item__comp" BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE "item__exec_comp_fns"();
 UPDATE "item" SET id = id;
+ALTER TABLE "item" ALTER COLUMN "total" SET NOT NULL;
 
 ===
 

--- a/migrations/testdata/computed_field_changed_to_required.txt
+++ b/migrations/testdata/computed_field_changed_to_required.txt
@@ -22,7 +22,7 @@ CREATE FUNCTION "item__total__0614a79a__comp"(r "item") RETURNS NUMERIC AS $$ BE
 	RETURN r."quantity" * r."price";
 END; $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION "item__exec_comp_fns"() RETURNS TRIGGER AS $$ BEGIN
-	NEW.total := item__total__0614a79a__comp(NEW);
+	NEW."total" := item__total__0614a79a__comp(NEW);
 	RETURN NEW;
 END; $$ LANGUAGE plpgsql;
 CREATE OR REPLACE TRIGGER "item__comp" BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE "item__exec_comp_fns"();

--- a/migrations/testdata/computed_field_initial.txt
+++ b/migrations/testdata/computed_field_initial.txt
@@ -36,7 +36,7 @@ ALTER TABLE "identity" ADD CONSTRAINT identity_email_issuer_udx UNIQUE ("email",
 CREATE TABLE "item" (
 "price" NUMERIC NOT NULL,
 "quantity" INTEGER NOT NULL,
-"total" NUMERIC NOT NULL,
+"total" NUMERIC,
 "id" TEXT NOT NULL DEFAULT ksuid(),
 "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
 "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now()
@@ -70,6 +70,7 @@ CREATE OR REPLACE FUNCTION "item__exec_comp_fns"() RETURNS TRIGGER AS $$ BEGIN
 END; $$ LANGUAGE plpgsql;
 CREATE OR REPLACE TRIGGER "item__comp" BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE "item__exec_comp_fns"();
 UPDATE "item" SET id = id;
+ALTER TABLE "item" ALTER COLUMN "total" SET NOT NULL;
 
 ===
 

--- a/migrations/testdata/computed_field_initial.txt
+++ b/migrations/testdata/computed_field_initial.txt
@@ -65,7 +65,7 @@ CREATE FUNCTION "item__total__0614a79a__comp"(r "item") RETURNS NUMERIC AS $$ BE
 	RETURN r."quantity" * r."price";
 END; $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION "item__exec_comp_fns"() RETURNS TRIGGER AS $$ BEGIN
-	NEW.total := item__total__0614a79a__comp(NEW);
+	NEW."total" := item__total__0614a79a__comp(NEW);
 	RETURN NEW;
 END; $$ LANGUAGE plpgsql;
 CREATE OR REPLACE TRIGGER "item__comp" BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE "item__exec_comp_fns"();

--- a/migrations/testdata/computed_field_many_to_one.txt
+++ b/migrations/testdata/computed_field_many_to_one.txt
@@ -103,27 +103,27 @@ CREATE FUNCTION "item__total__8f543d38__comp"(r "item") RETURNS NUMERIC AS $$ BE
 	RETURN r."quantity" * (SELECT "product"."price" FROM "product" WHERE "product"."id" IS NOT DISTINCT FROM r."product_id") + (SELECT "product$agent"."commission" FROM "product" LEFT JOIN "agent" AS "product$agent" ON "product$agent"."id" = "product"."agent_id" WHERE "product"."id" IS NOT DISTINCT FROM r."product_id");
 END; $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION "item__exec_comp_fns"() RETURNS TRIGGER AS $$ BEGIN
-	NEW.total := item__total__8f543d38__comp(NEW);
+	NEW."total" := item__total__8f543d38__comp(NEW);
 	RETURN NEW;
 END; $$ LANGUAGE plpgsql;
 CREATE OR REPLACE TRIGGER "item__comp" BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE "item__exec_comp_fns"();
 CREATE OR REPLACE FUNCTION "agent__to__product__2eb4dbe9__comp_dep"() RETURNS TRIGGER AS $$
 BEGIN
-	UPDATE "product" SET id = id WHERE agent_id IN (NEW.id, OLD.id);
+	UPDATE "product" SET id = id WHERE "agent_id" IN (NEW.id, OLD.id);
 	RETURN NULL;
 END; $$ LANGUAGE plpgsql;
 CREATE OR REPLACE TRIGGER "agent__to__product__2eb4dbe9__comp_dep" AFTER INSERT OR DELETE ON "agent" FOR EACH ROW EXECUTE PROCEDURE "agent__to__product__2eb4dbe9__comp_dep"();
-CREATE OR REPLACE TRIGGER "agent__to__product__2eb4dbe9__comp_dep_update" AFTER UPDATE ON "agent" FOR EACH ROW WHEN(NEW.commission IS DISTINCT FROM OLD.commission) EXECUTE PROCEDURE "agent__to__product__2eb4dbe9__comp_dep"();
+CREATE OR REPLACE TRIGGER "agent__to__product__2eb4dbe9__comp_dep_update" AFTER UPDATE ON "agent" FOR EACH ROW WHEN(NEW."commission" IS DISTINCT FROM OLD."commission") EXECUTE PROCEDURE "agent__to__product__2eb4dbe9__comp_dep"();
 CREATE OR REPLACE FUNCTION "product__to__item__037dbf3a__comp_dep"() RETURNS TRIGGER AS $$
 BEGIN
-	UPDATE "item" SET id = id WHERE product_id IN (NEW.id, OLD.id);
+	UPDATE "item" SET id = id WHERE "product_id" IN (NEW.id, OLD.id);
 	RETURN NULL;
 END; $$ LANGUAGE plpgsql;
 CREATE OR REPLACE TRIGGER "product__to__item__037dbf3a__comp_dep" AFTER INSERT OR DELETE ON "product" FOR EACH ROW EXECUTE PROCEDURE "product__to__item__037dbf3a__comp_dep"();
-CREATE OR REPLACE TRIGGER "product__to__item__037dbf3a__comp_dep_update" AFTER UPDATE ON "product" FOR EACH ROW WHEN(NEW.price IS DISTINCT FROM OLD.price) EXECUTE PROCEDURE "product__to__item__037dbf3a__comp_dep"();
+CREATE OR REPLACE TRIGGER "product__to__item__037dbf3a__comp_dep_update" AFTER UPDATE ON "product" FOR EACH ROW WHEN(NEW."price" IS DISTINCT FROM OLD."price") EXECUTE PROCEDURE "product__to__item__037dbf3a__comp_dep"();
 CREATE OR REPLACE FUNCTION "product__to__item__2eb4dbe9__comp_dep"() RETURNS TRIGGER AS $$
 BEGIN
-	UPDATE "item" SET id = id WHERE product_id IN (NEW.id, OLD.id);
+	UPDATE "item" SET id = id WHERE "product_id" IN (NEW.id, OLD.id);
 	RETURN NULL;
 END; $$ LANGUAGE plpgsql;
 CREATE OR REPLACE TRIGGER "product__to__item__2eb4dbe9__comp_dep" AFTER INSERT OR DELETE ON "product" FOR EACH ROW EXECUTE PROCEDURE "product__to__item__2eb4dbe9__comp_dep"();

--- a/migrations/testdata/computed_field_many_to_one.txt
+++ b/migrations/testdata/computed_field_many_to_one.txt
@@ -56,7 +56,7 @@ ALTER TABLE "identity" ADD CONSTRAINT identity_email_issuer_udx UNIQUE ("email",
 CREATE TABLE "item" (
 "product_id" TEXT NOT NULL,
 "quantity" INTEGER NOT NULL,
-"total" NUMERIC NOT NULL,
+"total" NUMERIC,
 "id" TEXT NOT NULL DEFAULT ksuid(),
 "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
 "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now()
@@ -113,14 +113,14 @@ BEGIN
 	RETURN NULL;
 END; $$ LANGUAGE plpgsql;
 CREATE OR REPLACE TRIGGER "agent__to__product__2eb4dbe9__comp_dep" AFTER INSERT OR DELETE ON "agent" FOR EACH ROW EXECUTE PROCEDURE "agent__to__product__2eb4dbe9__comp_dep"();
-CREATE OR REPLACE TRIGGER "agent__to__product__2eb4dbe9__comp_dep_update" AFTER UPDATE ON "agent" FOR EACH ROW WHEN(NEW.commission <> OLD.commission) EXECUTE PROCEDURE "agent__to__product__2eb4dbe9__comp_dep"();
+CREATE OR REPLACE TRIGGER "agent__to__product__2eb4dbe9__comp_dep_update" AFTER UPDATE ON "agent" FOR EACH ROW WHEN(NEW.commission IS DISTINCT FROM OLD.commission) EXECUTE PROCEDURE "agent__to__product__2eb4dbe9__comp_dep"();
 CREATE OR REPLACE FUNCTION "product__to__item__037dbf3a__comp_dep"() RETURNS TRIGGER AS $$
 BEGIN
 	UPDATE "item" SET id = id WHERE product_id IN (NEW.id, OLD.id);
 	RETURN NULL;
 END; $$ LANGUAGE plpgsql;
 CREATE OR REPLACE TRIGGER "product__to__item__037dbf3a__comp_dep" AFTER INSERT OR DELETE ON "product" FOR EACH ROW EXECUTE PROCEDURE "product__to__item__037dbf3a__comp_dep"();
-CREATE OR REPLACE TRIGGER "product__to__item__037dbf3a__comp_dep_update" AFTER UPDATE ON "product" FOR EACH ROW WHEN(NEW.price <> OLD.price) EXECUTE PROCEDURE "product__to__item__037dbf3a__comp_dep"();
+CREATE OR REPLACE TRIGGER "product__to__item__037dbf3a__comp_dep_update" AFTER UPDATE ON "product" FOR EACH ROW WHEN(NEW.price IS DISTINCT FROM OLD.price) EXECUTE PROCEDURE "product__to__item__037dbf3a__comp_dep"();
 CREATE OR REPLACE FUNCTION "product__to__item__2eb4dbe9__comp_dep"() RETURNS TRIGGER AS $$
 BEGIN
 	UPDATE "item" SET id = id WHERE product_id IN (NEW.id, OLD.id);
@@ -129,6 +129,7 @@ END; $$ LANGUAGE plpgsql;
 CREATE OR REPLACE TRIGGER "product__to__item__2eb4dbe9__comp_dep" AFTER INSERT OR DELETE ON "product" FOR EACH ROW EXECUTE PROCEDURE "product__to__item__2eb4dbe9__comp_dep"();
 CREATE OR REPLACE TRIGGER "product__to__item__2eb4dbe9__comp_dep_update" AFTER UPDATE ON "product" FOR EACH ROW WHEN(TRUE) EXECUTE PROCEDURE "product__to__item__2eb4dbe9__comp_dep"();
 UPDATE "item" SET id = id;
+ALTER TABLE "item" ALTER COLUMN "total" SET NOT NULL;
 
 ===
 

--- a/migrations/testdata/computed_field_many_to_one_changed.txt
+++ b/migrations/testdata/computed_field_many_to_one_changed.txt
@@ -49,7 +49,7 @@ CREATE FUNCTION "item__total__5474c2e0__comp"(r "item") RETURNS NUMERIC AS $$ BE
 END; $$ LANGUAGE plpgsql;
 DROP FUNCTION "item__total__8f543d38__comp";
 CREATE OR REPLACE FUNCTION "item__exec_comp_fns"() RETURNS TRIGGER AS $$ BEGIN
-	NEW.total := item__total__5474c2e0__comp(NEW);
+	NEW."total" := item__total__5474c2e0__comp(NEW);
 	RETURN NEW;
 END; $$ LANGUAGE plpgsql;
 CREATE OR REPLACE TRIGGER "item__comp" BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE "item__exec_comp_fns"();

--- a/migrations/testdata/computed_field_multiple_depend.txt
+++ b/migrations/testdata/computed_field_multiple_depend.txt
@@ -28,8 +28,8 @@ CREATE FUNCTION "item__total_with_shipping__53d0d09b__comp"(r "item") RETURNS NU
 	RETURN r."total" + 5;
 END; $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION "item__exec_comp_fns"() RETURNS TRIGGER AS $$ BEGIN
-	NEW.total := item__total__0614a79a__comp(NEW);
-NEW.total_with_shipping := item__total_with_shipping__53d0d09b__comp(NEW);
+	NEW."total" := item__total__0614a79a__comp(NEW);
+	NEW."total_with_shipping" := item__total_with_shipping__53d0d09b__comp(NEW);
 	RETURN NEW;
 END; $$ LANGUAGE plpgsql;
 CREATE OR REPLACE TRIGGER "item__comp" BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE "item__exec_comp_fns"();

--- a/migrations/testdata/computed_field_renamed_field.txt
+++ b/migrations/testdata/computed_field_renamed_field.txt
@@ -25,7 +25,7 @@ CREATE FUNCTION "item__new_total__0614a79a__comp"(r "item") RETURNS NUMERIC AS $
 END; $$ LANGUAGE plpgsql;
 DROP FUNCTION "item__total__0614a79a__comp";
 CREATE OR REPLACE FUNCTION "item__exec_comp_fns"() RETURNS TRIGGER AS $$ BEGIN
-	NEW.new_total := item__new_total__0614a79a__comp(NEW);
+	NEW."new_total" := item__new_total__0614a79a__comp(NEW);
 	RETURN NEW;
 END; $$ LANGUAGE plpgsql;
 CREATE OR REPLACE TRIGGER "item__comp" BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE "item__exec_comp_fns"();

--- a/migrations/testdata/computed_field_renamed_field.txt
+++ b/migrations/testdata/computed_field_renamed_field.txt
@@ -18,7 +18,7 @@ model Item {
 
 ===
 
-ALTER TABLE "item" ADD COLUMN "new_total" NUMERIC NOT NULL;
+ALTER TABLE "item" ADD COLUMN "new_total" NUMERIC;
 ALTER TABLE "item" DROP COLUMN "total" CASCADE;
 CREATE FUNCTION "item__new_total__0614a79a__comp"(r "item") RETURNS NUMERIC AS $$ BEGIN
 	RETURN r."quantity" * r."price";
@@ -30,6 +30,7 @@ CREATE OR REPLACE FUNCTION "item__exec_comp_fns"() RETURNS TRIGGER AS $$ BEGIN
 END; $$ LANGUAGE plpgsql;
 CREATE OR REPLACE TRIGGER "item__comp" BEFORE INSERT OR UPDATE ON "item" FOR EACH ROW EXECUTE PROCEDURE "item__exec_comp_fns"();
 UPDATE "item" SET id = id;
+ALTER TABLE "item" ALTER COLUMN "new_total" SET NOT NULL;
 
 ===
 


### PR DESCRIPTION
Migrations for computed fields and NOT NULL
===

Previously, if a new _required_ computed field was added to a model or an existing field was made into a _required_ computed field, then there would be a NOT NULL constraint error from the database as existing rows would have that column set to NULL before the recomputing could occur.

This fixes the issue by deferring the NOT NULL constraint until after the recomputing is done.