### PR TITLE
fix: relaxing enum casing

### DIFF
--- a/integration/testdata/built_in_actions/main.test.ts
+++ b/integration/testdata/built_in_actions/main.test.ts
@@ -122,13 +122,13 @@ test("list action - notEquals with enum", async () => {
   });
   await models.post.create({
     title: "mango",
-    category: Category.Lifestyle,
+    category: Category.something_123,
     subTitle: "mno",
   });
 
   const posts = await actions.listPosts({
     where: {
-      category: { notEquals: Category.Lifestyle },
+      category: { notEquals: Category.something_123 },
     },
   });
 
@@ -223,18 +223,23 @@ test("list action - oneOf enum", async () => {
   });
   await models.post.create({
     title: "mango",
-    category: Category.Lifestyle,
+    category: Category.lifestyle,
     subTitle: "mno",
   });
   await models.post.create({
     title: "orange",
-    category: Category.Food,
+    category: Category.FOOD,
     subTitle: "fog",
+  });
+  await models.post.create({
+    title: "something",
+    category: Category.something_123,
+    subTitle: "som",
   });
 
   const { results } = await actions.listPosts({
     where: {
-      category: { oneOf: [Category.Technical, Category.Lifestyle] },
+      category: { oneOf: [Category.Technical, Category.lifestyle] },
     },
   });
 

--- a/integration/testdata/built_in_actions/schema.keel
+++ b/integration/testdata/built_in_actions/schema.keel
@@ -27,8 +27,9 @@ model Post {
 
 enum Category {
     Technical
-    Food
-    Lifestyle
+    FOOD
+    lifestyle
+    something_123
 }
 
 api Web {

--- a/runtime/apis/graphql/testdata/graphql/enums.graphql
+++ b/runtime/apis/graphql/testdata/graphql/enums.graphql
@@ -30,10 +30,11 @@ type Timestamp {
 }
 
 enum Occupation {
-  Astronaut
   Doctor
-  Firefighter
+  FIRE_FIGHTER
+  Officer_1
   Teacher
+  astronaut
 }
 
 scalar Any

--- a/runtime/apis/graphql/testdata/graphql/enums.keel
+++ b/runtime/apis/graphql/testdata/graphql/enums.keel
@@ -12,8 +12,9 @@ model Person {
 enum Occupation {
     Teacher
     Doctor
-    Firefighter
-    Astronaut
+    FIRE_FIGHTER
+    astronaut
+    Officer_1
 }
 
 api Test {

--- a/runtime/openapi/testdata/basic.json
+++ b/runtime/openapi/testdata/basic.json
@@ -1,6 +1,9 @@
 {
   "openapi": "3.1.0",
-  "info": { "title": "Web", "version": "1" },
+  "info": {
+    "title": "Web",
+    "version": "1"
+  },
   "paths": {
     "/web/json/createCustomer": {
       "post": {
@@ -15,11 +18,34 @@
                   "address": {
                     "$ref": "#/components/schemas/CreateCustomerAddressInput"
                   },
-                  "dateOfBirth": { "type": "string", "format": "date" },
-                  "details": { "type": "string", "format": "markdown" },
-                  "name": { "type": "string" },
-                  "picture": { "type": "string", "format": "data-url" },
-                  "weight": { "type": "number", "format": "float" }
+                  "dateOfBirth": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "details": {
+                    "type": "string",
+                    "format": "markdown"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "occupation": {
+                    "enum": [
+                      "Teacher",
+                      "Doctor",
+                      "FIRE_FIGHTER",
+                      "astronaut",
+                      "Officer_1"
+                    ]
+                  },
+                  "picture": {
+                    "type": "string",
+                    "format": "data-url"
+                  },
+                  "weight": {
+                    "type": "number",
+                    "format": "float"
+                  }
                 },
                 "unevaluatedProperties": false,
                 "required": [
@@ -28,7 +54,8 @@
                   "address",
                   "details",
                   "weight",
-                  "picture"
+                  "picture",
+                  "occupation"
                 ]
               }
             }
@@ -39,7 +66,9 @@
             "description": "createCustomer Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Customer" }
+                "schema": {
+                  "$ref": "#/components/schemas/Customer"
+                }
               }
             }
           },
@@ -49,20 +78,28 @@
               "application/json": {
                 "schema": {
                   "properties": {
-                    "code": { "type": "string" },
+                    "code": {
+                      "type": "string"
+                    },
                     "data": {
                       "type": ["object", "null"],
                       "properties": {
                         "errors": {
                           "type": "array",
                           "properties": {
-                            "error": { "type": "string" },
-                            "field": { "type": "string" }
+                            "error": {
+                              "type": "string"
+                            },
+                            "field": {
+                              "type": "string"
+                            }
                           }
                         }
                       }
                     },
-                    "message": { "type": "string" }
+                    "message": {
+                      "type": "string"
+                    }
                   }
                 }
               }
@@ -81,13 +118,27 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "after": { "type": "string" },
-                  "before": { "type": "string" },
-                  "first": { "type": "number" },
-                  "last": { "type": "number" },
-                  "limit": { "type": "number" },
-                  "offset": { "type": "number" },
-                  "where": { "$ref": "#/components/schemas/CustomersWhere" }
+                  "after": {
+                    "type": "string"
+                  },
+                  "before": {
+                    "type": "string"
+                  },
+                  "first": {
+                    "type": "number"
+                  },
+                  "last": {
+                    "type": "number"
+                  },
+                  "limit": {
+                    "type": "number"
+                  },
+                  "offset": {
+                    "type": "number"
+                  },
+                  "where": {
+                    "$ref": "#/components/schemas/CustomersWhere"
+                  }
                 },
                 "unevaluatedProperties": false
               }
@@ -103,17 +154,31 @@
                   "properties": {
                     "pageInfo": {
                       "properties": {
-                        "count": { "type": "number" },
-                        "endCursor": { "type": "string" },
-                        "hasNextPage": { "type": "boolean" },
-                        "pageNumber": { "type": "number" },
-                        "startCursor": { "type": "string" },
-                        "totalCount": { "type": "number" }
+                        "count": {
+                          "type": "number"
+                        },
+                        "endCursor": {
+                          "type": "string"
+                        },
+                        "hasNextPage": {
+                          "type": "boolean"
+                        },
+                        "pageNumber": {
+                          "type": "number"
+                        },
+                        "startCursor": {
+                          "type": "string"
+                        },
+                        "totalCount": {
+                          "type": "number"
+                        }
                       }
                     },
                     "results": {
                       "type": "array",
-                      "items": { "$ref": "#/components/schemas/Customer" }
+                      "items": {
+                        "$ref": "#/components/schemas/Customer"
+                      }
                     }
                   }
                 }
@@ -126,20 +191,28 @@
               "application/json": {
                 "schema": {
                   "properties": {
-                    "code": { "type": "string" },
+                    "code": {
+                      "type": "string"
+                    },
                     "data": {
                       "type": ["object", "null"],
                       "properties": {
                         "errors": {
                           "type": "array",
                           "properties": {
-                            "error": { "type": "string" },
-                            "field": { "type": "string" }
+                            "error": {
+                              "type": "string"
+                            },
+                            "field": {
+                              "type": "string"
+                            }
                           }
                         }
                       }
                     },
-                    "message": { "type": "string" }
+                    "message": {
+                      "type": "string"
+                    }
                   }
                 }
               }
@@ -157,7 +230,11 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "properties": { "id": { "type": "string" } },
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  }
+                },
                 "unevaluatedProperties": false,
                 "required": ["id"]
               }
@@ -169,7 +246,9 @@
             "description": "getCustomer Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Customer" }
+                "schema": {
+                  "$ref": "#/components/schemas/Customer"
+                }
               }
             }
           },
@@ -179,20 +258,28 @@
               "application/json": {
                 "schema": {
                   "properties": {
-                    "code": { "type": "string" },
+                    "code": {
+                      "type": "string"
+                    },
                     "data": {
                       "type": ["object", "null"],
                       "properties": {
                         "errors": {
                           "type": "array",
                           "properties": {
-                            "error": { "type": "string" },
-                            "field": { "type": "string" }
+                            "error": {
+                              "type": "string"
+                            },
+                            "field": {
+                              "type": "string"
+                            }
                           }
                         }
                       }
                     },
-                    "message": { "type": "string" }
+                    "message": {
+                      "type": "string"
+                    }
                   }
                 }
               }
@@ -229,7 +316,9 @@
             "description": "updateCustomer Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Customer" }
+                "schema": {
+                  "$ref": "#/components/schemas/Customer"
+                }
               }
             }
           },
@@ -239,20 +328,28 @@
               "application/json": {
                 "schema": {
                   "properties": {
-                    "code": { "type": "string" },
+                    "code": {
+                      "type": "string"
+                    },
                     "data": {
                       "type": ["object", "null"],
                       "properties": {
                         "errors": {
                           "type": "array",
                           "properties": {
-                            "error": { "type": "string" },
-                            "field": { "type": "string" }
+                            "error": {
+                              "type": "string"
+                            },
+                            "field": {
+                              "type": "string"
+                            }
                           }
                         }
                       }
                     },
-                    "message": { "type": "string" }
+                    "message": {
+                      "type": "string"
+                    }
                   }
                 }
               }
@@ -267,33 +364,77 @@
       "CreateCustomerAddressInput": {
         "type": "object",
         "properties": {
-          "addressLine1": { "type": "string" },
-          "town": { "type": "string" }
+          "addressLine1": {
+            "type": "string"
+          },
+          "town": {
+            "type": "string"
+          }
         },
         "unevaluatedProperties": false,
         "required": ["addressLine1", "town"]
       },
       "Customer": {
         "properties": {
-          "addressId": { "type": "string" },
-          "createdAt": { "type": "string", "format": "date-time" },
-          "dateOfBirth": { "type": "string", "format": "date" },
-          "details": { "type": "string", "format": "markdown" },
-          "id": { "type": "string" },
-          "name": { "type": "string" },
+          "addressId": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "dateOfBirth": {
+            "type": "string",
+            "format": "date"
+          },
+          "details": {
+            "type": "string",
+            "format": "markdown"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "occupation": {
+            "enum": [
+              "Teacher",
+              "Doctor",
+              "FIRE_FIGHTER",
+              "astronaut",
+              "Officer_1"
+            ]
+          },
           "picture": {
             "type": "object",
             "properties": {
-              "contentType": { "type": "string" },
-              "filename": { "type": "string" },
-              "key": { "type": "string" },
-              "size": { "type": "number" },
-              "url": { "type": "string" }
+              "contentType": {
+                "type": "string"
+              },
+              "filename": {
+                "type": "string"
+              },
+              "key": {
+                "type": "string"
+              },
+              "size": {
+                "type": "number"
+              },
+              "url": {
+                "type": "string"
+              }
             },
             "required": ["key", "filename", "contentType", "size", "url"]
           },
-          "updatedAt": { "type": "string", "format": "date-time" },
-          "weight": { "type": "number", "format": "float" }
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "weight": {
+            "type": "number",
+            "format": "float"
+          }
         },
         "required": [
           "name",
@@ -302,6 +443,7 @@
           "details",
           "weight",
           "picture",
+          "occupation",
           "id",
           "createdAt",
           "updatedAt"
@@ -310,7 +452,9 @@
       "CustomersWhere": {
         "type": "object",
         "properties": {
-          "name": { "$ref": "#/components/schemas/StringQueryInput" }
+          "name": {
+            "$ref": "#/components/schemas/StringQueryInput"
+          }
         },
         "unevaluatedProperties": false
       },
@@ -319,38 +463,63 @@
         "oneOf": [
           {
             "type": "object",
-            "properties": { "equals": { "type": ["string", "null"] } },
+            "properties": {
+              "equals": {
+                "type": ["string", "null"]
+              }
+            },
             "required": ["equals"],
             "title": "equals"
           },
           {
             "type": "object",
-            "properties": { "notEquals": { "type": ["string", "null"] } },
+            "properties": {
+              "notEquals": {
+                "type": ["string", "null"]
+              }
+            },
             "required": ["notEquals"],
             "title": "notEquals"
           },
           {
             "type": "object",
-            "properties": { "startsWith": { "type": "string" } },
+            "properties": {
+              "startsWith": {
+                "type": "string"
+              }
+            },
             "required": ["startsWith"],
             "title": "startsWith"
           },
           {
             "type": "object",
-            "properties": { "endsWith": { "type": "string" } },
+            "properties": {
+              "endsWith": {
+                "type": "string"
+              }
+            },
             "required": ["endsWith"],
             "title": "endsWith"
           },
           {
             "type": "object",
-            "properties": { "contains": { "type": "string" } },
+            "properties": {
+              "contains": {
+                "type": "string"
+              }
+            },
             "required": ["contains"],
             "title": "contains"
           },
           {
             "type": "object",
             "properties": {
-              "oneOf": { "type": "array", "items": { "type": "string" } }
+              "oneOf": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
             },
             "required": ["oneOf"],
             "title": "oneOf"
@@ -360,17 +529,35 @@
       "UpdateCustomerValues": {
         "type": "object",
         "properties": {
-          "dateOfBirth": { "type": "string", "format": "date" },
-          "details": { "type": "string", "format": "markdown" },
-          "name": { "type": "string" },
-          "picture": { "type": "string", "format": "data-url" },
-          "weight": { "type": "number", "format": "float" }
+          "dateOfBirth": {
+            "type": "string",
+            "format": "date"
+          },
+          "details": {
+            "type": "string",
+            "format": "markdown"
+          },
+          "name": {
+            "type": "string"
+          },
+          "picture": {
+            "type": "string",
+            "format": "data-url"
+          },
+          "weight": {
+            "type": "number",
+            "format": "float"
+          }
         },
         "unevaluatedProperties": false
       },
       "UpdateCustomerWhere": {
         "type": "object",
-        "properties": { "id": { "type": "string" } },
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
         "unevaluatedProperties": false,
         "required": ["id"]
       }

--- a/runtime/openapi/testdata/basic.keel
+++ b/runtime/openapi/testdata/basic.keel
@@ -13,6 +13,7 @@ model Customer {
         details Markdown
         weight Decimal
         picture File
+        occupation Occupation
     }
 
     actions {
@@ -24,12 +25,21 @@ model Customer {
             address.town,
             details,
             weight,
-            picture
+            picture,
+            occupation
         )
         update updateCustomer(id) with (name?, dateOfBirth?, details?, weight?, picture?)
         list customers(name?)
     }
 }
+
+enum Occupation {
+    Teacher
+    Doctor
+    FIRE_FIGHTER
+    astronaut
+    Officer_1
+} 
 
 api Web {
     models {

--- a/schema/testdata/proto/enums/proto.json
+++ b/schema/testdata/proto/enums/proto.json
@@ -237,6 +237,26 @@
           "name": "Neptune"
         }
       ]
+    },
+    {
+      "name": "BlackHoles",
+      "values": [
+        {
+          "name": "SaggittariusA"
+        },
+        {
+          "name": "Ton_618"
+        },
+        {
+          "name": "NGC_4468B"
+        },
+        {
+          "name": "S5_0014plus81"
+        },
+        {
+          "name": "ic_1459"
+        }
+      ]
     }
   ],
   "messages": [

--- a/schema/testdata/proto/enums/schema.keel
+++ b/schema/testdata/proto/enums/schema.keel
@@ -8,3 +8,11 @@ enum Planets {
     Uranus
     Neptune
 }
+
+enum BlackHoles {
+    SaggittariusA
+    Ton_618
+    NGC_4468B
+    S5_0014plus81
+    ic_1459
+}

--- a/schema/validation/casing.go
+++ b/schema/validation/casing.go
@@ -34,9 +34,6 @@ func CasingRule(_ []*parser.AST, errs *errorhandling.ValidationErrors) Visitor {
 		},
 		EnterEnum: func(n *parser.EnumNode) {
 			errs.AppendError(checkCasing(n.Name, "enum"))
-			for _, v := range n.Values {
-				errs.AppendError(checkCasing(v.Name, "enum value"))
-			}
 		},
 		EnterMessage: func(n *parser.MessageNode) {
 			errs.AppendError(checkCasing(n.Name, "message"))


### PR DESCRIPTION
Enum values were restricted to being upper case camel, for e.g. `ComputerParts`.  This PR relaxed this rule and allows for any casing, numbers and the underscore. 