### PR TITLE
feat: auto-indexing on inputs and facet fields

### DIFF
--- a/migrations/indexes.sql
+++ b/migrations/indexes.sql
@@ -1,0 +1,14 @@
+SELECT
+    i.tablename AS table_name,
+    i.indexname AS index_name,
+    a.attname AS column_name,
+    ix.indisunique AS is_unique,
+    ix.indisprimary AS is_primary
+FROM pg_catalog.pg_indexes i
+JOIN pg_catalog.pg_stat_all_tables t ON i.tablename = t.relname
+JOIN pg_catalog.pg_class c ON c.relname = i.indexname
+JOIN pg_catalog.pg_index ix ON ix.indexrelid = c.oid
+JOIN pg_catalog.pg_attribute a ON a.attrelid = ix.indrelid 
+    AND a.attnum = ANY(ix.indkey)
+WHERE t.schemaname = 'public'
+	AND i.tablename not like ('keel_%')

--- a/migrations/introspection.go
+++ b/migrations/introspection.go
@@ -27,6 +27,11 @@ func getComputedFunctions(database db.Database) ([]*FunctionRow, error) {
 	return rows, database.GetDB().Raw(computedFunctionsQuery).Scan(&rows).Error
 }
 
+func getIndexes(database db.Database) ([]*IndexRow, error) {
+	rows := []*IndexRow{}
+	return rows, database.GetDB().Raw(indexesQuery).Scan(&rows).Error
+}
+
 var (
 	//go:embed columns.sql
 	columnsQuery string
@@ -39,6 +44,9 @@ var (
 
 	//go:embed computed_functions.sql
 	computedFunctionsQuery string
+
+	//go:embed indexes.sql
+	indexesQuery string
 )
 
 type ColumnRow struct {
@@ -77,7 +85,7 @@ type ConstraintRow struct {
 }
 
 type TriggerRow struct {
-	// company_employee_delete
+	// e.g. company_employee_delete
 	TriggerName string `json:"trigger_name"`
 	// e.g. company_employee
 	TableName string `json:"table_name"`
@@ -91,4 +99,17 @@ type TriggerRow struct {
 
 type FunctionRow struct {
 	RoutineName string `json:"routine_name"`
+}
+
+type IndexRow struct {
+	// e.g. company_employee
+	TableName string `json:"table_name"`
+	// e.g. name
+	ColumnName string `json:"column_name"`
+	// e.g. idx_company_employee__name
+	IndexName string `json:"index_name"`
+	// e.g. false
+	IsUnique bool `json:"is_unique"`
+	// e.g. false
+	IsPrimary bool `json:"is_primary"`
 }

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -365,6 +365,14 @@ func New(ctx context.Context, schema *proto.Schema, database db.Database) (*Migr
 		}
 	}
 
+	// Amend indexes for fields which are used as required action inputs or as facets
+	existingIndexes, err := getIndexes(database)
+	if err != nil {
+		return nil, err
+	}
+	indexStmts := createIndexStmts(schema, existingIndexes)
+	statements = append(statements, indexStmts...)
+
 	// Fetch all computed functions in the database
 	existingComputedFns, err := getComputedFunctions(database)
 	if err != nil {

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -46,10 +46,6 @@ func TestMigrations(t *testing.T) {
 	}()
 
 	for _, testCase := range testCases {
-		if testCase.Name() != "indexes_added_inputs.txt" {
-			continue
-		}
-
 		t.Run(strings.TrimSuffix(testCase.Name(), ".txt"), func(t *testing.T) {
 			// Make a database name for this test
 			re := regexp.MustCompile(`[^\w]`)

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -46,6 +46,10 @@ func TestMigrations(t *testing.T) {
 	}()
 
 	for _, testCase := range testCases {
+		if testCase.Name() != "indexes_added_inputs.txt" {
+			continue
+		}
+
 		t.Run(strings.TrimSuffix(testCase.Name(), ".txt"), func(t *testing.T) {
 			// Make a database name for this test
 			re := regexp.MustCompile(`[^\w]`)

--- a/migrations/sql.go
+++ b/migrations/sql.go
@@ -575,6 +575,7 @@ func createIndexStmts(schema *proto.Schema, existingIndexes []*IndexRow) []strin
 				continue
 			}
 
+			// Find fields used as required inputs
 			indexedFields = append(indexedFields, findIndexableInputFields(schema, model, message)...)
 
 			// Find fields used as facets
@@ -594,11 +595,6 @@ func createIndexStmts(schema *proto.Schema, existingIndexes []*IndexRow) []strin
 	for _, field := range indexedFields {
 		// Skip fields which are unique as these will already have an index
 		if field.Unique {
-			continue
-		}
-
-		// Skip relationship FK fields as these will are already indexed by the FK constraint
-		if field.Type.Type == proto.Type_TYPE_MODEL {
 			continue
 		}
 

--- a/migrations/sql.go
+++ b/migrations/sql.go
@@ -564,3 +564,114 @@ func createUpdatedAtTriggerStmts(triggers []*TriggerRow, model *proto.Model) str
 
 	return strings.Join(statements, "\n")
 }
+
+// createIndexStmts generates index changes for input fields and faceted fields
+func createIndexStmts(schema *proto.Schema, existingIndexes []*IndexRow) []string {
+	indexedFields := []*proto.Field{}
+	for _, model := range schema.Models {
+		for _, action := range model.Actions {
+			message := proto.FindWhereInputMessage(schema, action.Name)
+			if message == nil {
+				continue
+			}
+
+			indexedFields = append(indexedFields, findIndexableInputFields(schema, model, message)...)
+
+			// Find fields used as facets
+			for _, facet := range action.Facets {
+				field := model.FindField(facet)
+
+				if !lo.Contains(indexedFields, field) {
+					indexedFields = append(indexedFields, field)
+				}
+			}
+		}
+	}
+
+	statements := []string{}
+
+	// Add indexes which don't exist yet
+	for _, field := range indexedFields {
+		// Skip fields which are unique as these will already have an index
+		if field.Unique {
+			continue
+		}
+
+		// Skip relationship FK fields as these will are already indexed by the FK constraint
+		if field.Type.Type == proto.Type_TYPE_MODEL {
+			continue
+		}
+
+		// Skip fields which already have an index
+		if lo.ContainsBy(existingIndexes, func(i *IndexRow) bool {
+			return indexName(field.ModelName, field.Name) == i.IndexName
+		}) {
+			continue
+		}
+
+		stmt := fmt.Sprintf("CREATE INDEX \"%s\" ON %s (%s);", indexName(field.ModelName, field.Name), Identifier(field.ModelName), Identifier(field.Name))
+		statements = append(statements, stmt)
+	}
+
+	// Drop existing indexes which don't exist anymore
+	for _, index := range existingIndexes {
+		if lo.ContainsBy(indexedFields, func(f *proto.Field) bool {
+			return indexName(f.ModelName, f.Name) == index.IndexName
+		}) {
+			continue
+		}
+
+		// Skip dropping primary key and unique indexes as we are not concerned with these here
+		if index.IsPrimary || index.IsUnique {
+			continue
+		}
+
+		stmt := fmt.Sprintf("DROP INDEX IF EXISTS \"%s\";", index.IndexName)
+		statements = append(statements, stmt)
+	}
+
+	return statements
+}
+
+func indexName(modelName string, fieldName string) string {
+	return fmt.Sprintf("%s__%s__idx", casing.ToSnake(modelName), casing.ToSnake(fieldName))
+}
+
+func findIndexableInputFields(schema *proto.Schema, model *proto.Model, message *proto.Message) []*proto.Field {
+	indexedFields := []*proto.Field{}
+
+	for _, msgField := range message.Fields {
+		m := model
+
+		// Skip optional inputs
+		if msgField.Optional {
+			continue
+		}
+
+		if msgField.Type.Type == proto.Type_TYPE_MESSAGE {
+			nestedMsg := schema.FindMessage(msgField.Type.MessageName.Value)
+			indexedFields = append(indexedFields, findIndexableInputFields(schema, model, nestedMsg)...)
+		}
+
+		// Skip indexing on optional fields
+		if msgField.Optional {
+			continue
+		}
+
+		// Skip inputs which don't correlate to a model field
+		if len(msgField.Target) == 0 {
+			continue
+		}
+
+		// If this is a nested relationship query input, then we need to find the model in targets
+		if len(msgField.Target) > 1 {
+			m = schema.FindModel(strcase.ToCamel(msgField.Target[len(msgField.Target)-2]))
+		}
+
+		f := m.FindField(msgField.Target[len(msgField.Target)-1])
+
+		indexedFields = append(indexedFields, f)
+	}
+
+	return indexedFields
+}

--- a/migrations/testdata/indexes_added_inputs.txt
+++ b/migrations/testdata/indexes_added_inputs.txt
@@ -1,0 +1,62 @@
+model Order {
+    fields {
+        price Decimal
+        quantity Number
+        customer Customer
+        category Category?
+        tag Text
+    }
+}
+
+model Customer {
+    fields {
+        name Text
+    }
+}
+
+enum Category {
+    Food
+    Electronics
+    Books
+}
+
+===
+
+model Order {
+    fields {
+        price Decimal
+        quantity Number
+        customer Customer
+        category Category?
+        tag Text
+    }
+
+    actions {
+        list listOrders(customer.id, customer.name, category, tag?) {
+            @facet(price, quantity, category)
+        }
+    }
+}
+
+model Customer {
+    fields {
+        name Text
+    }
+}
+
+enum Category {
+    Food
+    Electronics
+    Books
+}
+
+===
+
+CREATE INDEX "customer__name__idx" ON "customer" ("name");
+CREATE INDEX "order__category__idx" ON "order" ("category");
+CREATE INDEX "order__price__idx" ON "order" ("price");
+CREATE INDEX "order__quantity__idx" ON "order" ("quantity");
+
+===
+
+[]

--- a/migrations/testdata/indexes_added_inputs.txt
+++ b/migrations/testdata/indexes_added_inputs.txt
@@ -20,6 +20,13 @@ enum Category {
     Books
 }
 
+model Product {
+    fields {
+        order Order
+        name Text
+    }
+}
+
 ===
 
 model Order {
@@ -29,10 +36,11 @@ model Order {
         customer Customer
         category Category?
         tag Text
+        products Product[]
     }
 
     actions {
-        list listOrders(customer.id, customer.name, category, tag?) {
+        list listOrders(customer.id, customer.name, category, tag?, products.name) {
             @facet(price, quantity, category)
         }
     }
@@ -40,6 +48,13 @@ model Order {
 
 model Customer {
     fields {
+        name Text
+    }
+}
+
+model Product {
+    fields {
+        order Order
         name Text
     }
 }
@@ -54,6 +69,7 @@ enum Category {
 
 CREATE INDEX "customer__name__idx" ON "customer" ("name");
 CREATE INDEX "order__category__idx" ON "order" ("category");
+CREATE INDEX "product__name__idx" ON "product" ("name");
 CREATE INDEX "order__price__idx" ON "order" ("price");
 CREATE INDEX "order__quantity__idx" ON "order" ("quantity");
 

--- a/migrations/testdata/indexes_changed.txt
+++ b/migrations/testdata/indexes_changed.txt
@@ -1,0 +1,67 @@
+model Order {
+    fields {
+        price Decimal
+        quantity Number
+        customer Customer
+        category Category?
+        tag Text
+    }
+
+    actions {
+    list listOrders(customer.id, customer.name, category, tag) {
+        @facet(price, quantity, category)
+    }
+    }
+}
+
+model Customer {
+    fields {
+        name Text
+    }
+}
+
+enum Category {
+    Food
+    Electronics
+    Books
+}
+
+===
+
+model Order {
+    fields {
+        price Decimal
+        quantity Number
+        customer Customer
+        category Category?
+        tag Text
+    }
+
+    actions {
+        list listOrders(customer.id?, customer.name?, category?, tag?) {
+            @facet(quantity, category)
+        }
+    }
+}
+
+model Customer {
+    fields {
+        name Text
+    }
+}
+
+enum Category {
+    Food
+    Electronics
+    Books
+}
+
+===
+
+DROP INDEX IF EXISTS "customer__name__idx";
+DROP INDEX IF EXISTS "order__tag__idx";
+DROP INDEX IF EXISTS "order__price__idx";
+
+===
+
+[]

--- a/migrations/testdata/indexes_removed_inputs.txt
+++ b/migrations/testdata/indexes_removed_inputs.txt
@@ -1,4 +1,3 @@
-
 model Order {
     fields {
         price Decimal

--- a/migrations/testdata/indexes_removed_inputs.txt
+++ b/migrations/testdata/indexes_removed_inputs.txt
@@ -1,0 +1,67 @@
+
+model Order {
+    fields {
+        price Decimal
+        quantity Number
+        customer Customer
+        category Category
+    }
+
+    actions {
+        list listOrders(customer.id, customer.name, category) {
+            @facet(price, quantity, category)
+        }
+    }
+}
+
+model Customer {
+    fields {
+        name Text
+    }
+}
+
+enum Category {
+    Food
+    Electronics
+    Books
+}
+
+
+===
+
+model Order {
+    fields {
+        price Decimal
+        quantity Number
+        customer Customer
+        category Category
+    }
+
+    actions {
+        list listOrders() {
+            @facet(price)
+        }
+    }
+}
+
+model Customer {
+    fields {
+        name Text
+    }
+}
+
+enum Category {
+    Food
+    Electronics
+    Books
+}
+
+===
+
+DROP INDEX IF EXISTS "customer__name__idx";
+DROP INDEX IF EXISTS "order__category__idx";
+DROP INDEX IF EXISTS "order__quantity__idx";
+
+===
+
+[]


### PR DESCRIPTION
Auto-indexing
===

We now add a standard column index on any field which is used as a query input to an action AND fields which are faceted.

This will also consider nested relationship lookup query inputs.

For example, the schema below will have the following indexes created:

```sql
CREATE INDEX "customer__name__idx" ON "customer" ("name");
CREATE INDEX "order__category__idx" ON "order" ("category");
CREATE INDEX "order__price__idx" ON "order" ("price");
CREATE INDEX "order__quantity__idx" ON "order" ("quantity");
```

```
model Order {
    fields {
        price Decimal
        quantity Number
        customer Customer
        category Category?
        tag Text
    }

    actions {
        list listOrders(customer.id, customer.name, category, tag?) {
            @facet(price, quantity, category)
        }
    }
}

model Customer {
    fields {
        name Text
    }
}
```
