### PR TITLE
fix: duration type not found on keel test

### DIFF
--- a/packages/testing-runtime/package.json
+++ b/packages/testing-runtime/package.json
@@ -18,7 +18,7 @@
     "prettier": "3.1.1"
   },
   "dependencies": {
-    "@teamkeel/functions-runtime": "0.394.0",
+    "@teamkeel/functions-runtime": "0.401.5",
     "jsonwebtoken": "^9.0.2",
     "kysely": "^0.26.3",
     "lodash.ismatch": "^4.4.0",


### PR DESCRIPTION
Fix for the following issue when running `keel test`:

 > SyntaxError: Named export 'Duration' not found. The requested module '@teamkeel/functions-runtime' is a CommonJS module, which may not support all module.exports as named exports.