### PR TITLE
fix: url parsing for files in functions

### DIFF
--- a/packages/functions-runtime/src/File.js
+++ b/packages/functions-runtime/src/File.js
@@ -34,7 +34,7 @@ const s3Client = (() => {
     // By impleenting a full resolver we can force it to be the endpoint we want.
     endpointProvider: () => {
       return {
-        url: URL.parse(endpoint),
+        url: new URL(endpoint),
       };
     },
   });


### PR DESCRIPTION
Fix for the following functions runtime exception:

```
TypeError: URL.parse is not a function
    at Object.endpointProvider (/var/task/node_modules/.pnpm/@teamkeel+functions-runtime@0.404.1_@aws-sdk+client-sso-oidc@3.750.0/node_modules/@teamkeel/functions-runtime/src/File.js:37:18)
    at getEndpointFromInstructions (/var/task/node_modules/.pnpm/@smithy+middleware-endpoint@3.2.8/node_modules/@smithy/middleware-endpoint/dist-cjs/index.js:139:33)
    at <anonymous> (/var/task/node_modules/.pnpm/@smithy+middleware-endpoint@3.2.8/node_modules/@smithy/middleware-endpoint/dist-cjs/index.js:186:22)
    at <anonymous> (/var/task/node_modules/.pnpm/@aws-sdk+middleware-sdk-s3@3.716.0/node_modules/@aws-sdk/middleware-sdk-s3/dist-cjs/index.js:110:22)
    at <anonymous> (/var/task/node_modules/.pnpm/@aws-sdk+middleware-sdk-s3@3.716.0/node_modules/@aws-sdk/middleware-sdk-s3/dist-cjs/index.js:138:14)
    at <anonymous> (/var/task/node_modules/.pnpm/@aws-sdk+middleware-logger@3.714.0/node_modules/@aws-sdk/middleware-logger/dist-cjs/index.js:34:22)
    at storeFile (/var/task/node_modules/.pnpm/@teamkeel+functions-runtime@0.404.1_@aws-sdk+client-sso-oidc@3.750.0/node_modules/@teamkeel/functions-runtime/src/File.js:250:7)
    at fg.store (/var/task/node_modules/.pnpm/@teamkeel+functions-runtime@0.404.1_@aws-sdk+client-sso-oidc@3.750.0/node_modules/@teamkeel/functions-runtime/src/File.js:95:5)
```