### PR TITLE
build: goreleaser duplicate names

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,9 +29,11 @@ archives:
   - id: keel
     builds:
       - keel
+    name_template: "keel_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
   - id: runtime-lambda
     builds:
       - runtime-lambda
+    name_template: "runtime-lambda_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 release:
   github:
     owner: teamkeel


### PR DESCRIPTION
Fixes the goreleaser error encountered:

```
 error=archive named dist/keel_0.406.1_linux_amd64.tar.gz already exists. Check your archive name template
```