### PR TITLE
fix: presigned file urls with inline content disposition

### DIFF
--- a/packages/functions-runtime/src/File.js
+++ b/packages/functions-runtime/src/File.js
@@ -166,9 +166,7 @@ class File extends InlineFile {
       const command = new GetObjectCommand({
         Bucket: process.env.KEEL_FILES_BUCKET_NAME,
         Key: "files/" + this.key,
-        ResponseContentDisposition: `attachment; filename="${encodeURIComponent(
-          this.filename
-        )}"`,
+        ResponseContentDisposition: "inline",
       });
 
       const url = await getSignedUrl(s3Client, command, { expiresIn: 60 * 60 });


### PR DESCRIPTION
Changing the presigned URL for files to inline content disposition so that clients have the option to display the file contents in the browser rather than forcing a download.

See thread: https://teamkeel.slack.com/archives/C03DJNS3BD0/p1740420868030909