### PR TITLE
fix: change the filesystem watcher to use fsnotify for less cpu usage

### DIFF
--- a/cmd/program/commands.go
+++ b/cmd/program/commands.go
@@ -14,13 +14,12 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 
 	_ "embed"
 
 	"github.com/Masterminds/semver/v3"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/radovskyb/watcher"
+	"github.com/fsnotify/fsnotify"
 	"github.com/teamkeel/keel/cmd/cliconfig"
 	"github.com/teamkeel/keel/cmd/database"
 	"github.com/teamkeel/keel/cmd/localTraceExporter"
@@ -570,64 +569,113 @@ type WatcherMsg struct {
 
 func StartWatcher(dir string, ch chan tea.Msg, filter []string) tea.Cmd {
 	return func() tea.Msg {
-		w := watcher.New()
-		w.SetMaxEvents(1)
-		w.FilterOps(watcher.Write, watcher.Remove)
-
-		ignored := []string{
-			"node_modules",
-			"tools",
-		}
-
-		w.AddFilterHook(func(info os.FileInfo, fullPath string) error {
-			// Skip if any directory component is hidden or is in the ignored list
-			pathParts := strings.Split(filepath.Clean(fullPath), string(filepath.Separator))
-			for _, part := range pathParts {
-				if strings.HasPrefix(part, ".") {
-					return watcher.ErrSkip
-				}
-
-				for _, v := range ignored {
-					if strings.Contains(part, v) {
-						return watcher.ErrSkip
-					}
-				}
-			}
-
-			// If there is a filter set then only watch these files
-			if len(filter) > 0 {
-				for _, v := range filter {
-					if !strings.Contains(fullPath, v) {
-						return watcher.ErrSkip
-					}
-				}
-			}
-
-			return nil
-		})
-
-		go func() {
-			for {
-				select {
-				case event := <-w.Event:
-					ch <- WatcherMsg{
-						Path:  event.Path,
-						Event: event.Op.String(),
-					}
-				case <-w.Closed:
-					return
-				}
-			}
-		}()
-
-		err := w.AddRecursive(dir)
+		// Convert relative path to absolute path
+		absDir, err := filepath.Abs(dir)
 		if err != nil {
 			return WatcherMsg{
 				Err: err,
 			}
 		}
 
-		_ = w.Start(time.Millisecond * 100)
+		watcher, err := fsnotify.NewWatcher()
+		if err != nil {
+			return WatcherMsg{
+				Err: err,
+			}
+		}
+
+		// List of ignored directory components
+		ignored := []string{
+			"node_modules",
+			"tools",
+		}
+
+		// Walk through the directory tree and add directories to watch
+		err = filepath.Walk(absDir, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if !info.IsDir() {
+				return nil // Only add directories to the watcher
+			}
+
+			// Skip if any directory component is hidden or is in the ignored list
+			pathParts := strings.Split(filepath.Clean(path), string(filepath.Separator))
+
+			for _, part := range pathParts {
+				if strings.HasPrefix(part, ".") {
+					return filepath.SkipDir
+				}
+
+				for _, v := range ignored {
+					if strings.Contains(part, v) {
+						return filepath.SkipDir
+					}
+				}
+			}
+
+			// If there is a filter set, check if we should watch this directory
+			if len(filter) > 0 {
+				// For filters, we check if any of the files in the directory match
+				// the filter. If not, we skip the directory.
+				shouldWatch := false
+				for _, v := range filter {
+					if strings.Contains(path, v) {
+						shouldWatch = true
+						break
+					}
+				}
+
+				if !shouldWatch {
+					return filepath.SkipDir
+				}
+			}
+
+			// Add the directory to the watcher
+			return watcher.Add(path)
+		})
+
+		if err != nil {
+			return WatcherMsg{
+				Err: err,
+			}
+		}
+
+		// Start watching for events
+		go func() {
+			for {
+				select {
+				case event, ok := <-watcher.Events:
+					if !ok {
+						return
+					}
+
+					// Only send events for write and remove operations
+					if event.Op&fsnotify.Write == fsnotify.Write ||
+						event.Op&fsnotify.Remove == fsnotify.Remove {
+						eventType := "Write"
+						if event.Op&fsnotify.Remove == fsnotify.Remove {
+							eventType = "Remove"
+						}
+
+						ch <- WatcherMsg{
+							Path:  event.Name,
+							Event: eventType,
+						}
+					}
+				case err, ok := <-watcher.Errors:
+					if !ok {
+						return
+					}
+					ch <- WatcherMsg{
+						Err: err,
+					}
+				}
+			}
+		}()
+
+		// Return nil to indicate successful setup
 		return nil
 	}
 }

--- a/cmd/program/commands.go
+++ b/cmd/program/commands.go
@@ -565,7 +565,6 @@ type WatcherMsg struct {
 	Err   error
 	Path  string
 	Event string
-	IsDir bool
 }
 
 func StartWatcher(dir string, ch chan tea.Msg, filter []string) tea.Cmd {

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/emirpasic/gods v1.18.1
 	github.com/evanw/esbuild v0.25.0
 	github.com/fatih/camelcase v1.0.0
+	github.com/fsnotify/fsnotify v1.8.0
 	github.com/goccy/go-yaml v1.15.13
 	github.com/golang-jwt/jwt/v4 v4.5.1
 	github.com/google/cel-go v0.23.2
@@ -50,7 +51,6 @@ require (
 	github.com/otiai10/copy v1.14.1
 	github.com/pulumi/pulumi-aws/sdk/v6 v6.69.0
 	github.com/pulumi/pulumi/sdk/v3 v3.150.0
-	github.com/radovskyb/watcher v1.0.7
 	github.com/relvacode/iso8601 v1.6.0
 	github.com/rs/cors v1.11.1
 	github.com/samber/lo v1.47.0
@@ -122,7 +122,6 @@ require (
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.6.1 // indirect
 	github.com/go-git/go-git/v5 v5.13.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -377,8 +377,6 @@ github.com/pulumi/pulumi-aws/sdk/v6 v6.69.0 h1:SO9xo9PIgufYORBPx82lSQN0CLg1CMab+
 github.com/pulumi/pulumi-aws/sdk/v6 v6.69.0/go.mod h1:OaqbSRCkPxr8XpanQ7u3Xup9MgSnyqQFDxNhV2pXWzw=
 github.com/pulumi/pulumi/sdk/v3 v3.150.0 h1:w5df9oOxqmVfsokWNb901/AvJEFjgBGrG9rgsWFlsJI=
 github.com/pulumi/pulumi/sdk/v3 v3.150.0/go.mod h1:+WC9aIDo8fMgd2g0jCHuZU2S/VYNLRAZ3QXt6YVgwaA=
-github.com/radovskyb/watcher v1.0.7 h1:AYePLih6dpmS32vlHfhCeli8127LzkIgwJGcwwe8tUE=
-github.com/radovskyb/watcher v1.0.7/go.mod h1:78okwvY5wPdzcb1UYnip1pvrZNIVEIh/Cm+ZuvsUYIg=
 github.com/relvacode/iso8601 v1.6.0 h1:eFXUhMJN3Gz8Rcq82f9DTMW0svjtAVuIEULglM7QHTU=
 github.com/relvacode/iso8601 v1.6.0/go.mod h1:FlNp+jz+TXpyRqgmM7tnzHHzBnz776kmAH2h3sZCn0I=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=


### PR DESCRIPTION
Changes the filesystem watcher from radovskyb/watcher to fsnotify, which uses filesystem events instead of polling. This results in a significant drop in CPU usage. 

Previously while running keel I was seeing 60% cpu usage and 1600 energy usage while idle. This drops it to 0.5% cpu usage and 0.5 energy usage for me.

I am not experienced with Go but this looks like it's correct with the same behavior as before, but please let me know if I missed anything and I can fix it :)