### PR TITLE
fix: validator improvements

### DIFF
--- a/schema/testdata/errors/relationships_update_nested_invalid_input.keel
+++ b/schema/testdata/errors/relationships_update_nested_invalid_input.keel
@@ -1,0 +1,39 @@
+model Post {
+    fields {
+        name Text
+        another Text
+        votes Vote[]
+    }
+
+    actions {
+        create createPost1() with (name, another, votes.score)
+        //expect-error:51:59:ActionInputError:Cannot provide the id of nested records which do not exist yet
+        create createPost2() with (name, another, votes.id)
+        //expect-error:38:49:ActionInputError:Update actions cannot perform field updates on nested models.
+        update updatePost1(id) with (votes.score)
+        update updatePost2(id) with (votes.id)
+    }
+}
+
+model Vote {
+    fields {
+        score Number
+        post Post?
+    }
+
+    actions {
+        create createVote1() with (score, post.id)
+        create createVote2() with (score, post.name, post.another)
+        update updateVote1(id) with (score)
+        update updateVote2(id) with (post.id)
+        //expect-error:47:57:ActionInputError:Update actions cannot perform field updates on nested models.
+        update updateVote3(id) with (post.id, post.name?)
+        //expect-error:38:48:ActionInputError:Update actions cannot perform field updates on nested models.
+        update updateVote4(id) with (post.name?)
+        //expect-error:38:47:ActionInputError:Update actions cannot perform field updates on nested models.
+        //expect-error:49:61:ActionInputError:Update actions cannot perform field updates on nested models.
+        update updateVote5(id) with (post.name, post.another)
+        update updateVote6(id) with (score, post.id)
+    }
+}
+            

--- a/schema/testdata/errors/relationships_update_nested_invalid_input.keel
+++ b/schema/testdata/errors/relationships_update_nested_invalid_input.keel
@@ -3,6 +3,7 @@ model Post {
         name Text
         another Text
         votes Vote[]
+        category Category?
     }
 
     actions {
@@ -12,6 +13,9 @@ model Post {
         //expect-error:38:49:ActionInputError:Update actions cannot perform field updates on nested models.
         update updatePost1(id) with (votes.score)
         update updatePost2(id) with (votes.id)
+        update updatePost3(id) with (category.id)
+        //expect-error:38:51:ActionInputError:Update actions cannot perform field updates on nested models.
+        update updatePost4(id) with (category.name)
     }
 }
 
@@ -36,4 +40,17 @@ model Vote {
         update updateVote6(id) with (score, post.id)
     }
 }
-            
+
+model Category {
+    fields {
+        name Text
+        posts Post[]
+    }
+
+    actions {
+        update updateCategory1(id) with (name)
+        update updateCategory2(id) with (posts.id)
+        //expect-error:42:52:ActionInputError:Update actions cannot perform field updates on nested models.
+        update updateCategory3(id) with (posts.name)
+    }
+}

--- a/schema/testdata/errors/set_attribute_built_in_fields.keel
+++ b/schema/testdata/errors/set_attribute_built_in_fields.keel
@@ -28,6 +28,7 @@ model Post {
             //expect-error:18:32:AttributeExpressionError:Cannot set the field 'updatedAt' as it is a built-in field and can only be mutated internally
             @set(post.updatedAt = ctx.now)
         }
+        //expect-error:44:58:ActionInputError:Update actions cannot perform field updates on nested models.
         update updatePost2(id) with (name, publisher.name) {
             //expect-error:18:42:AttributeExpressionError:Cannot set the field 'createdAt' as it is a built-in field and can only be mutated internally
             @set(post.publisher.createdAt = ctx.now)

--- a/schema/testdata/proto/action_inputs_in_both_query_and_with/proto.json
+++ b/schema/testdata/proto/action_inputs_in_both_query_and_with/proto.json
@@ -136,7 +136,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["issuer"]
+          "uniqueWith": [
+            "issuer"
+          ]
         },
         {
           "modelName": "Identity",
@@ -173,7 +175,9 @@
             "type": "TYPE_STRING"
           },
           "optional": true,
-          "uniqueWith": ["email"]
+          "uniqueWith": [
+            "email"
+          ]
         },
         {
           "modelName": "Identity",
@@ -423,7 +427,9 @@
             "modelName": "Account",
             "fieldName": "username"
           },
-          "target": ["username"]
+          "target": [
+            "username"
+          ]
         }
       ]
     },
@@ -438,7 +444,9 @@
             "modelName": "Account",
             "fieldName": "name"
           },
-          "target": ["name"]
+          "target": [
+            "name"
+          ]
         },
         {
           "messageName": "UpdateAccountValues",
@@ -448,7 +456,9 @@
             "modelName": "Account",
             "fieldName": "username"
           },
-          "target": ["username"]
+          "target": [
+            "username"
+          ]
         },
         {
           "messageName": "UpdateAccountValues",
@@ -458,7 +468,9 @@
             "modelName": "Account",
             "fieldName": "isActive"
           },
-          "target": ["isActive"]
+          "target": [
+            "isActive"
+          ]
         }
       ]
     },
@@ -494,7 +506,9 @@
             "modelName": "Account",
             "fieldName": "username"
           },
-          "target": ["username"]
+          "target": [
+            "username"
+          ]
         },
         {
           "messageName": "UpdateAccount2Where",
@@ -504,7 +518,9 @@
             "modelName": "Account",
             "fieldName": "isActive"
           },
-          "target": ["isActive"]
+          "target": [
+            "isActive"
+          ]
         }
       ]
     },
@@ -519,7 +535,9 @@
             "modelName": "Account",
             "fieldName": "name"
           },
-          "target": ["name"]
+          "target": [
+            "name"
+          ]
         },
         {
           "messageName": "UpdateAccount2Values",
@@ -529,7 +547,9 @@
             "modelName": "Account",
             "fieldName": "username"
           },
-          "target": ["username"]
+          "target": [
+            "username"
+          ]
         },
         {
           "messageName": "UpdateAccount2Values",
@@ -539,7 +559,9 @@
             "modelName": "Account",
             "fieldName": "isActive"
           },
-          "target": ["isActive"]
+          "target": [
+            "isActive"
+          ]
         }
       ]
     },
@@ -575,7 +597,10 @@
             "modelName": "Identity",
             "fieldName": "id"
           },
-          "target": ["identity", "id"]
+          "target": [
+            "identity",
+            "id"
+          ]
         }
       ]
     },
@@ -603,7 +628,10 @@
             "modelName": "Identity",
             "fieldName": "id"
           },
-          "target": ["identity", "id"]
+          "target": [
+            "identity",
+            "id"
+          ]
         }
       ]
     },
@@ -640,7 +668,10 @@
             "fieldName": "email"
           },
           "nullable": true,
-          "target": ["identity", "email"]
+          "target": [
+            "identity",
+            "email"
+          ]
         },
         {
           "messageName": "UpdateAccount4Where",
@@ -651,7 +682,10 @@
             "fieldName": "issuer"
           },
           "nullable": true,
-          "target": ["identity", "issuer"]
+          "target": [
+            "identity",
+            "issuer"
+          ]
         }
       ]
     },
@@ -666,7 +700,9 @@
             "modelName": "Account",
             "fieldName": "email"
           },
-          "target": ["email"]
+          "target": [
+            "email"
+          ]
         }
       ]
     },
@@ -703,7 +739,10 @@
             "fieldName": "email"
           },
           "nullable": true,
-          "target": ["identity", "email"]
+          "target": [
+            "identity",
+            "email"
+          ]
         },
         {
           "messageName": "UpdateAccount5Where",
@@ -714,7 +753,10 @@
             "fieldName": "issuer"
           },
           "nullable": true,
-          "target": ["identity", "issuer"]
+          "target": [
+            "identity",
+            "issuer"
+          ]
         }
       ]
     },
@@ -723,27 +765,15 @@
       "fields": [
         {
           "messageName": "UpdateAccount5Values",
-          "name": "identity",
-          "type": {
-            "type": "TYPE_MESSAGE",
-            "messageName": "UpdateAccount5IdentityInput"
-          }
-        }
-      ]
-    },
-    {
-      "name": "UpdateAccount5IdentityInput",
-      "fields": [
-        {
-          "messageName": "UpdateAccount5IdentityInput",
-          "name": "email",
+          "name": "name",
           "type": {
             "type": "TYPE_STRING",
-            "modelName": "Identity",
-            "fieldName": "email"
+            "modelName": "Account",
+            "fieldName": "name"
           },
-          "nullable": true,
-          "target": ["identity", "email"]
+          "target": [
+            "name"
+          ]
         }
       ]
     },

--- a/schema/testdata/proto/action_inputs_in_both_query_and_with/schema.keel
+++ b/schema/testdata/proto/action_inputs_in_both_query_and_with/schema.keel
@@ -16,6 +16,6 @@ model Account {
 
         update updateAccount4(identity.email, identity.issuer) with (email)
 
-        update updateAccount5(identity.email, identity.issuer) with (identity.email)
+        update updateAccount5(identity.email, identity.issuer) with (name)
     }
 }

--- a/schema/validation/unique_attribute.go
+++ b/schema/validation/unique_attribute.go
@@ -162,22 +162,20 @@ func UniqueAttributeRule(asts []*parser.AST, errs *errorhandling.ValidationError
 
 			idents, err := resolve.AsIdentArray(expression)
 			if err != nil {
-				if err != nil {
-					errs.AppendError(
-						errorhandling.NewValidationErrorWithDetails(
-							errorhandling.ActionInputError,
-							errorhandling.ErrorDetails{
-								Message: "@unique argument must be an array of field names",
-								Hint:    "For example, @unique([sku, supplierCode])",
-							},
-							expression,
-						),
-					)
-					return
-				}
+				errs.AppendError(
+					errorhandling.NewValidationErrorWithDetails(
+						errorhandling.ActionInputError,
+						errorhandling.ErrorDetails{
+							Message: "@unique argument must be an array of field names",
+							Hint:    "For example, @unique([sku, supplierCode])",
+						},
+						expression,
+					),
+				)
+				return
 			}
 
-			if len(idents) < 2 || err != nil {
+			if len(idents) < 2 {
 				errs.AppendError(
 					errorhandling.NewValidationErrorWithDetails(
 						errorhandling.AttributeArgumentError,

--- a/schema/validation/update_nested_inputs.go
+++ b/schema/validation/update_nested_inputs.go
@@ -69,8 +69,6 @@ func UpdateActionNestedInputsRule(asts []*parser.AST, errs *errorhandling.Valida
 					relationField = true
 				}
 			}
-
-			return
 		},
 	}
 }

--- a/schema/validation/update_nested_inputs.go
+++ b/schema/validation/update_nested_inputs.go
@@ -1,0 +1,76 @@
+package validation
+
+import (
+	"fmt"
+
+	"github.com/samber/lo"
+	"github.com/teamkeel/keel/schema/parser"
+	"github.com/teamkeel/keel/schema/query"
+	"github.com/teamkeel/keel/schema/validation/errorhandling"
+)
+
+// UpdateActionNestedInputsRule checks that the action inputs for update aren't referencing any relationship fields
+// apart from the foreign key
+func UpdateActionNestedInputsRule(asts []*parser.AST, errs *errorhandling.ValidationErrors) Visitor {
+	var action *parser.ActionNode
+	var currentModel *parser.ModelNode
+
+	return Visitor{
+		EnterModel: func(n *parser.ModelNode) {
+			currentModel = n
+		},
+		LeaveModel: func(n *parser.ModelNode) {
+			currentModel = nil
+		},
+		EnterAction: func(n *parser.ActionNode) {
+			if currentModel == nil {
+				return
+			}
+			if n.Type.Value == parser.ActionTypeUpdate {
+				action = n
+			}
+		},
+		LeaveAction: func(n *parser.ActionNode) {
+			action = nil
+		},
+		EnterActionInput: func(input *parser.ActionInputNode) {
+			if action == nil || currentModel == nil {
+				return
+			}
+
+			if !lo.Contains(action.With, input) {
+				return
+			}
+
+			var field *parser.FieldNode
+			model := currentModel
+			relationField := false
+			for _, fragment := range input.Type.Fragments {
+				if model == nil {
+					return
+				}
+				field = query.ModelField(model, fragment.Fragment)
+				if field == nil {
+					return
+				}
+
+				if relationField && field.Name.Value != "id" {
+					errs.AppendError(errorhandling.NewValidationErrorWithDetails(
+						errorhandling.ActionInputError,
+						errorhandling.ErrorDetails{
+							Message: "Update actions cannot perform field updates on nested models.",
+							Hint:    fmt.Sprintf("A %s's fields cannot be updated directly from a %s's update action.", model.Name.Value, currentModel.Name.Value),
+						},
+						input,
+					))
+				}
+
+				if model = query.Model(asts, field.Type.Value); model != nil {
+					relationField = true
+				}
+			}
+
+			return
+		},
+	}
+}

--- a/schema/validation/validation.go
+++ b/schema/validation/validation.go
@@ -85,6 +85,7 @@ var visitorFuncs = []VisitorFunc{
 	ApiModelActionsRule,
 	ApiDuplicateModelNamesRule,
 	StudioFeatures,
+	UpdateActionNestedInputsRule,
 }
 
 // RunAllValidators will run all the validators available. If withWarnings is true, it will return the errors even if


### PR DESCRIPTION
Improvements to the keel validator:

* Explicitly check update actions to make sure there are no nested fields used as inputs as the runtime currently doesn't support updating related models; e.g.

```erlang
model Post {
  fields {
    name Text
    categ Category
  }
  actions {
    update updatePost(id) with (name, categ.name) <-- this is not allowed
  }
}

model Category {
  fields {
    name Text
    posts Post[]
  }
}
```