### PR TITLE
perf: previous data lookup in events

### DIFF
--- a/integration/testdata/events_basic/functions/updateTrackers.ts
+++ b/integration/testdata/events_basic/functions/updateTrackers.ts
@@ -1,0 +1,8 @@
+import { models, UpdateTrackers } from "@teamkeel/sdk";
+
+export default UpdateTrackers(async (ctx, inputs) => {
+  const trackers = await models.tracker.findMany();
+  for (const t of trackers) {
+    await models.tracker.update({ id: t.id }, { views: t.views + 1 });
+  }
+});

--- a/integration/testdata/events_basic/schema.keel
+++ b/integration/testdata/events_basic/schema.keel
@@ -33,6 +33,27 @@ model Person {
     )
 }
 
+model Tracker {
+    fields {
+        views Number @default(0)
+        verifiedUpdate Boolean @default(true)
+    }
+    actions {
+        update updateViews(id) with (views) {
+            @set(tracker.verifiedUpdate = false)
+            @permission(expression: true)
+        }
+        write updateTrackers(Any) returns (Any) {
+            @permission(expression: true)
+        }
+    }
+
+    @on(
+        [update],
+        verifyUpdate
+    )
+}
+
 job CreateRandomPersons {
     inputs {
         raiseException Boolean

--- a/integration/testdata/events_basic/subscribers/verifyUpdate.ts
+++ b/integration/testdata/events_basic/subscribers/verifyUpdate.ts
@@ -1,18 +1,38 @@
-import { models, VerifyUpdate, SubscriberContextAPI } from "@teamkeel/sdk";
+import { models, VerifyUpdate } from "@teamkeel/sdk";
 
-export default VerifyUpdate(async (ctx: SubscriberContextAPI, event) => {
-  if (event.target.data.name == "") {
-    throw new Error("name cannot be empty");
-  }
+export default VerifyUpdate(async (ctx, event) => {
+  switch (event.eventName) {
+    case "person.updated":
+      if (event.target.data.name == "") {
+        throw new Error("name cannot be empty");
+      }
 
-  if (event.target.previousData == null) {
-    throw new Error("previous data cannot be null");
-  }
+      if (event.target.previousData == null) {
+        throw new Error("previous data cannot be null");
+      }
 
-  if (!event.target.data.verifiedUpdate) {
-    await models.person.update(
-      { id: event.target.data.id },
-      { verifiedUpdate: true }
-    );
+      if (!event.target.data.verifiedUpdate) {
+        await models.person.update(
+          { id: event.target.data.id },
+          { verifiedUpdate: true }
+        );
+      }
+
+      break;
+
+    case "tracker.updated":
+      if (event.target.data.views != event.target.previousData.views + 1) {
+        console.log("previous data not correct");
+        throw new Error("previous data not correct");
+      }
+
+      if (!event.target.data.verifiedUpdate) {
+        await models.tracker.update(
+          { id: event.target.data.id },
+          { verifiedUpdate: true }
+        );
+      }
+
+      break;
   }
 });

--- a/integration/testdata/events_basic/tests.test.ts
+++ b/integration/testdata/events_basic/tests.test.ts
@@ -3,87 +3,139 @@ import { beforeEach, expect, test } from "vitest";
 
 beforeEach(resetDatabase);
 
-test("events from action", async () => {
-  await actions.createPerson({ name: "Keelson", email: "keelson@keel.so" });
-  await actions.createPersonFn({ name: "Weaveton", email: "weaveton@keel.so" });
+// test("events from action", async () => {
+//   await actions.createPerson({ name: "Keelson", email: "keelson@keel.so" });
+//   await actions.createPersonFn({ name: "Weaveton", email: "weaveton@keel.so" });
 
-  const persons = await models.person.findMany();
+//   const persons = await models.person.findMany();
 
-  expect(persons).toHaveLength(2);
-  expect(persons[0].verifiedEmail).toBeTruthy();
-  expect(persons[1].verifiedEmail).toBeTruthy();
-  expect(persons[0].verifiedUpdate).toBeTruthy();
-  expect(persons[1].verifiedUpdate).toBeTruthy();
-});
+//   expect(persons).toHaveLength(2);
+//   expect(persons[0].verifiedEmail).toBeTruthy();
+//   expect(persons[1].verifiedEmail).toBeTruthy();
+//   expect(persons[0].verifiedUpdate).toBeTruthy();
+//   expect(persons[1].verifiedUpdate).toBeTruthy();
+// });
 
-test("events from hook functions", async () => {
-  await actions.createPersonFn({ name: "Keelson", email: "keelson@keel.so" });
-  await actions.createPersonFn({ name: "Weaveton", email: "weaveton@keel.so" });
+// test("events from hook functions", async () => {
+//   await actions.createPersonFn({ name: "Keelson", email: "keelson@keel.so" });
+//   await actions.createPersonFn({ name: "Weaveton", email: "weaveton@keel.so" });
 
-  const persons = await models.person.findMany();
+//   const persons = await models.person.findMany();
 
-  expect(persons).toHaveLength(2);
-  expect(persons[0].verifiedEmail).toBeTruthy();
-  expect(persons[1].verifiedEmail).toBeTruthy();
-  expect(persons[0].verifiedUpdate).toBeTruthy();
-  expect(persons[1].verifiedUpdate).toBeTruthy();
-});
+//   expect(persons).toHaveLength(2);
+//   expect(persons[0].verifiedEmail).toBeTruthy();
+//   expect(persons[1].verifiedEmail).toBeTruthy();
+//   expect(persons[0].verifiedUpdate).toBeTruthy();
+//   expect(persons[1].verifiedUpdate).toBeTruthy();
+// });
 
-test("events from custom function", async () => {
-  const result = await actions.writeRandomPersons();
-  expect(result).toBeTruthy();
+// test("events from custom function", async () => {
+//   const result = await actions.writeRandomPersons();
+//   expect(result).toBeTruthy();
 
-  const persons = await models.person.findMany();
+//   const persons = await models.person.findMany();
 
-  expect(persons).toHaveLength(2);
-  expect(persons[0].verifiedEmail).toBeTruthy();
-  expect(persons[1].verifiedEmail).toBeTruthy();
-  expect(persons[0].verifiedUpdate).toBeTruthy();
-  expect(persons[1].verifiedUpdate).toBeTruthy();
-});
+//   expect(persons).toHaveLength(2);
+//   expect(persons[0].verifiedEmail).toBeTruthy();
+//   expect(persons[1].verifiedEmail).toBeTruthy();
+//   expect(persons[0].verifiedUpdate).toBeTruthy();
+//   expect(persons[1].verifiedUpdate).toBeTruthy();
+// });
 
-test("events from job", async () => {
-  await jobs.createRandomPersons({ raiseException: false });
+// test("events from job", async () => {
+//   await jobs.createRandomPersons({ raiseException: false });
 
-  const persons = await models.person.findMany();
+//   const persons = await models.person.findMany();
 
-  expect(persons).toHaveLength(2);
-  expect(persons[0].verifiedEmail).toBeTruthy();
-  expect(persons[1].verifiedEmail).toBeTruthy();
-  expect(persons[0].verifiedUpdate).toBeTruthy();
-  expect(persons[1].verifiedUpdate).toBeTruthy();
-});
+//   expect(persons).toHaveLength(2);
+//   expect(persons[0].verifiedEmail).toBeTruthy();
+//   expect(persons[1].verifiedEmail).toBeTruthy();
+//   expect(persons[0].verifiedUpdate).toBeTruthy();
+//   expect(persons[1].verifiedUpdate).toBeTruthy();
+// });
 
-test("events from failed hook function with rollback", async () => {
-  await expect(
-    actions.createPersonFn({ name: "", email: "keelson@keel.so" })
-  ).toHaveError({
-    code: "ERR_UNKNOWN",
+// test("events from failed hook function with rollback", async () => {
+//   await expect(
+//     actions.createPersonFn({ name: "", email: "keelson@keel.so" })
+//   ).toHaveError({
+//     code: "ERR_UNKNOWN",
+//   });
+
+//   const persons = await models.person.findMany();
+//   expect(persons).toHaveLength(0);
+// });
+
+// test("events from failed job", async () => {
+//   await jobs.createRandomPersons({ raiseException: true });
+
+//   const persons = await models.person.findMany();
+
+//   expect(persons).toHaveLength(2);
+//   expect(persons[0].verifiedEmail).toBeTruthy();
+//   expect(persons[1].verifiedEmail).toBeTruthy();
+//   expect(persons[0].verifiedUpdate).toBeTruthy();
+//   expect(persons[1].verifiedUpdate).toBeTruthy();
+// });
+
+// test("events from failed custom function with rollback", async () => {
+//   await expect(
+//     actions.writeRandomPersons({ raiseException: true })
+//   ).toHaveError({
+//     code: "ERR_UNKNOWN",
+//   });
+
+//   const persons = await models.person.findMany();
+//   expect(persons).toHaveLength(0);
+// });
+
+// test("event previous data", async () => {
+//   const t = await models.tracker.create({
+//     views: 0,
+//   });
+
+//   const updated = await actions.updateViews({ where: { id: t.id }, values: { views: 1 } });
+
+//   const get = await models.tracker.findOne({ id: t.id });
+
+//   expect(get!.views).toEqual(1);
+//   expect(get!.verifiedUpdate).toBeTruthy();
+
+// });
+
+test("event previous data bulk", async () => {
+  await models.tracker.create({
+    views: 3,
   });
 
-  const persons = await models.person.findMany();
-  expect(persons).toHaveLength(0);
-});
-
-test("events from failed job", async () => {
-  await jobs.createRandomPersons({ raiseException: true });
-
-  const persons = await models.person.findMany();
-
-  expect(persons).toHaveLength(2);
-  expect(persons[0].verifiedEmail).toBeTruthy();
-  expect(persons[1].verifiedEmail).toBeTruthy();
-  expect(persons[0].verifiedUpdate).toBeTruthy();
-  expect(persons[1].verifiedUpdate).toBeTruthy();
-});
-
-test("events from failed custom function with rollback", async () => {
-  await expect(
-    actions.writeRandomPersons({ raiseException: true })
-  ).toHaveError({
-    code: "ERR_UNKNOWN",
+  await models.tracker.create({
+    views: 0,
   });
 
-  const persons = await models.person.findMany();
-  expect(persons).toHaveLength(0);
+  await models.tracker.create({
+    views: 10,
+  });
+
+  await models.tracker.create({
+    views: 8,
+  });
+
+  await models.tracker.create({
+    views: 2,
+  });
+
+  await models.tracker.create({
+    views: 4,
+  });
+
+  await actions.updateTrackers({});
+  await actions.updateTrackers({});
+  await actions.updateTrackers({});
+  await actions.updateTrackers({});
+  await actions.updateTrackers({});
+
+  const trackers = await models.tracker.findMany();
+
+  for (const t of trackers) {
+    expect(t.verifiedUpdate).toBeTruthy();
+  }
 });

--- a/integration/testdata/events_basic/tests.test.ts
+++ b/integration/testdata/events_basic/tests.test.ts
@@ -3,104 +3,106 @@ import { beforeEach, expect, test } from "vitest";
 
 beforeEach(resetDatabase);
 
-// test("events from action", async () => {
-//   await actions.createPerson({ name: "Keelson", email: "keelson@keel.so" });
-//   await actions.createPersonFn({ name: "Weaveton", email: "weaveton@keel.so" });
+test("events from action", async () => {
+  await actions.createPerson({ name: "Keelson", email: "keelson@keel.so" });
+  await actions.createPersonFn({ name: "Weaveton", email: "weaveton@keel.so" });
 
-//   const persons = await models.person.findMany();
+  const persons = await models.person.findMany();
 
-//   expect(persons).toHaveLength(2);
-//   expect(persons[0].verifiedEmail).toBeTruthy();
-//   expect(persons[1].verifiedEmail).toBeTruthy();
-//   expect(persons[0].verifiedUpdate).toBeTruthy();
-//   expect(persons[1].verifiedUpdate).toBeTruthy();
-// });
+  expect(persons).toHaveLength(2);
+  expect(persons[0].verifiedEmail).toBeTruthy();
+  expect(persons[1].verifiedEmail).toBeTruthy();
+  expect(persons[0].verifiedUpdate).toBeTruthy();
+  expect(persons[1].verifiedUpdate).toBeTruthy();
+});
 
-// test("events from hook functions", async () => {
-//   await actions.createPersonFn({ name: "Keelson", email: "keelson@keel.so" });
-//   await actions.createPersonFn({ name: "Weaveton", email: "weaveton@keel.so" });
+test("events from hook functions", async () => {
+  await actions.createPersonFn({ name: "Keelson", email: "keelson@keel.so" });
+  await actions.createPersonFn({ name: "Weaveton", email: "weaveton@keel.so" });
 
-//   const persons = await models.person.findMany();
+  const persons = await models.person.findMany();
 
-//   expect(persons).toHaveLength(2);
-//   expect(persons[0].verifiedEmail).toBeTruthy();
-//   expect(persons[1].verifiedEmail).toBeTruthy();
-//   expect(persons[0].verifiedUpdate).toBeTruthy();
-//   expect(persons[1].verifiedUpdate).toBeTruthy();
-// });
+  expect(persons).toHaveLength(2);
+  expect(persons[0].verifiedEmail).toBeTruthy();
+  expect(persons[1].verifiedEmail).toBeTruthy();
+  expect(persons[0].verifiedUpdate).toBeTruthy();
+  expect(persons[1].verifiedUpdate).toBeTruthy();
+});
 
-// test("events from custom function", async () => {
-//   const result = await actions.writeRandomPersons();
-//   expect(result).toBeTruthy();
+test("events from custom function", async () => {
+  const result = await actions.writeRandomPersons();
+  expect(result).toBeTruthy();
 
-//   const persons = await models.person.findMany();
+  const persons = await models.person.findMany();
 
-//   expect(persons).toHaveLength(2);
-//   expect(persons[0].verifiedEmail).toBeTruthy();
-//   expect(persons[1].verifiedEmail).toBeTruthy();
-//   expect(persons[0].verifiedUpdate).toBeTruthy();
-//   expect(persons[1].verifiedUpdate).toBeTruthy();
-// });
+  expect(persons).toHaveLength(2);
+  expect(persons[0].verifiedEmail).toBeTruthy();
+  expect(persons[1].verifiedEmail).toBeTruthy();
+  expect(persons[0].verifiedUpdate).toBeTruthy();
+  expect(persons[1].verifiedUpdate).toBeTruthy();
+});
 
-// test("events from job", async () => {
-//   await jobs.createRandomPersons({ raiseException: false });
+test("events from job", async () => {
+  await jobs.createRandomPersons({ raiseException: false });
 
-//   const persons = await models.person.findMany();
+  const persons = await models.person.findMany();
 
-//   expect(persons).toHaveLength(2);
-//   expect(persons[0].verifiedEmail).toBeTruthy();
-//   expect(persons[1].verifiedEmail).toBeTruthy();
-//   expect(persons[0].verifiedUpdate).toBeTruthy();
-//   expect(persons[1].verifiedUpdate).toBeTruthy();
-// });
+  expect(persons).toHaveLength(2);
+  expect(persons[0].verifiedEmail).toBeTruthy();
+  expect(persons[1].verifiedEmail).toBeTruthy();
+  expect(persons[0].verifiedUpdate).toBeTruthy();
+  expect(persons[1].verifiedUpdate).toBeTruthy();
+});
 
-// test("events from failed hook function with rollback", async () => {
-//   await expect(
-//     actions.createPersonFn({ name: "", email: "keelson@keel.so" })
-//   ).toHaveError({
-//     code: "ERR_UNKNOWN",
-//   });
+test("events from failed hook function with rollback", async () => {
+  await expect(
+    actions.createPersonFn({ name: "", email: "keelson@keel.so" })
+  ).toHaveError({
+    code: "ERR_UNKNOWN",
+  });
 
-//   const persons = await models.person.findMany();
-//   expect(persons).toHaveLength(0);
-// });
+  const persons = await models.person.findMany();
+  expect(persons).toHaveLength(0);
+});
 
-// test("events from failed job", async () => {
-//   await jobs.createRandomPersons({ raiseException: true });
+test("events from failed job", async () => {
+  await jobs.createRandomPersons({ raiseException: true });
 
-//   const persons = await models.person.findMany();
+  const persons = await models.person.findMany();
 
-//   expect(persons).toHaveLength(2);
-//   expect(persons[0].verifiedEmail).toBeTruthy();
-//   expect(persons[1].verifiedEmail).toBeTruthy();
-//   expect(persons[0].verifiedUpdate).toBeTruthy();
-//   expect(persons[1].verifiedUpdate).toBeTruthy();
-// });
+  expect(persons).toHaveLength(2);
+  expect(persons[0].verifiedEmail).toBeTruthy();
+  expect(persons[1].verifiedEmail).toBeTruthy();
+  expect(persons[0].verifiedUpdate).toBeTruthy();
+  expect(persons[1].verifiedUpdate).toBeTruthy();
+});
 
-// test("events from failed custom function with rollback", async () => {
-//   await expect(
-//     actions.writeRandomPersons({ raiseException: true })
-//   ).toHaveError({
-//     code: "ERR_UNKNOWN",
-//   });
+test("events from failed custom function with rollback", async () => {
+  await expect(
+    actions.writeRandomPersons({ raiseException: true })
+  ).toHaveError({
+    code: "ERR_UNKNOWN",
+  });
 
-//   const persons = await models.person.findMany();
-//   expect(persons).toHaveLength(0);
-// });
+  const persons = await models.person.findMany();
+  expect(persons).toHaveLength(0);
+});
 
-// test("event previous data", async () => {
-//   const t = await models.tracker.create({
-//     views: 0,
-//   });
+test("event previous data", async () => {
+  const t = await models.tracker.create({
+    views: 0,
+  });
 
-//   const updated = await actions.updateViews({ where: { id: t.id }, values: { views: 1 } });
+  const updated = await actions.updateViews({
+    where: { id: t.id },
+    values: { views: 1 },
+  });
 
-//   const get = await models.tracker.findOne({ id: t.id });
+  const get = await models.tracker.findOne({ id: t.id });
 
-//   expect(get!.views).toEqual(1);
-//   expect(get!.verifiedUpdate).toBeTruthy();
-
-// });
+  expect(get!.views).toEqual(1);
+  expect(get!.verifiedUpdate).toBeTruthy();
+});
 
 test("event previous data bulk", async () => {
   await models.tracker.create({


### PR DESCRIPTION
When performing updates on a large set of data for a model which has an event subscriber, there was a performance issue in how we looked up the "previousData" in the event payload.  For each changed row, there was a lookup.  This has been changed to perform a single lookup for multiple changes.