### PR TITLE
feat: flow orchestration via SQS

### DIFF
--- a/cmd/program/model.go
+++ b/cmd/program/model.go
@@ -520,7 +520,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Setting the flows orchestrator
-		ctx, err = flows.WithOrchestrator(ctx, flows.NewOrchestrator(ctx, m.Schema, flows.WithDirectInvocation()))
+		ctx, err = flows.WithOrchestrator(ctx, flows.NewOrchestrator(m.Schema, flows.WithDirectInvocation()))
 		if err != nil {
 			m.Err = err
 			return m, tea.Quit

--- a/cmd/program/model.go
+++ b/cmd/program/model.go
@@ -520,7 +520,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Setting the flows orchestrator
-		ctx, err = flows.WithOrchestrator(ctx, flows.NewOrchestrator(m.Schema, flows.WithDirectInvocation()))
+		ctx, err = flows.WithOrchestrator(ctx, flows.NewOrchestrator(m.Schema))
 		if err != nil {
 			m.Err = err
 			return m, tea.Quit

--- a/deploy/lambdas/runtime/cmd/main.go
+++ b/deploy/lambdas/runtime/cmd/main.go
@@ -20,9 +20,10 @@ func main() {
 		SecretNames:    strings.Split(os.Getenv("KEEL_SECRETS"), ":"),
 
 		// AWS resources
-		QueueURL:     os.Getenv("KEEL_QUEUE_URL"),
-		FunctionsARN: os.Getenv("KEEL_FUNCTIONS_ARN"),
-		BucketName:   os.Getenv("KEEL_FILES_BUCKET_NAME"),
+		EventsQueueURL: os.Getenv("KEEL_EVENTS_QUEUE_URL"),
+		FlowsQueueURL:  os.Getenv("KEEL_FLOWS_QUEUE_URL"),
+		FunctionsARN:   os.Getenv("KEEL_FUNCTIONS_ARN"),
+		BucketName:     os.Getenv("KEEL_FILES_BUCKET_NAME"),
 
 		// RDS
 		DBEndpoint:  os.Getenv("KEEL_DATABASE_ENDPOINT"),

--- a/deploy/lambdas/runtime/flows.go
+++ b/deploy/lambdas/runtime/flows.go
@@ -2,41 +2,91 @@ package runtime
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
-	"github.com/teamkeel/keel/runtime"
+	lambdaevents "github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/sirupsen/logrus"
+	"github.com/teamkeel/keel/proto"
+	"github.com/teamkeel/keel/runtime/flows"
+	"github.com/teamkeel/keel/util"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 )
 
-type RunFlowPayload struct {
-	ID string `json:"id"`
-	// The name of the flow to run e.g. MySpecialFlow
-	Name string `json:"name"`
+func initOrchestrator(ctx context.Context, queueURL string, awsEndpoint string, schema *proto.Schema) (*flows.Orchestrator, error) {
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
 
-	Inputs map[string]any `json:"inputs"`
+	opts := []func(*sqs.Options){}
+	if awsEndpoint != "" {
+		opts = append(opts, func(o *sqs.Options) {
+			o.BaseEndpoint = &awsEndpoint
+		})
+	}
+
+	client := sqs.NewFromConfig(cfg, opts...)
+
+	return flows.NewOrchestrator(schema, flows.WithAsyncQueue(queueURL, client)), nil
 }
 
-func (h *Handler) FlowHandler(ctx context.Context, payload *RunFlowPayload) error {
+func (h *Handler) FlowHandler(ctx context.Context, event lambdaevents.SQSEvent) error {
 	defer func() {
 		if h.tracerProvider != nil {
 			h.tracerProvider.ForceFlush(ctx)
 		}
 	}()
 
-	ctx, span := h.tracer.Start(ctx, payload.Name)
+	if len(event.Records) != 1 {
+		return fmt.Errorf("flow lambda is only designed to process exactly one message at a time, received %v", len(event.Records))
+	}
+
+	message := event.Records[0]
+
+	var wrapper flows.EventWrapper
+	err := json.Unmarshal([]byte(message.Body), &wrapper)
+	if err != nil {
+		return err
+	}
+
+	h.log.WithFields(logrus.Fields{
+		"eventName":    wrapper.EventName,
+		"eventPayload": wrapper.Payload,
+	}).Info("Event received")
+
+	// Use the span context from the event payload, which
+	// originates from the runtime execution that triggered the event.
+	spanContext := util.ParseTraceparent(wrapper.Traceparent)
+	if spanContext.IsValid() {
+		ctx = trace.ContextWithSpanContext(ctx, spanContext)
+	}
+
+	ctx, span := h.tracer.Start(ctx, "Process event")
 	defer span.End()
 
-	ctx, err := h.buildContext(ctx)
+	span.SetAttributes(
+		attribute.String("type", "event"),
+		attribute.String("event.name", wrapper.EventName),
+		attribute.String("event.messageId", message.MessageId),
+		attribute.String("event.payload", wrapper.Payload),
+	)
+
+	ctx, err = h.buildContext(ctx)
 	if err != nil {
 		span.RecordError(err, trace.WithStackTrace(true))
 		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
 
-	err = runtime.NewFlowHandler(h.schema).RunFlow(ctx, payload.ID, payload.Name, payload.Inputs)
+	o, err := flows.GetOrchestrator(ctx)
 	if err != nil {
 		return err
 	}
 
-	return nil
+	return o.HandleEvent(ctx, &wrapper)
 }

--- a/integration/testdata/flows/tests.test.ts
+++ b/integration/testdata/flows/tests.test.ts
@@ -1,5 +1,5 @@
 import { resetDatabase, models, flows } from "@teamkeel/testing";
-import { useDatabase } from "@teamkeel/sdk"
+import { useDatabase } from "@teamkeel/sdk";
 import { beforeEach, expect, test } from "vitest";
 import { sql } from "kysely";
 
@@ -11,9 +11,11 @@ test("flows - basic execution", async () => {
   const things = await models.thing.findMany();
   expect(things.length).toBe(1);
   expect(things[0].name).toBe("Keelson");
-  
+
   const dbFlows = await sql`SELECT * FROM keel_flow_run`.execute(useDatabase());
   expect(dbFlows.rows.length).toBe(1);
-  const dbSteps = await sql`SELECT * FROM keel_flow_step`.execute(useDatabase());
+  const dbSteps = await sql`SELECT * FROM keel_flow_step`.execute(
+    useDatabase()
+  );
   expect(dbSteps.rows.length).toBe(2);
 });

--- a/integration/testdata/flows/tests.test.ts
+++ b/integration/testdata/flows/tests.test.ts
@@ -1,5 +1,7 @@
-import { actions, resetDatabase, models, flows } from "@teamkeel/testing";
+import { resetDatabase, models, flows } from "@teamkeel/testing";
+import { useDatabase } from "@teamkeel/sdk"
 import { beforeEach, expect, test } from "vitest";
+import { sql } from "kysely";
 
 beforeEach(resetDatabase);
 
@@ -9,4 +11,9 @@ test("flows - basic execution", async () => {
   const things = await models.thing.findMany();
   expect(things.length).toBe(1);
   expect(things[0].name).toBe("Keelson");
+  
+  const dbFlows = await sql`SELECT * FROM keel_flow_run`.execute(useDatabase());
+  expect(dbFlows.rows.length).toBe(1);
+  const dbSteps = await sql`SELECT * FROM keel_flow_step`.execute(useDatabase());
+  expect(dbSteps.rows.length).toBe(2);
 });

--- a/runtime/flows/events.go
+++ b/runtime/flows/events.go
@@ -33,8 +33,7 @@ func (e *FlowRunStarted) ReadPayload(ev *EventWrapper) error {
 		return fmt.Errorf("invalid event type")
 	}
 
-	err := json.Unmarshal([]byte(ev.Payload), e)
-	return fmt.Errorf("failed to unmarshal message body: %w", err)
+	return json.Unmarshal([]byte(ev.Payload), e)
 }
 
 func (e *FlowRunStarted) Wrap() (*EventWrapper, error) {
@@ -62,8 +61,7 @@ func (e *FlowRunUpdated) ReadPayload(ev *EventWrapper) error {
 		return fmt.Errorf("invalid event type")
 	}
 
-	err := json.Unmarshal([]byte(ev.Payload), e)
-	return fmt.Errorf("failed to unmarshal message body: %w", err)
+	return json.Unmarshal([]byte(ev.Payload), e)
 }
 
 func (e *FlowRunUpdated) Wrap() (*EventWrapper, error) {

--- a/runtime/flows/events.go
+++ b/runtime/flows/events.go
@@ -18,6 +18,37 @@ type EventWrapper struct {
 	Traceparent string `json:"traceparent,omitempty"`
 }
 
+type FlowRunStarted struct {
+	// The name of the flow to run e.g. MySpecialFlow
+	Name   string         `json:"name"`
+	Inputs map[string]any `json:"inputs"`
+}
+
+func (e *FlowRunStarted) ReadPayload(ev *EventWrapper) error {
+	if ev == nil {
+		return fmt.Errorf("invalid event ")
+	}
+
+	if ev.EventName != EventNameFlowRunStarted {
+		return fmt.Errorf("invalid event type")
+	}
+
+	err := json.Unmarshal([]byte(ev.Payload), e)
+	return fmt.Errorf("failed to unmarshal message body: %w", err)
+}
+
+func (e *FlowRunStarted) Wrap() (*EventWrapper, error) {
+	payload, err := json.Marshal(e)
+	if err != nil {
+		return nil, err
+	}
+
+	return &EventWrapper{
+		EventName: EventNameFlowRunStarted,
+		Payload:   string(payload),
+	}, nil
+}
+
 type FlowRunUpdated struct {
 	RunID string `json:"runId"`
 }

--- a/runtime/flows/orchestrator.go
+++ b/runtime/flows/orchestrator.go
@@ -141,6 +141,22 @@ func (o *Orchestrator) HandleEvent(ctx context.Context, event *EventWrapper) err
 		}
 
 		return o.orchestrateRun(ctx, ev.RunID)
+	case EventNameFlowRunStarted:
+		// a new flow has started; create the run and start orchestrating it
+		var ev FlowRunStarted
+		if err := ev.ReadPayload(event); err != nil {
+			return err
+		}
+
+		flow := o.schema.FindFlow(ev.Name)
+		if flow == nil {
+			return fmt.Errorf("unknown flow: %s", ev.Name)
+		}
+		run, err := CreateRun(ctx, flow, ev.Inputs)
+		if err != nil {
+			return err
+		}
+		return o.orchestrateRun(ctx, run.ID)
 	}
 	return nil
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -325,10 +325,6 @@ func (handler SubscriberHandler) RunSubscriber(ctx context.Context, subscriberNa
 	return err
 }
 
-type FlowHandler struct {
-	schema *proto.Schema
-}
-
 func NewRouter(s *proto.Schema) *httprouter.Router {
 	router := httprouter.New()
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -329,41 +329,6 @@ type FlowHandler struct {
 	schema *proto.Schema
 }
 
-func NewFlowHandler(currSchema *proto.Schema) FlowHandler {
-	return FlowHandler{
-		schema: currSchema,
-	}
-}
-
-// RunJob will run the job function in the runtime.
-func (handler FlowHandler) RunFlow(ctx context.Context, id string, flowName string, input map[string]any) error {
-	ctx, span := tracer.Start(ctx, "Run flow")
-	defer span.End()
-
-	flow := handler.schema.FindFlow(strcase.ToCamel(flowName))
-	if flow == nil {
-		return fmt.Errorf("no flow with the name '%s' exists", flowName)
-	}
-
-	// TODO: we need to create the flow in the database
-	// var err error
-	// if flow.InputMessageName != "" {
-	// 	message := handler.schema.FindMessage(flow.InputMessageName)
-	// 	input, err = actions.TransformInputs(handler.schema, message, input, true)
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// }
-
-	_, _, err := functions.CallFlow(
-		ctx,
-		flow,
-		id,
-	)
-
-	return err
-}
-
 func NewRouter(s *proto.Schema) *httprouter.Router {
 	router := httprouter.New()
 

--- a/testing/aws.go
+++ b/testing/aws.go
@@ -25,7 +25,7 @@ type AWSAPIHandler struct {
 	FunctionsURL  string
 	FunctionsARN  string
 	S3Bucket      map[string]*S3Object
-	OnSQSEvent    func(events.SQSEvent)
+	OnSQSEvent    map[string]func(event events.SQSEvent) // map of event handlers for each queueURL
 }
 
 func (h *AWSAPIHandler) HandleHTTP(r *http.Request, w http.ResponseWriter) {
@@ -195,7 +195,8 @@ func (h *AWSAPIHandler) sqsSendMessage(r *http.Request, w http.ResponseWriter) {
 		},
 	}
 
-	h.OnSQSEvent(event)
+	eh := h.OnSQSEvent[*input.QueueUrl]
+	eh(event)
 
 	writeJSON(w, http.StatusOK, nil)
 }

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -278,17 +278,17 @@ func Run(ctx context.Context, opts *RunnerOpts) error {
 
 				writeJSON(w, http.StatusOK, map[string]any{})
 				return
-			case FlowsPath:
-				err = HandleFlowExecutorRequest(r.WithContext(ctx), lambdaHandler)
-				if err != nil {
-					response := httpjson.NewErrorResponse(ctx, err, nil)
-					w.WriteHeader(response.Status)
-					_, _ = w.Write(response.Body)
-					return
-				}
+			// case FlowsPath:
+			// 	err = HandleFlowExecutorRequest(r.WithContext(ctx), lambdaHandler)
+			// 	if err != nil {
+			// 		response := httpjson.NewErrorResponse(ctx, err, nil)
+			// 		w.WriteHeader(response.Status)
+			// 		_, _ = w.Write(response.Body)
+			// 		return
+			// 	}
 
-				writeJSON(w, http.StatusOK, map[string]any{})
-				return
+			// 	writeJSON(w, http.StatusOK, map[string]any{})
+			// 	return
 			default:
 				e, err := toLambdaFunctionURLRequest(r)
 				if err != nil {
@@ -334,7 +334,7 @@ func Run(ctx context.Context, opts *RunnerOpts) error {
 		ConfigPath:     path.Join(opts.Dir, ".build/runtime/config.json"),
 		ProjectName:    opts.TestGroupName,
 		Env:            "test",
-		QueueURL:       "https://testing-sqs-queue.com/123456789/events",
+		EventsQueueURL: "https://testing-sqs-queue.com/123456789/events",
 		FunctionsARN:   functionsARN,
 		BucketName:     bucketName,
 		SecretNames:    lo.Keys(ssmParams),
@@ -466,29 +466,29 @@ func HandleSubscriberExecutorRequest(r *http.Request, h *runtime.Handler) error 
 	})
 }
 
-// HandleFlowExecutorRequest handles requests to the flow module in the testing package.
-func HandleFlowExecutorRequest(r *http.Request, h *runtime.Handler) error {
-	id := ksuid.New().String()
+// // HandleFlowExecutorRequest handles requests to the flow module in the testing package.
+// func HandleFlowExecutorRequest(r *http.Request, h *runtime.Handler) error {
+// 	id := ksuid.New().String()
 
-	name := path.Base(r.URL.Path)
+// 	name := path.Base(r.URL.Path)
 
-	b, err := io.ReadAll(r.Body)
-	if err != nil {
-		return err
-	}
+// 	b, err := io.ReadAll(r.Body)
+// 	if err != nil {
+// 		return err
+// 	}
 
-	m := make(map[string]any)
-	err = json.Unmarshal(b, &m)
-	if err != nil {
-		return err
-	}
+// 	m := make(map[string]any)
+// 	err = json.Unmarshal(b, &m)
+// 	if err != nil {
+// 		return err
+// 	}
 
-	return h.FlowHandler(r.Context(), &runtime.RunFlowPayload{
-		ID:     id,
-		Name:   name,
-		Inputs: m,
-	})
-}
+// 	return h.FlowHandler(r.Context(), &runtime.RunFlowPayload{
+// 		ID:     id,
+// 		Name:   name,
+// 		Inputs: m,
+// 	})
+// }
 
 func toLambdaFunctionURLRequest(r *http.Request) (lambdaevents.LambdaFunctionURLRequest, error) {
 	headers := make(map[string]string)


### PR DESCRIPTION
Refactors the flow orchestrator to handle events and trigger new orchestrations by pushing events for itself. In the case of the orchestrator being initialised without a SQS client & queue URL, the events will be handled synchroneously instead of being pushed onto a queue.

Keel deploy will now provision a new queue for flows, and a new runtime lambda in flow mode, which is invoked via queue events.