### PR TITLE
chore: hide source model when generating embedded tools

### DIFF
--- a/tools/generator.go
+++ b/tools/generator.go
@@ -346,6 +346,10 @@ func (g *Generator) generateEmbeddedTools() {
 										},
 									},
 								},
+								ResponseOverrides: []*toolsproto.ResponseOverrides{{
+									FieldLocation: &toolsproto.JsonPath{Path: "$.results[*]." + f.InverseFieldName.Value + "Id"},
+									Visible:       false,
+								}},
 							},
 						},
 						Visible: true,

--- a/tools/testdata/blog/tools.json
+++ b/tools/testdata/blog/tools.json
@@ -766,7 +766,14 @@
                 "title": {
                   "template": "comments"
                 }
-              }
+              },
+              "responseOverrides": [
+                {
+                  "fieldLocation": {
+                    "path": "$.results[*].parentId"
+                  }
+                }
+              ]
             }
           ],
           "visible": true

--- a/tools/testdata/config_use_api/tools.json
+++ b/tools/testdata/config_use_api/tools.json
@@ -502,7 +502,14 @@
                 "title": {
                   "template": "comments"
                 }
-              }
+              },
+              "responseOverrides": [
+                {
+                  "fieldLocation": {
+                    "path": "$.results[*].parentId"
+                  }
+                }
+              ]
             }
           ],
           "visible": true

--- a/tools/testdata/one_to_many_links/tools.json
+++ b/tools/testdata/one_to_many_links/tools.json
@@ -113,7 +113,14 @@
                 "title": {
                   "template": "items"
                 }
-              }
+              },
+              "responseOverrides": [
+                {
+                  "fieldLocation": {
+                    "path": "$.results[*].orderId"
+                  }
+                }
+              ]
             }
           ],
           "visible": true


### PR DESCRIPTION
When generating embedded tools for a get tool that operates on a model that has a has many relationship, the embedded tool should not display the field for the source model (i.e. the one for the get tool) as it is redundant.


I.e. a `get-order`, embeds `list-order-lines`, this list tool should have a response override to hide the `order` column for all order lines.