### PR TITLE
fix: tools generate wrapping response field for embedded models

### DIFF
--- a/tools/generator.go
+++ b/tools/generator.go
@@ -674,7 +674,7 @@ func (g *Generator) makeResponsesForModel(model *proto.Model, pathPrefix string,
 				fields = append(fields, embeddedFields...)
 			}
 
-			if !f.IsHasMany() {
+			if !f.IsHasMany() && !found {
 				continue
 			}
 		}

--- a/tools/testdata/blog/tools.json
+++ b/tools/testdata/blog/tools.json
@@ -1616,10 +1616,19 @@
           "fieldName": "updatedAt"
         },
         {
+          "fieldLocation": { "path": "$.results[*].author" },
+          "fieldType": "TYPE_MODEL",
+          "displayName": "Author",
+          "displayOrder": 4,
+          "visible": true,
+          "modelName": "BlogPost",
+          "fieldName": "author"
+        },
+        {
           "fieldLocation": { "path": "$.results[*].authorId" },
           "fieldType": "TYPE_ID",
           "displayName": "Author",
-          "displayOrder": 4,
+          "displayOrder": 5,
           "visible": true,
           "modelName": "BlogPost",
           "fieldName": "authorId"
@@ -1628,7 +1637,7 @@
           "fieldLocation": { "path": "$.results[*].image" },
           "fieldType": "TYPE_FILE",
           "displayName": "Image",
-          "displayOrder": 5,
+          "displayOrder": 6,
           "visible": true,
           "imagePreview": true,
           "modelName": "BlogPost",
@@ -1639,7 +1648,7 @@
           "fieldType": "TYPE_STRING",
           "repeated": true,
           "displayName": "Tags",
-          "displayOrder": 6,
+          "displayOrder": 7,
           "visible": true,
           "modelName": "BlogPost",
           "fieldName": "tags"
@@ -1680,10 +1689,19 @@
           "fieldName": "updatedAt"
         },
         {
+          "fieldLocation": { "path": "$.results[*].category" },
+          "fieldType": "TYPE_MODEL",
+          "displayName": "Category",
+          "displayOrder": 8,
+          "visible": true,
+          "modelName": "BlogPost",
+          "fieldName": "category"
+        },
+        {
           "fieldLocation": { "path": "$.results[*].categoryId" },
           "fieldType": "TYPE_ID",
           "displayName": "Category",
-          "displayOrder": 7,
+          "displayOrder": 9,
           "visible": true,
           "link": {
             "toolId": "getCategory",
@@ -1699,7 +1717,7 @@
           "fieldType": "TYPE_MODEL",
           "repeated": true,
           "displayName": "Comments",
-          "displayOrder": 8,
+          "displayOrder": 10,
           "visible": true,
           "link": {
             "toolId": "listComments",
@@ -1717,7 +1735,7 @@
           "fieldLocation": { "path": "$.results[*].status" },
           "fieldType": "TYPE_ENUM",
           "displayName": "Status",
-          "displayOrder": 9,
+          "displayOrder": 11,
           "visible": true,
           "enumName": "Status",
           "modelName": "BlogPost",

--- a/tools/testdata/input_get_entry_actions/tools.json
+++ b/tools/testdata/input_get_entry_actions/tools.json
@@ -274,10 +274,19 @@
           "fieldName": "updatedAt"
         },
         {
+          "fieldLocation": { "path": "$.supplier" },
+          "fieldType": "TYPE_MODEL",
+          "displayName": "Supplier",
+          "displayOrder": 2,
+          "visible": true,
+          "modelName": "Product",
+          "fieldName": "supplier"
+        },
+        {
           "fieldLocation": { "path": "$.supplierId" },
           "fieldType": "TYPE_ID",
           "displayName": "Supplier",
-          "displayOrder": 2,
+          "displayOrder": 3,
           "visible": true,
           "modelName": "Product",
           "fieldName": "supplierId"


### PR DESCRIPTION
When generating response fields for tools, we're now including a wrapper response field for models that have been embedded.