### PR TITLE
fix: handle tools generation with no config

### DIFF
--- a/tools/generator.go
+++ b/tools/generator.go
@@ -85,7 +85,7 @@ func (g *Generator) Generate(ctx context.Context) error {
 // the completed generation is done later on
 func (g *Generator) scaffoldTools() {
 	var api *proto.Api
-	if g.KeelConfig.Console.Api != nil {
+	if g.KeelConfig != nil && g.KeelConfig.Console.Api != nil {
 		if api = proto.FindApi(g.Schema, *g.KeelConfig.Console.Api); api == nil {
 			return
 		}


### PR DESCRIPTION
Prevent panic when attempting to generate tools without any keel config.