### PR TITLE
fix: disabling keel studio warnings

### DIFF
--- a/packages/wasm/index.test.ts
+++ b/packages/wasm/index.test.ts
@@ -143,24 +143,24 @@ test("validate - multi file", async () => {
   expect(errors.length).toEqual(0);
 });
 
-test("validate - warnings", async () => {
-  const schema = `model Person {
-    fields { 
-        name Text
-    }
+// test("validate - warnings", async () => {
+//   const schema = `model Person {
+//     fields { 
+//         name Text
+//     }
 
-    @on([create], createPersonSubscriber
-    )
-}`;
-  const { errors, warnings } = await validate({
-    schemaFiles: [{ filename: "schema.keel", contents: schema }],
-    config: configFile,
-    includeWarnings: true,
-  });
+//     @on([create], createPersonSubscriber
+//     )
+// }`;
+//   const { errors, warnings } = await validate({
+//     schemaFiles: [{ filename: "schema.keel", contents: schema }],
+//     config: configFile,
+//     includeWarnings: true,
+//   });
 
-  expect(errors.length).toEqual(0);
-  expect(warnings?.length).toEqual(1);
-});
+//   expect(errors.length).toEqual(0);
+//   expect(warnings?.length).toEqual(1);
+// });
 
 test("validate - ignore warnings", async () => {
   const schema = `model Person {

--- a/packages/wasm/index.test.ts
+++ b/packages/wasm/index.test.ts
@@ -145,7 +145,7 @@ test("validate - multi file", async () => {
 
 // test("validate - warnings", async () => {
 //   const schema = `model Person {
-//     fields { 
+//     fields {
 //         name Text
 //     }
 

--- a/schema/validation/validation.go
+++ b/schema/validation/validation.go
@@ -84,7 +84,7 @@ var visitorFuncs = []VisitorFunc{
 	RelationshipsRules,
 	ApiModelActionsRule,
 	ApiDuplicateModelNamesRule,
-	StudioFeatures,
+	//StudioFeatures, //disabled temporarily as it's causing noise on non-studio builds
 }
 
 // RunAllValidators will run all the validators available. If withWarnings is true, it will return the errors even if

--- a/schema/validation/validation.go
+++ b/schema/validation/validation.go
@@ -84,7 +84,7 @@ var visitorFuncs = []VisitorFunc{
 	RelationshipsRules,
 	ApiModelActionsRule,
 	ApiDuplicateModelNamesRule,
-	//StudioFeatures, //disabled temporarily as it's causing noise on non-studio builds
+	//StudioFeatures, disabled temporarily as it's causing noise on non-studio builds
 }
 
 // RunAllValidators will run all the validators available. If withWarnings is true, it will return the errors even if


### PR DESCRIPTION
Disabling the Keel studio validation warnings as these are appearing in non-Studio builds in the Console.