### PR TITLE
fix: allow zero page size on list

### DIFF
--- a/runtime/actions/pagination.go
+++ b/runtime/actions/pagination.go
@@ -34,13 +34,20 @@ type Page struct {
 // ParsePage extracts page mandate information from the given map and uses it to
 // compose a Page.
 func ParsePage(args map[string]any) (Page, error) {
-	page := Page{}
+	page := Page{
+		// Default page size
+		First: 50,
+	}
 
 	if arg, ok := extractIntArg(args, "first"); ok {
-		page.First = arg
+		if arg >= 0 {
+			page.First = arg
+		}
 	}
 	if arg, ok := extractIntArg(args, "last"); ok {
-		page.Last = arg
+		if arg >= 0 {
+			page.Last = arg
+		}
 	}
 	if arg, ok := extractIntArg(args, "offset"); ok {
 		if arg > 0 {
@@ -49,11 +56,6 @@ func ParsePage(args map[string]any) (Page, error) {
 	}
 	if arg, ok := extractIntArg(args, "limit"); ok {
 		page.Limit = arg
-	}
-
-	// If none specified - use a sensible default for cursor pagination
-	if !page.OffsetPagination() && page.First == 0 && page.Last == 0 {
-		page.First = 50
 	}
 
 	if after, ok := args["after"]; ok {

--- a/runtime/actions/query.go
+++ b/runtime/actions/query.go
@@ -668,7 +668,7 @@ func (query *QueryBuilder) ApplyPaging(page Page) error {
 	query.And()
 
 	// Add where condition to implement the page size
-	if page.GetLimit() > 0 {
+	if page.GetLimit() >= 0 {
 		query.Limit(page.GetLimit())
 	}
 

--- a/runtime/actions/query_test.go
+++ b/runtime/actions/query_test.go
@@ -2148,6 +2148,30 @@ var testCases = []testCase{
 		expectedArgs: []any{"123", 2},
 	},
 	{
+		name: "list_op_zero_page_size",
+		keelSchema: `
+			model Thing {
+				actions {
+					list listThings()
+				}
+				@permission(expression: true, actions: [list])
+			}`,
+		actionName: "listThings",
+		input: map[string]any{
+			"first": 0,
+		},
+		expectedTemplate: `
+			SELECT
+				DISTINCT ON("thing"."id") "thing".*, CASE WHEN LEAD("thing"."id") OVER (ORDER BY "thing"."id" ASC) IS NOT NULL THEN true ELSE false END AS hasNext,
+				(SELECT COUNT(DISTINCT "thing"."id") FROM "thing" ) AS totalCount
+			FROM
+				"thing"
+			ORDER BY
+				"thing"."id" ASC
+			LIMIT ?`,
+		expectedArgs: []any{0},
+	},
+	{
 		name: "list_multiple_conditions_no_parenthesis",
 		keelSchema: `
 			model Thing {


### PR DESCRIPTION
Setting `first` to 0 would result in the default of 50 being used.  This change allows for a zero-size page.