### PR TITLE
feat: computed on relationship fields

### DIFF
--- a/integration/testdata/computed_fields_model_field/schema.keel
+++ b/integration/testdata/computed_fields_model_field/schema.keel
@@ -1,0 +1,21 @@
+
+
+model OrderJob {
+    fields {
+        customer Customer @computed(orderJob.order.customer)
+        order Order 
+    }
+}
+
+model Order {
+    fields {
+        customer Customer
+    }
+}
+
+model Customer {
+    fields {
+        name Text
+        orders Order[]
+    }
+}

--- a/integration/testdata/computed_fields_model_field/tests.test.ts
+++ b/integration/testdata/computed_fields_model_field/tests.test.ts
@@ -1,0 +1,22 @@
+import { test, expect, beforeEach } from "vitest";
+import { models, resetDatabase } from "@teamkeel/testing";
+
+beforeEach(resetDatabase);
+
+test("computed fields - model field", async () => {
+  const customer1 = await models.customer.create({ name: "John Doe" });
+  const order = await models.order.create({ customerId: customer1.id });
+  const job = await models.orderJob.create({ orderId: order.id });
+
+  expect(job.customerId).toEqual(customer1.id);
+
+  const customer2 = await models.customer.create({ name: "Weave Keelson" });
+  const updatedOrder = await models.order.update(
+    { id: order.id },
+    { customerId: customer2.id }
+  );
+  expect(updatedOrder.customerId).toEqual(customer2.id);
+
+  const getJob = await models.orderJob.findOne({ id: job.id });
+  expect(getJob?.customerId).toEqual(customer2.id);
+});

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -156,6 +156,7 @@ func assertJSON(t *testing.T, expected []byte, actual []byte) {
 	switch diff {
 	case jsondiff.FullMatch:
 		// success
+		return
 	case jsondiff.SupersetMatch, jsondiff.NoMatch:
 		assert.Fail(t, "changes do not match expected", explanation)
 	case jsondiff.FirstArgIsInvalidJson:

--- a/migrations/sql.go
+++ b/migrations/sql.go
@@ -282,6 +282,8 @@ func addComputedFieldFuncStmt(schema *proto.Schema, model *proto.Model, field *p
 	switch field.Type.Type {
 	case proto.Type_TYPE_DECIMAL, proto.Type_TYPE_INT, proto.Type_TYPE_BOOL, proto.Type_TYPE_STRING:
 		sqlType = PostgresFieldTypes[field.Type.Type]
+	case proto.Type_TYPE_MODEL:
+		sqlType = "TEXT"
 	default:
 		return "", "", fmt.Errorf("type not supported for computed fields: %s", field.Type.Type)
 	}

--- a/migrations/testdata/computed_field_model_fields.txt
+++ b/migrations/testdata/computed_field_model_fields.txt
@@ -1,0 +1,128 @@
+===
+
+
+
+model OrderJob {
+    fields {
+        customer Customer @computed(orderJob.order.customer)
+        order Order 
+    }
+}
+
+model Order {
+    fields {
+        customer Customer
+    }
+}
+
+model Customer {
+    fields {
+        name Text
+        orders Order[]
+    }
+}
+
+===
+
+CREATE TABLE "customer" (
+"name" TEXT NOT NULL,
+"id" TEXT NOT NULL DEFAULT ksuid(),
+"created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+"updated_at" TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+ALTER TABLE "customer" ADD CONSTRAINT customer_id_pkey PRIMARY KEY ("id");
+CREATE TABLE "identity" (
+"email" TEXT,
+"email_verified" BOOL NOT NULL DEFAULT false,
+"password" TEXT,
+"external_id" TEXT,
+"issuer" TEXT,
+"name" TEXT,
+"given_name" TEXT,
+"family_name" TEXT,
+"middle_name" TEXT,
+"nick_name" TEXT,
+"profile" TEXT,
+"picture" TEXT,
+"website" TEXT,
+"gender" TEXT,
+"zone_info" TEXT,
+"locale" TEXT,
+"id" TEXT NOT NULL DEFAULT ksuid(),
+"created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+"updated_at" TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+ALTER TABLE "identity" ADD CONSTRAINT identity_id_pkey PRIMARY KEY ("id");
+ALTER TABLE "identity" ADD CONSTRAINT identity_email_issuer_udx UNIQUE ("email", "issuer");
+CREATE TABLE "keel_audit" (
+"id" TEXT NOT NULL DEFAULT ksuid(),
+"table_name" TEXT NOT NULL,
+"op" TEXT NOT NULL,
+"data" jsonb NOT NULL,
+"created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+"identity_id" TEXT,
+"trace_id" TEXT,
+"event_processed_at" TIMESTAMPTZ
+);
+ALTER TABLE "keel_audit" ADD CONSTRAINT keel_audit_id_pkey PRIMARY KEY ("id");
+CREATE TABLE "order" (
+"customer_id" TEXT NOT NULL,
+"id" TEXT NOT NULL DEFAULT ksuid(),
+"created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+"updated_at" TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+ALTER TABLE "order" ADD CONSTRAINT order_id_pkey PRIMARY KEY ("id");
+CREATE TABLE "order_job" (
+"customer_id" TEXT NOT NULL,
+"order_id" TEXT NOT NULL,
+"id" TEXT NOT NULL DEFAULT ksuid(),
+"created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+"updated_at" TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+ALTER TABLE "order_job" ADD CONSTRAINT order_job_id_pkey PRIMARY KEY ("id");
+ALTER TABLE "order" ADD FOREIGN KEY ("customer_id") REFERENCES "customer"("id") ON DELETE CASCADE;
+ALTER TABLE "order_job" ADD FOREIGN KEY ("customer_id") REFERENCES "customer"("id") ON DELETE CASCADE;
+ALTER TABLE "order_job" ADD FOREIGN KEY ("order_id") REFERENCES "order"("id") ON DELETE CASCADE;
+CREATE TRIGGER order_job_create AFTER INSERT ON "order_job" REFERENCING NEW TABLE AS new_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
+CREATE TRIGGER order_job_update AFTER UPDATE ON "order_job" REFERENCING NEW TABLE AS new_table OLD TABLE AS old_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
+CREATE TRIGGER order_job_delete AFTER DELETE ON "order_job" REFERENCING OLD TABLE AS old_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
+CREATE TRIGGER order_job_updated_at BEFORE UPDATE ON "order_job" FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+CREATE TRIGGER order_create AFTER INSERT ON "order" REFERENCING NEW TABLE AS new_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
+CREATE TRIGGER order_update AFTER UPDATE ON "order" REFERENCING NEW TABLE AS new_table OLD TABLE AS old_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
+CREATE TRIGGER order_delete AFTER DELETE ON "order" REFERENCING OLD TABLE AS old_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
+CREATE TRIGGER order_updated_at BEFORE UPDATE ON "order" FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+CREATE TRIGGER customer_create AFTER INSERT ON "customer" REFERENCING NEW TABLE AS new_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
+CREATE TRIGGER customer_update AFTER UPDATE ON "customer" REFERENCING NEW TABLE AS new_table OLD TABLE AS old_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
+CREATE TRIGGER customer_delete AFTER DELETE ON "customer" REFERENCING OLD TABLE AS old_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
+CREATE TRIGGER customer_updated_at BEFORE UPDATE ON "customer" FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+CREATE TRIGGER identity_create AFTER INSERT ON "identity" REFERENCING NEW TABLE AS new_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
+CREATE TRIGGER identity_update AFTER UPDATE ON "identity" REFERENCING NEW TABLE AS new_table OLD TABLE AS old_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
+CREATE TRIGGER identity_delete AFTER DELETE ON "identity" REFERENCING OLD TABLE AS old_table FOR EACH STATEMENT EXECUTE PROCEDURE process_audit();
+CREATE TRIGGER identity_updated_at BEFORE UPDATE ON "identity" FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+CREATE FUNCTION "order_job__customer__92d925ba__comp"(r "order_job") RETURNS TEXT AS $$ BEGIN
+	RETURN (SELECT "order"."customer_id" FROM "order" WHERE "order"."id" IS NOT DISTINCT FROM r."order_id");
+END; $$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION "order_job__exec_comp_fns"() RETURNS TRIGGER AS $$ BEGIN
+	NEW."customer_id" := order_job__customer__92d925ba__comp(NEW);
+	RETURN NEW;
+END; $$ LANGUAGE plpgsql;
+CREATE OR REPLACE TRIGGER "order_job__comp" BEFORE INSERT OR UPDATE ON "order_job" FOR EACH ROW EXECUTE PROCEDURE "order_job__exec_comp_fns"();
+CREATE OR REPLACE FUNCTION "order__to__order_job__8302a118__comp_dep"() RETURNS TRIGGER AS $$
+BEGIN
+	UPDATE "order_job" SET id = id WHERE "order_id" IN (NEW.id, OLD.id);
+	RETURN NULL;
+END; $$ LANGUAGE plpgsql;
+CREATE OR REPLACE TRIGGER "order__to__order_job__8302a118__comp_dep" AFTER INSERT OR DELETE ON "order" FOR EACH ROW EXECUTE PROCEDURE "order__to__order_job__8302a118__comp_dep"();
+CREATE OR REPLACE TRIGGER "order__to__order_job__8302a118__comp_dep_update" AFTER UPDATE ON "order" FOR EACH ROW WHEN(NEW."customer_id" IS DISTINCT FROM OLD."customer_id") EXECUTE PROCEDURE "order__to__order_job__8302a118__comp_dep"();
+UPDATE "order_job" SET id = id;
+ALTER TABLE "order_job" ALTER COLUMN "customer_id" SET NOT NULL;
+
+===
+
+[
+    {"Model":"Customer","Field":"","Type":"ADDED"},
+    {"Model":"Identity","Field":"","Type":"ADDED"},
+    {"Model":"KeelAudit","Field":"","Type":"ADDED"},
+    {"Model":"Order","Field":"","Type":"ADDED"},
+    {"Model":"OrderJob","Field":"","Type":"ADDED"}
+]

--- a/node/codegen.go
+++ b/node/codegen.go
@@ -369,15 +369,15 @@ func writeCreateValuesType(w *codegen.Writer, schema *proto.Schema, model *proto
 			continue
 		}
 
+		if field.ComputedExpression != nil {
+			continue
+		}
+
 		if field.ForeignKeyFieldName != nil {
 			w.Writef("// if providing a value for this field do not also set %s\n", field.ForeignKeyFieldName.Value)
 		}
 		if field.ForeignKeyInfo != nil {
 			w.Writef("// if providing a value for this field do not also set %s\n", strings.TrimSuffix(field.Name, "Id"))
-		}
-
-		if field.ComputedExpression != nil {
-			continue
 		}
 
 		w.Write(field.Name)
@@ -435,6 +435,10 @@ func writeCreateValuesType(w *codegen.Writer, schema *proto.Schema, model *proto
 	// the generated foreign key field or the actual model field, but not both.
 	for _, field := range model.Fields {
 		if field.ForeignKeyFieldName == nil || field.Optional {
+			continue
+		}
+
+		if field.ComputedExpression != nil {
 			continue
 		}
 

--- a/runtime/actions/generate_computed_test.go
+++ b/runtime/actions/generate_computed_test.go
@@ -197,7 +197,7 @@ var computedTestCases = []computedTestCase{
 		name:        "concating strings",
 		keelSchema:  testSchema,
 		field:       "name Text @computed(\"Product: \" + item.product.name)",
-		expectedSql: `"Product: " || (SELECT "product"."name" FROM "product" WHERE "product"."id" IS NOT DISTINCT FROM r."product_id")`,
+		expectedSql: `'Product: ' || (SELECT "product"."name" FROM "product" WHERE "product"."id" IS NOT DISTINCT FROM r."product_id")`,
 	},
 }
 

--- a/schema/testdata/errors/attribute_computed.keel
+++ b/schema/testdata/errors/attribute_computed.keel
@@ -15,6 +15,9 @@ model Item {
         secret Secret @computed("secret")
         //expect-error:28:39:AttributeExpressionError:@default cannot be used with computed fields
         withDefault Number @default(1) @computed(1 + 1)
+        //expect-error:31:33:AttributeExpressionError:expression expected to resolve to type Thing but it is Text
+        thing Thing @computed("")
+
     }
     actions {
         get getItem(id) {
@@ -29,6 +32,9 @@ model Item {
 model Thing {
     fields {
         total Decimal @computed(1 + 1)
+        //expect-error:22:35:AttributeNotAllowedError:@computed cannot be used on this side of a relationship
+        //expect-error:32:34:AttributeExpressionError:expression expected to resolve to type Item[] but it is Text
+        items Item[] @computed("")
     }
     actions {
         //expect-error:35:40:ActionInputError:computed fields cannot be used as inputs as they are automatically generated

--- a/schema/testdata/errors/attribute_computed_expression.keel
+++ b/schema/testdata/errors/attribute_computed_expression.keel
@@ -19,7 +19,7 @@ model Item {
         wrongType Decimal @computed(item.description)
         //expect-error:31:34:AttributeExpressionError:unknown identifier 'ctx'
         ctx Boolean @computed(ctx.isAuthenticated)
-        //expect-error:27:50:AttributeNotAllowedError:@computed cannot be used on field of type Identity
+        //expect-error:37:40:AttributeExpressionError:unknown identifier 'ctx'
         identity Identity @computed(ctx.identity)
         //expect-error:33:43:AttributeArgumentError:@computed expressions cannot reference itself
         total Decimal @computed(item.total * 5)

--- a/schema/validation/computed_attribute.go
+++ b/schema/validation/computed_attribute.go
@@ -2,7 +2,9 @@ package validation
 
 import (
 	"fmt"
+	"slices"
 
+	"github.com/teamkeel/keel/casing"
 	"github.com/teamkeel/keel/expressions/resolve"
 	"github.com/teamkeel/keel/schema/attributes"
 	"github.com/teamkeel/keel/schema/parser"
@@ -33,13 +35,20 @@ func ComputedAttributeRules(asts []*parser.AST, errs *errorhandling.ValidationEr
 				return
 			}
 
-			switch field.Type.Value {
-			case parser.FieldTypeBoolean,
+			// Basic types supported with computed fields
+			supportedTypes := []string{
+				parser.FieldTypeBoolean,
 				parser.FieldTypeNumber,
 				parser.FieldTypeDecimal,
-				parser.FieldTypeText:
-				attribute = attr
-			default:
+				parser.FieldTypeText,
+			}
+
+			// Model fields are also supported
+			for _, t := range query.Models(asts) {
+				supportedTypes = append(supportedTypes, t.Name.Value)
+			}
+
+			if !slices.Contains(supportedTypes, field.Type.Value) {
 				errs.AppendError(
 					errorhandling.NewValidationErrorWithDetails(
 						errorhandling.AttributeNotAllowedError,
@@ -49,18 +58,32 @@ func ComputedAttributeRules(asts []*parser.AST, errs *errorhandling.ValidationEr
 						attr,
 					),
 				)
+			} else {
+				attribute = attr
 			}
 
 			if field.Repeated {
-				errs.AppendError(
-					errorhandling.NewValidationErrorWithDetails(
-						errorhandling.AttributeNotAllowedError,
-						errorhandling.ErrorDetails{
-							Message: "@computed cannot be used on repeated fields",
-						},
-						attr,
-					),
-				)
+				if query.Model(asts, field.Type.Value) != nil {
+					errs.AppendError(
+						errorhandling.NewValidationErrorWithDetails(
+							errorhandling.AttributeNotAllowedError,
+							errorhandling.ErrorDetails{
+								Message: "@computed cannot be used on this side of a relationship",
+							},
+							attr,
+						),
+					)
+				} else {
+					errs.AppendError(
+						errorhandling.NewValidationErrorWithDetails(
+							errorhandling.AttributeNotAllowedError,
+							errorhandling.ErrorDetails{
+								Message: "@computed cannot be used on repeated fields",
+							},
+							attr,
+						),
+					)
+				}
 			}
 
 			if len(attr.Arguments) != 1 {
@@ -107,6 +130,10 @@ func ComputedAttributeRules(asts []*parser.AST, errs *errorhandling.ValidationEr
 
 			for _, operand := range operands {
 				if len(operand.Fragments) < 2 {
+					continue
+				}
+
+				if operand.Fragments[0] != casing.ToSnake(model.Name.Value) {
 					continue
 				}
 


### PR DESCRIPTION
Computed on relationship fields
===

One can now use `@computed`  on to-many relationship fields.  See example below:

```
model OrderJob {
    fields {
        customer Customer @computed(orderJob.order.customer)
        order Order 
    }
}

model Order {
    fields {
        customer Customer
    }
}

model Customer {
    fields {
        name Text
        orders Order[]
    }
}
```