### PR TITLE
fix: conflicting where inputs

### DIFF
--- a/schema/testdata/errors/attribute_expression_unresolvable_rhs.keel
+++ b/schema/testdata/errors/attribute_expression_unresolvable_rhs.keel
@@ -7,10 +7,6 @@ model Post {
     }
 
     actions {
-        update updatePost(id) with (title) {
-            //expect-error:18:28:ActionInputError:title is already being used as an input so cannot also be used in an expression
-            @set(post.title = title)
-        }
         update updatePost2(id) with (title) {
             //expect-error:34:39:AttributeExpressionError:unknown identifier 'thing'
             @set(post.subTitle = thing.title)

--- a/schema/testdata/errors/clashing_explicit_implicit_inputs.keel
+++ b/schema/testdata/errors/clashing_explicit_implicit_inputs.keel
@@ -5,12 +5,8 @@ model Post {
 
     actions {
         create createPost() with (title, coolTitle: Text) {
-            //expect-error:18:28:ActionInputError:title is already being used as an input so cannot also be used in an expression
+            //expect-error:18:28:ActionInputError:title is already being used as a value input so cannot also be used in @set
             @set(post.title = coolTitle)
-        }
-        list listPost(id, coolId: ID) {
-            //expect-error:20:27:ActionInputError:id is already being used as an input so cannot also be used in an expression
-            @where(post.id == coolId)
         }
     }
 }

--- a/schema/validation/conflicting_value_inputs.go
+++ b/schema/validation/conflicting_value_inputs.go
@@ -10,16 +10,14 @@ import (
 	"github.com/teamkeel/keel/schema/validation/errorhandling"
 )
 
-// ConflictingInputsRule checks for model inputs that are also used in @set
-// or @where attributes. In this case one usage would cancel out the other,
+// ConflictingValueInputsRule checks for model value inputs that are also used in @set
+// In this case one usage would cancel out the other,
 // so it doesn't make sense to have both.
 //
-// For example in the getThing operation `id` is listed as a model input but
-// is also used in a @where expression.
-func ConflictingInputsRule(_ []*parser.AST, errs *errorhandling.ValidationErrors) Visitor {
+// For example, createPost() with (title) { @set(post.title = title) }
+func ConflictingValueInputsRule(_ []*parser.AST, errs *errorhandling.ValidationErrors) Visitor {
 	isAction := false
 	var action *parser.ActionNode
-	filterInputs := map[*parser.ActionInputNode]bool{}
 	writeInputs := map[*parser.ActionInputNode]bool{}
 
 	return Visitor{
@@ -30,22 +28,18 @@ func ConflictingInputsRule(_ []*parser.AST, errs *errorhandling.ValidationErrors
 			isAction = false
 		},
 		EnterAction: func(n *parser.ActionNode) {
-			filterInputs = map[*parser.ActionInputNode]bool{}
 			writeInputs = map[*parser.ActionInputNode]bool{}
 			action = n
 		},
 		EnterActionInput: func(n *parser.ActionInputNode) {
 			if n.Label == nil && isAction {
-				if lo.Contains(action.Inputs, n) {
-					filterInputs[n] = true
-				}
 				if lo.Contains(action.With, n) {
 					writeInputs[n] = true
 				}
 			}
 		},
 		EnterAttribute: func(n *parser.AttributeNode) {
-			isRelevantAttr := lo.Contains([]string{parser.AttributeWhere, parser.AttributeSet}, n.Name.Value)
+			isRelevantAttr := lo.Contains([]string{parser.AttributeSet}, n.Name.Value)
 			if !isAction || !isRelevantAttr || len(n.Arguments) == 0 {
 				return
 			}
@@ -55,38 +49,18 @@ func ConflictingInputsRule(_ []*parser.AST, errs *errorhandling.ValidationErrors
 				return
 			}
 
-			var inputs map[*parser.ActionInputNode]bool
-			if n.Name.Value == parser.AttributeWhere {
-				inputs = filterInputs
-			} else if n.Name.Value == parser.AttributeSet {
-				inputs = writeInputs
+			lhs, _, err := n.Arguments[0].Expression.ToAssignmentExpression()
+			if err != nil {
+				return
 			}
 
-			idents := []*parser.ExpressionIdent{}
-			var err error
-			switch n.Name.Value {
-			case parser.AttributeWhere:
-				idents, err = resolve.IdentOperands(n.Arguments[0].Expression)
-				if err != nil {
-					return
-				}
-			case parser.AttributeSet:
-				lhs, _, err := n.Arguments[0].Expression.ToAssignmentExpression()
-				if err != nil {
-					return
-				} else {
-					idents, err = resolve.IdentOperands(lhs)
-					if err != nil {
-						return
-					}
-				}
-			}
+			idents, err := resolve.IdentOperands(lhs)
 			if err != nil {
 				return
 			}
 
 			for _, operand := range idents {
-				for in := range inputs {
+				for in := range writeInputs {
 					// in an expression the first ident fragment will be the model name
 					// we create an indent without the first fragment
 					identWithoutModelName := operand.Fragments[1:]
@@ -99,7 +73,7 @@ func ConflictingInputsRule(_ []*parser.AST, errs *errorhandling.ValidationErrors
 						errorhandling.NewValidationErrorWithDetails(
 							errorhandling.ActionInputError,
 							errorhandling.ErrorDetails{
-								Message: fmt.Sprintf("%s is already being used as an input so cannot also be used in an expression", in.Type.ToString()),
+								Message: fmt.Sprintf("%s is already being used as a value input so cannot also be used in @set", in.Type.ToString()),
 							},
 							operand,
 						),

--- a/schema/validation/validation.go
+++ b/schema/validation/validation.go
@@ -61,7 +61,7 @@ var visitorFuncs = []VisitorFunc{
 	UnusedInputRule,
 	NotMutableInputs,
 	CreateNestedInputIsMany,
-	ConflictingInputsRule,
+	ConflictingValueInputsRule,
 	UniqueLookup,
 	InvalidWithUsage,
 	AttributeArgumentsRules,


### PR DESCRIPTION
There is no need to restrict a field which is filtered by inputs and in `@where`.  See example schema below where this case would be valid.  This PR relaxes that condition, but we still validate against using write values and `@set` on the same field.

```
model Order {
    fields {
	quantity Number
	price Decimal
	category Text
	status Status
    }
    actions {
	list listOrders(status?, category?) {
            @where(order.status != Status.Cancelled)
	}
    }
}
```
