### PR TITLE
fix: get auth providers in client sdk

### DIFF
--- a/config/auth.go
+++ b/config/auth.go
@@ -140,14 +140,14 @@ func (c *AuthConfig) AddOidcProvider(name string, issuerUrl string, clientId str
 		if strings.HasPrefix(err.Message, fmt.Sprintf("auth.providers.%d.name", newProviderIndex)) {
 			// This function allows the adding of internal auth providers which can start with 'keel_'
 			if !strings.Contains(err.Message, "Cannot start with 'keel_'") {
-				return fmt.Errorf(err.Message)
+				return err
 			}
 		}
 		if strings.HasPrefix(err.Message, fmt.Sprintf("auth.providers.%d.issuerUrl", newProviderIndex)) {
-			return fmt.Errorf(err.Message)
+			return err
 		}
 		if strings.HasPrefix(err.Message, fmt.Sprintf("auth.providers.%d.clientId", newProviderIndex)) {
-			return fmt.Errorf(err.Message)
+			return err
 		}
 	}
 

--- a/integration/testdata/client_auth/keelconfig.yaml
+++ b/integration/testdata/client_auth/keelconfig.yaml
@@ -1,0 +1,18 @@
+auth:
+  providers:
+    - type: oidc
+      name: myOidcProvider
+      issuerUrl: "https://auth.example.com/"
+      clientId: foo_1
+    - type: google
+      name: googleProvider
+      clientId: foo_3
+    - type: slack
+      name: slackProvider
+      clientId: foo_4
+    - type: facebook
+      name: facebookProvider
+      clientId: foo_5
+    - type: gitlab
+      name: Gitlab_Provider
+      clientId: foo_6

--- a/integration/testdata/client_auth/main.test.ts
+++ b/integration/testdata/client_auth/main.test.ts
@@ -75,3 +75,45 @@ test("authentication - not authenticated and no permissions", async () => {
   expect(response.data?.results).toHaveLength(1);
   expect(response.error).toBeUndefined();
 });
+
+test("authentication - get providers", async () => {
+  const provs = await client.auth.providers();
+  console.log(provs);
+
+  expect(provs.data?.[0]).toEqual({
+    name: "myOidcProvider",
+    type: "oidc",
+    authorizeUrl: process.env.KEEL_TESTING_AUTH_API_URL + "/authorize/myoidcprovider",
+    callbackUrl: process.env.KEEL_TESTING_AUTH_API_URL + "/callback/myoidcprovider",
+  });
+  
+  expect(provs.data?.[1]).toEqual({
+    name: "googleProvider",
+    type: "google",
+    authorizeUrl: process.env.KEEL_TESTING_AUTH_API_URL + "/authorize/googleprovider",
+    callbackUrl: process.env.KEEL_TESTING_AUTH_API_URL + "/callback/googleprovider",
+  });
+
+  expect(provs.data?.[2]).toEqual({
+    name: "slackProvider",
+    type: "slack",
+    authorizeUrl: process.env.KEEL_TESTING_AUTH_API_URL + "/authorize/slackprovider",
+    callbackUrl: process.env.KEEL_TESTING_AUTH_API_URL + "/callback/slackprovider",
+  });
+  
+  expect(provs.data?.[3]).toEqual({
+    name: "facebookProvider",
+    type: "facebook",
+    authorizeUrl: process.env.KEEL_TESTING_AUTH_API_URL + "/authorize/facebookprovider",
+    callbackUrl: process.env.KEEL_TESTING_AUTH_API_URL + "/callback/facebookprovider",
+  });
+
+  expect(provs.data?.[4]).toEqual({
+    name: "Gitlab_Provider",
+    type: "gitlab",
+    authorizeUrl: process.env.KEEL_TESTING_AUTH_API_URL + "/authorize/gitlab_provider",
+    callbackUrl: process.env.KEEL_TESTING_AUTH_API_URL + "/callback/gitlab_provider",
+  });
+
+  expect(provs.data?.length).toEqual(5);
+});

--- a/integration/testdata/client_auth/main.test.ts
+++ b/integration/testdata/client_auth/main.test.ts
@@ -83,36 +83,46 @@ test("authentication - get providers", async () => {
   expect(provs.data?.[0]).toEqual({
     name: "myOidcProvider",
     type: "oidc",
-    authorizeUrl: process.env.KEEL_TESTING_AUTH_API_URL + "/authorize/myoidcprovider",
-    callbackUrl: process.env.KEEL_TESTING_AUTH_API_URL + "/callback/myoidcprovider",
+    authorizeUrl:
+      process.env.KEEL_TESTING_AUTH_API_URL + "/authorize/myoidcprovider",
+    callbackUrl:
+      process.env.KEEL_TESTING_AUTH_API_URL + "/callback/myoidcprovider",
   });
-  
+
   expect(provs.data?.[1]).toEqual({
     name: "googleProvider",
     type: "google",
-    authorizeUrl: process.env.KEEL_TESTING_AUTH_API_URL + "/authorize/googleprovider",
-    callbackUrl: process.env.KEEL_TESTING_AUTH_API_URL + "/callback/googleprovider",
+    authorizeUrl:
+      process.env.KEEL_TESTING_AUTH_API_URL + "/authorize/googleprovider",
+    callbackUrl:
+      process.env.KEEL_TESTING_AUTH_API_URL + "/callback/googleprovider",
   });
 
   expect(provs.data?.[2]).toEqual({
     name: "slackProvider",
     type: "slack",
-    authorizeUrl: process.env.KEEL_TESTING_AUTH_API_URL + "/authorize/slackprovider",
-    callbackUrl: process.env.KEEL_TESTING_AUTH_API_URL + "/callback/slackprovider",
+    authorizeUrl:
+      process.env.KEEL_TESTING_AUTH_API_URL + "/authorize/slackprovider",
+    callbackUrl:
+      process.env.KEEL_TESTING_AUTH_API_URL + "/callback/slackprovider",
   });
-  
+
   expect(provs.data?.[3]).toEqual({
     name: "facebookProvider",
     type: "facebook",
-    authorizeUrl: process.env.KEEL_TESTING_AUTH_API_URL + "/authorize/facebookprovider",
-    callbackUrl: process.env.KEEL_TESTING_AUTH_API_URL + "/callback/facebookprovider",
+    authorizeUrl:
+      process.env.KEEL_TESTING_AUTH_API_URL + "/authorize/facebookprovider",
+    callbackUrl:
+      process.env.KEEL_TESTING_AUTH_API_URL + "/callback/facebookprovider",
   });
 
   expect(provs.data?.[4]).toEqual({
     name: "Gitlab_Provider",
     type: "gitlab",
-    authorizeUrl: process.env.KEEL_TESTING_AUTH_API_URL + "/authorize/gitlab_provider",
-    callbackUrl: process.env.KEEL_TESTING_AUTH_API_URL + "/callback/gitlab_provider",
+    authorizeUrl:
+      process.env.KEEL_TESTING_AUTH_API_URL + "/authorize/gitlab_provider",
+    callbackUrl:
+      process.env.KEEL_TESTING_AUTH_API_URL + "/callback/gitlab_provider",
   });
 
   expect(provs.data?.length).toEqual(5);

--- a/node/templates/client/core.ts
+++ b/node/templates/client/core.ts
@@ -169,7 +169,7 @@ export class Core {
       });
 
       if (result.ok) {
-        return await result.json();
+        return { data: await result.json() };
       } else {
         return {
           error: {

--- a/runtime/apis/authapi/authorize_endpoint.go
+++ b/runtime/apis/authapi/authorize_endpoint.go
@@ -159,19 +159,13 @@ func CallbackHandler(schema *proto.Schema) common.HandlerFunc {
 			return common.InternalServerErrorResponse(ctx, err)
 		}
 
-		// Establishes new OIDC provider. This will call the providers discovery endpoint
-		oidcProvider, err := oidc.NewProvider(ctx, provider.IssuerUrl)
-		if err != nil {
-			return common.InternalServerErrorResponse(ctx, err)
-		}
-
 		// ClientSecret is required for token exchange
 		oauthConfig := &oauth2.Config{
 			ClientID:     provider.ClientId,
 			ClientSecret: secret,
 			Endpoint: oauth2.Endpoint{
-				AuthURL:  oidcProvider.Endpoint().AuthURL,
-				TokenURL: oidcProvider.Endpoint().TokenURL,
+				AuthURL:  oidcProv.Endpoint().AuthURL,
+				TokenURL: oidcProv.Endpoint().TokenURL,
 			},
 			RedirectURL: callbackUrl.String(),
 		}

--- a/runtime/apis/authapi/providers_endpoint.go
+++ b/runtime/apis/authapi/providers_endpoint.go
@@ -1,7 +1,6 @@
 package authapi
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -25,8 +24,6 @@ func ProvidersHandler(schema *proto.Schema) common.HandlerFunc {
 
 		config, err := runtimectx.GetOAuthConfig(ctx)
 		if err != nil {
-			fmt.Println(err)
-
 			return common.InternalServerErrorResponse(ctx, err)
 		}
 

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -174,6 +174,8 @@ func Run(ctx context.Context, opts *RunnerOpts) error {
 		os.Setenv(key, value)
 	}
 
+	os.Setenv("KEEL_API_URL", fmt.Sprintf("http://localhost:%s", runtimePort))
+
 	// Server to handle receiving HTTP requests from the ActionExecutor, JobExecutor and SubscriberExecutor.
 	runtimeServer := http.Server{
 		Addr: fmt.Sprintf(":%s", runtimePort),


### PR DESCRIPTION
In the client SDK, correctly parsing the providers collection under the `data` fields as now required by the `APIResult` wrapper. 