### PR TITLE
fix: update auth provider struct

### DIFF
--- a/config/auth.go
+++ b/config/auth.go
@@ -135,6 +135,10 @@ func (c *AuthConfig) AddOidcProvider(name string, issuerUrl string, clientId str
 		return err
 	}
 
+	if err == nil {
+		return nil
+	}
+
 	newProviderIndex := len(c.Providers) - 1
 	for _, err := range ToConfigErrors(err).Errors {
 		if strings.HasPrefix(err.Message, fmt.Sprintf("auth.providers.%d.name", newProviderIndex)) {

--- a/config/auth.go
+++ b/config/auth.go
@@ -64,7 +64,7 @@ type Provider struct {
 	Type      string `yaml:"type"`
 	Name      string `yaml:"name"`
 	ClientId  string `yaml:"clientId"`
-	IssuerUrl string `yaml:"issuerUrl"`
+	IssuerUrl string `yaml:"issuerUrl,omitempty"`
 }
 
 type IdentityClaim struct {

--- a/config/fixtures/test_auth_invalid_issuer.yaml
+++ b/config/fixtures/test_auth_invalid_issuer.yaml
@@ -4,6 +4,8 @@
 # auth.providers.2.issuerUrl: Does not match format 'uri'
 # auth.providers.3.issuerUrl: Does not match pattern '^https://'
 # auth.providers.3.issuerUrl: Does not match format 'uri'
+# auth.providers.4.issuerUrl: Does not match pattern '^https://'
+# auth.providers.4.issuerUrl: Does not match format 'uri'
 
 auth:
   providers:
@@ -24,4 +26,13 @@ auth:
     - type: oidc
       name: invalid_url
       issuerUrl: "whoops"
+      clientId: "kasj28fnq09ak"
+
+    - type: slack
+      name: slack
+      issuerUrl: ""
+      clientId: "kasj28fnq09ak"
+
+    - type: slack
+      name: slack2
       clientId: "kasj28fnq09ak"


### PR DESCRIPTION
When marshalling an auth provider to yaml, if the `issuerUrl` is empty (which is valid for slack/google/etc providers) we must omit it from the yaml otherwise it will be written as `issuerUrl: ""` which will cause the validator to fail later on when loading config from bytes as part of a deployment pipeline.