### PR TITLE
fix: using 127.0.0.1 instead of 0.0.0.0

### DIFF
--- a/cmd/database/database.go
+++ b/cmd/database/database.go
@@ -246,7 +246,7 @@ func createContainer(dockerClient *client.Client) (
 	connInfo = &db.ConnectionInfo{
 		Username: "postgres",
 		Password: "postgres",
-		Host:     "0.0.0.0",
+		Host:     "127.0.0.1",
 		Port:     port,
 	}
 	return createdInfo.ID, connInfo, nil


### PR DESCRIPTION
I can't explain why this isn't working for one of our customers when using 0.0.0.0, however after some reading it seems 127.0.0.1 should actually be used when connecting from a client.

 > When connecting to a PostgreSQL instance running in Docker from the host machine, you should use 127.0.0.1 (localhost) rather than 0.0.0.0. Here's why:
> - 0.0.0.0 is a special IP address that means "all IPv4 addresses on the local machine" when used as a binding address for servers
> - 127.0.0.1 specifically refers to the loopback interface (localhost)
> - When connecting as a client, you want to specify the actual address you're connecting to, not a binding address