### PR TITLE
fix: facet query compatibility with pg15

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,7 @@ jobs:
 
     services:
       postgres:
-        image: pgvector/pgvector:pg16
+        image: pgvector/pgvector:pg15
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/test_npm_modules.yml
+++ b/.github/workflows/test_npm_modules.yml
@@ -7,7 +7,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:11.13-alpine
+        image: pgvector/pgvector:pg15
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,7 +5,7 @@
 
 services:
   postgres:
-    image: pgvector/pgvector:pg16
+    image: pgvector/pgvector:pg15
     restart: always
     environment:
       - POSTGRES_USER=postgres

--- a/packages/functions-runtime/compose.yaml
+++ b/packages/functions-runtime/compose.yaml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:11.13-alpine
+    image: pgvector/pgvector:pg15
     restart: always
     environment:
       - POSTGRES_USER=postgres

--- a/packages/functions-runtime/src/ModelAPI.test.js
+++ b/packages/functions-runtime/src/ModelAPI.test.js
@@ -107,7 +107,9 @@ test("ModelAPI.create - throws if not not null constraint violation", async () =
       id: KSUID.randomSync().string,
       name: null,
     })
-  ).rejects.toThrow('null value in column "name" violates not-null constraint');
+  ).rejects.toThrow(
+    'null value in column "name" of relation "author" violates not-null constraint'
+  );
 });
 
 test("ModelAPI.create - throws if database constraint fails", async () => {
@@ -925,7 +927,7 @@ test("ModelAPI.update - throws if not not null constraint violation", async () =
   );
 
   await expect(result).rejects.toThrow(
-    'null value in column "name" violates not-null constraint'
+    'null value in column "name" of relation "author" violates not-null constraint'
   );
 });
 

--- a/packages/functions-runtime/src/handleJob.test.js
+++ b/packages/functions-runtime/src/handleJob.test.js
@@ -177,12 +177,14 @@ describe("ModelAPI error handling", () => {
       jsonrpc: "2.0",
       error: {
         code: RuntimeErrors.NotNullConstraintError,
-        message: 'null value in column "title" violates not-null constraint',
+        message:
+          'null value in column "title" of relation "post" violates not-null constraint',
         data: {
           code: "23502",
           column: "title",
           detail: expect.stringContaining("Failing row contains"),
           table: "post",
+          value: undefined,
         },
       },
     });
@@ -229,12 +231,13 @@ describe("ModelAPI error handling", () => {
       error: {
         code: RuntimeErrors.NotNullConstraintError,
         message:
-          'null value in column "author_id" violates not-null constraint',
+          'null value in column "author_id" of relation "post" violates not-null constraint',
         data: {
           code: "23502",
           column: "author_id",
           detail: expect.stringContaining("Failing row contains"),
           table: "post",
+          value: undefined,
         },
       },
     });

--- a/packages/functions-runtime/src/handleRequest.test.js
+++ b/packages/functions-runtime/src/handleRequest.test.js
@@ -374,12 +374,14 @@ describe("ModelAPI error handling", () => {
       jsonrpc: "2.0",
       error: {
         code: RuntimeErrors.NotNullConstraintError,
-        message: 'null value in column "title" violates not-null constraint',
+        message:
+          'null value in column "title" of relation "post" violates not-null constraint',
         data: {
           code: "23502",
           column: "title",
           detail: expect.stringContaining("Failing row contains"),
           table: "post",
+          value: undefined,
         },
       },
     });
@@ -423,12 +425,13 @@ describe("ModelAPI error handling", () => {
       error: {
         code: RuntimeErrors.NotNullConstraintError,
         message:
-          'null value in column "author_id" violates not-null constraint',
+          'null value in column "author_id" of relation "post" violates not-null constraint',
         data: {
           code: "23502",
           column: "author_id",
           detail: expect.stringContaining("Failing row contains"),
           table: "post",
+          value: undefined,
         },
       },
     });

--- a/runtime/actions/query.go
+++ b/runtime/actions/query.go
@@ -633,7 +633,7 @@ func (query *QueryBuilder) SelectFacets(scope *Scope, input map[string]any) erro
 				) AS %s
 				FROM (
 					%s
-				)`, sqlQuote(column), sqlQuote(column), subStatement.template)
+				) AS %s`, sqlQuote(column), sqlQuote(column), subStatement.template, sqlQuote(fmt.Sprintf("%s_facets_base", column)))
 
 			statement = &Statement{
 				template: sel,

--- a/runtime/actions/query_test.go
+++ b/runtime/actions/query_test.go
@@ -3819,88 +3819,87 @@ var testCases = []testCase{
 			SELECT DISTINCT ON("order"."id") 
 				(
 					WITH "id_facets" AS (
-					SELECT jsonb_agg(jsonb_build_object('value', "id", 'count', "count")) AS "id" 
-					FROM (
-						SELECT DISTINCT ON("order"."id") "order"."id", COUNT(*) as "count" 
-						FROM "order" 
-						WHERE "order"."category" IS NOT DISTINCT FROM ? AND "order"."status" IS DISTINCT FROM ? 
-						GROUP BY "order"."id" 
-						ORDER BY "order"."id" ASC
-					)
+						SELECT jsonb_agg(jsonb_build_object('value', "id", 'count', "count")) AS "id" 
+						FROM (
+							SELECT DISTINCT ON("order"."id") "order"."id", COUNT(*) as "count" 
+							FROM "order" 
+							WHERE "order"."category" IS NOT DISTINCT FROM ? AND "order"."status" IS DISTINCT FROM ? 
+							GROUP BY "order"."id" 
+							ORDER BY "order"."id" ASC
+						) AS "id_facets_base"
 					),
 					"quantity_facets" AS (
-					SELECT json_build_object(
-						'min', MIN("quantity"),
-						'max', MAX("quantity"), 
-						'avg', AVG("quantity")
-					) AS "quantity"
-					FROM "order"
-					WHERE "order"."category" IS NOT DISTINCT FROM ? AND "order"."status" IS DISTINCT FROM ?
-					),
-					"price_facets" AS (
-					SELECT json_build_object(
-						'min', MIN("price"),
-						'max', MAX("price"),
-						'avg', AVG("price")
-					) AS "price"
-					FROM "order"
-					WHERE "order"."category" IS NOT DISTINCT FROM ? AND "order"."status" IS DISTINCT FROM ?
-					),
-					"status_facets" AS (
-					SELECT jsonb_agg(jsonb_build_object('value', "status", 'count', "count")) AS "status"
-					FROM (
-						SELECT DISTINCT ON("order"."status") "order"."status", COUNT(*) as "count"
+						SELECT json_build_object(
+							'min', MIN("quantity"),
+							'max', MAX("quantity"), 
+							'avg', AVG("quantity")
+						) AS "quantity"
 						FROM "order"
 						WHERE "order"."category" IS NOT DISTINCT FROM ? AND "order"."status" IS DISTINCT FROM ?
-						GROUP BY "order"."status"
-						ORDER BY "order"."status" ASC
-					)
+					),
+					"price_facets" AS (
+						SELECT json_build_object(
+							'min', MIN("price"),
+							'max', MAX("price"),
+							'avg', AVG("price")
+						) AS "price"
+						FROM "order"
+						WHERE "order"."category" IS NOT DISTINCT FROM ? AND "order"."status" IS DISTINCT FROM ?
+					),
+					"status_facets" AS (
+						SELECT jsonb_agg(jsonb_build_object('value', "status", 'count', "count")) AS "status"
+						FROM (
+							SELECT DISTINCT ON("order"."status") "order"."status", COUNT(*) as "count"
+							FROM "order"
+							WHERE "order"."category" IS NOT DISTINCT FROM ? AND "order"."status" IS DISTINCT FROM ?
+							GROUP BY "order"."status"
+							ORDER BY "order"."status" ASC
+						) AS "status_facets_base"
 					),
 					"category_facets" AS (
-					SELECT jsonb_agg(jsonb_build_object('value', "category", 'count', "count")) AS "category"
-					FROM (
-						SELECT DISTINCT ON("order"."category") "order"."category", COUNT(*) as "count"
-						FROM "order"
-						WHERE "order"."status" IS DISTINCT FROM ?
-						GROUP BY "order"."category"
-						ORDER BY "order"."category" ASC
-					)
+						SELECT jsonb_agg(jsonb_build_object('value', "category", 'count', "count")) AS "category"
+						FROM (
+							SELECT DISTINCT ON("order"."category") "order"."category", COUNT(*) as "count"
+							FROM "order"
+							WHERE "order"."status" IS DISTINCT FROM ?
+							GROUP BY "order"."category"
+							ORDER BY "order"."category" ASC
+						) AS "category_facets_base"
 					),
 					"order_date_facets" AS (
-					SELECT json_build_object(
-						'min', MIN("order_date"),
-						'max', MAX("order_date")
-					) AS "order_date"
-					FROM "order"
-					WHERE "order"."category" IS NOT DISTINCT FROM ? AND "order"."status" IS DISTINCT FROM ?
+						SELECT json_build_object(
+							'min', MIN("order_date"),
+							'max', MAX("order_date")
+						) AS "order_date"
+						FROM "order"
+						WHERE "order"."category" IS NOT DISTINCT FROM ? AND "order"."status" IS DISTINCT FROM ?
 					),
 					"order_time_facets" AS (
-					SELECT json_build_object(
-						'min', MIN("order_time"),
-						'max', MAX("order_time")
-					) AS "order_time"
-					FROM "order"
-					WHERE "order"."category" IS NOT DISTINCT FROM ? AND "order"."status" IS DISTINCT FROM ?
+						SELECT json_build_object(
+							'min', MIN("order_time"),
+							'max', MAX("order_time")
+						) AS "order_time"
+						FROM "order"
+						WHERE "order"."category" IS NOT DISTINCT FROM ? AND "order"."status" IS DISTINCT FROM ?
 					),
 					"duration_to_purchase_facets" AS (
-					SELECT json_build_object(
-						'min', MIN("duration_to_purchase"),
-						'max', MAX("duration_to_purchase"),
-						'avg', AVG("duration_to_purchase")
-					) AS "duration_to_purchase"
-					FROM "order"
-					WHERE "order"."category" IS NOT DISTINCT FROM ? AND "order"."status" IS DISTINCT FROM ?
+						SELECT json_build_object(
+							'min', MIN("duration_to_purchase"),
+							'max', MAX("duration_to_purchase"),
+							'avg', AVG("duration_to_purchase")
+						) AS "duration_to_purchase"
+						FROM "order"
+						WHERE "order"."category" IS NOT DISTINCT FROM ? AND "order"."status" IS DISTINCT FROM ?
 					)
 					SELECT json_build_object(
-					'id', "id_facets"."id",
-					'quantity', "quantity_facets"."quantity",
-					'price', "price_facets"."price", 
-					'status', "status_facets"."status",
-					'category', "category_facets"."category",
-					'order_date', "order_date_facets"."order_date",
-					'order_time', "order_time_facets"."order_time",
-					'duration_to_purchase', "duration_to_purchase_facets"."duration_to_purchase"
-					)
+						'id', "id_facets"."id",
+						'quantity', "quantity_facets"."quantity",
+						'price', "price_facets"."price", 
+						'status', "status_facets"."status",
+						'category', "category_facets"."category",
+						'order_date', "order_date_facets"."order_date",
+						'order_time', "order_time_facets"."order_time",
+						'duration_to_purchase', "duration_to_purchase_facets"."duration_to_purchase")
 					FROM 
 						"id_facets", 
 						"quantity_facets", 
@@ -3910,7 +3909,7 @@ var testCases = []testCase{
 						"order_date_facets", 
 						"order_time_facets", 
 						"duration_to_purchase_facets"
-				) AS "_facets",
+					) AS "_facets",
 				"order".*, 
 				CASE WHEN LEAD("order"."id") OVER (ORDER BY "order"."id" ASC) IS NOT NULL THEN true ELSE false END AS hasNext,
 				(


### PR DESCRIPTION
Facet queries are not valid for pg15.  This issue is because Postgres [relaxed an aliasing rule from v15 to v16](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=bcedd8f5f).  This fix amends the facet SQL generation to be compatible with pg15.

I've also set our CI and local tests to use pg15. 