### PR TITLE
chore: bump kysely to 0.27.6

### DIFF
--- a/node/bootstrap.go
+++ b/node/bootstrap.go
@@ -43,7 +43,7 @@ func GetDependencies(options *bootstrapOptions) (map[string]string, map[string]s
 	deps := map[string]string{
 		"@teamkeel/functions-runtime": functionsRuntimeVersion,
 		"@teamkeel/testing-runtime":   testingRuntimeVersion,
-		"kysely":                      "0.27.4",
+		"kysely":                      "0.27.6",
 		"node-fetch":                  "3.3.2",
 	}
 


### PR DESCRIPTION
Bumps kysely to the latest version; this is consistent to the requirements of the `functions-runtime` package.