### PR TITLE
fix: prevent embedding data when no results are available

### DIFF
--- a/runtime/actions/get.go
+++ b/runtime/actions/get.go
@@ -63,7 +63,7 @@ func Get(scope *Scope, input map[string]any) (map[string]any, error) {
 	}
 
 	// if we have embedded data, let's resolve it
-	if len(scope.Action.ResponseEmbeds) > 0 {
+	if len(scope.Action.ResponseEmbeds) > 0 && len(res) > 0 {
 		for _, embed := range scope.Action.ResponseEmbeds {
 			// a response embed will be something like: `book.author.country` where book is the model for the current action
 			fragments := strings.Split(embed, ".")

--- a/runtime/actions/get.go
+++ b/runtime/actions/get.go
@@ -54,6 +54,11 @@ func Get(scope *Scope, input map[string]any) (map[string]any, error) {
 		return nil, common.NewPermissionError()
 	}
 
+	// if result not found, return early
+	if res == nil {
+		return nil, err
+	}
+
 	// if we have any files in our results we need to transform them to the object structure required
 	if scope.Model.HasFiles() {
 		res, err = transformModelFileResponses(scope.Context, scope.Model, res)
@@ -63,7 +68,7 @@ func Get(scope *Scope, input map[string]any) (map[string]any, error) {
 	}
 
 	// if we have embedded data, let's resolve it
-	if len(scope.Action.ResponseEmbeds) > 0 && len(res) > 0 {
+	if len(scope.Action.ResponseEmbeds) > 0 {
 		for _, embed := range scope.Action.ResponseEmbeds {
 			// a response embed will be something like: `book.author.country` where book is the model for the current action
 			fragments := strings.Split(embed, ".")


### PR DESCRIPTION
When resolving a `get` action which has no results (i.e. item not found), we should not attempt to retrieve any embedded data