### PR TITLE
feat: step retry limit and timeouts

### DIFF
--- a/migrations/flows.sql
+++ b/migrations/flows.sql
@@ -15,6 +15,8 @@ CREATE TABLE IF NOT EXISTS keel_flow_step (
 	"status" TEXT NOT NULL,
 	"type" TEXT NOT NULL,
 	"value" JSONB DEFAULT NULL,
+	"max_retries" INTEGER NOT NULL,
+	"timeout_in_ms" INTEGER NOT NULL,
 	"created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
 	"updated_at" TIMESTAMPTZ NOT NULL DEFAULT now()
 );

--- a/node/codegen.go
+++ b/node/codegen.go
@@ -1032,7 +1032,7 @@ func writeAPIDeclarations(w *codegen.Writer, schema *proto.Schema) {
 	// TODO: Definition and implementation for the flow context API
 	w.Writeln("export interface FlowContextAPI {")
 	w.Indent()
-	w.Writeln("step<T>(name: string, fn: () => Promise<T>): Promise<T>;")
+	w.Writeln("step<T>(name: string, fn: () => Promise<T>, opts?: { maxRetries?: number, timeoutInMs?: number }): Promise<T>;")
 	w.Dedent()
 	w.Writeln("}")
 }
@@ -1127,10 +1127,10 @@ func writeAPIFactory(w *codegen.Writer, schema *proto.Schema) {
 
 	w.Writeln("function createFlowContextAPI({ meta }) {")
 	w.Indent()
-	w.Writeln("const step = async (name, fn) => {")
+	w.Writeln("const step = async (name, fn, opts) => {")
 	w.Indent()
 	w.Writeln("const runner = new runtime.StepRunner(meta.runId);")
-	w.Writeln("return await runner.run(name, fn);")
+	w.Writeln("return await runner.run(name, fn, opts);")
 	w.Dedent()
 	w.Writeln("};")
 	w.Writeln("return { step };")

--- a/node/codegen_test.go
+++ b/node/codegen_test.go
@@ -507,9 +507,9 @@ function createSubscriberContextAPI({ meta }) {
 	return { env, now, secrets };
 };
 function createFlowContextAPI({ meta }) {
-	const step = async (name, fn) => {
+	const step = async (name, fn, opts) => {
 		const runner = new runtime.StepRunner(meta.runId);
-		return await runner.run(name, fn);
+		return await runner.run(name, fn, opts);
 	};
 	return { step };
 };

--- a/packages/functions-runtime/src/StepRunner.js
+++ b/packages/functions-runtime/src/StepRunner.js
@@ -12,6 +12,11 @@ const STEP_TYPE = {
   DELAY: "DELAY",
 };
 
+const defaultOpts = {
+  maxRetries: 5,
+  timeoutInMs: 60000,
+};
+
 // This is a special type that is thrown to disrupt the execution of a flow
 class FlowDisrupt {
   constructor() {}
@@ -46,8 +51,8 @@ class StepRunner {
         name: name,
         status: STEP_STATUS.NEW,
         type: STEP_TYPE.FUNCTION,
-        maxRetries: opts?.maxRetries ?? 3,
-        timeoutInMs: opts?.timeoutInMs ?? 500,
+        maxRetries: opts?.maxRetries ?? defaultOpts.maxRetries,
+        timeoutInMs: opts?.timeoutInMs ?? defaultOpts.timeoutInMs,
       })
       .returningAll()
       .executeTakeFirst();
@@ -56,7 +61,7 @@ class StepRunner {
 
     let result = null;
     try {
-      result = await withTimeout(fn(), { timeout: step.timeoutInMs });
+      result = await withTimeout(fn(), step.timeoutInMs );
     } catch (e) {
       outcome = STEP_STATUS.FAILED;
     }
@@ -80,12 +85,10 @@ function wait(milliseconds) {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
-export function withTimeout(promiseFn, opts) {
-  const timeOut = opts?.timeout ?? 2500;
-
+export function withTimeout(promiseFn, timeout) {
   return Promise.race([
     promiseFn,
-    wait(timeOut).then(() => {
+    wait(timeout).then(() => {
       throw new Error(`flow times out after ${timeout}ms`);
     }),
   ]);

--- a/packages/functions-runtime/src/handleFlow.js
+++ b/packages/functions-runtime/src/handleFlow.js
@@ -71,13 +71,11 @@ async function handleFlow(request, config) {
           // parse request params to convert objects into rich field types (e.g. InlineFile)
           const inputs = parseInputs(flowRun.input);
 
-          // Return the job function to the containing tryExecuteJob block
           return flowFunction(ctx, inputs);
         });
 
         // If we reach this point, then we know the entire flow completed successfully
         // TODO: Send FlowRunUpdated event with run_completed = true
-
         return createJSONRPCSuccessResponse(request.id, {
           runId: runId,
           runCompleted: true,
@@ -86,7 +84,6 @@ async function handleFlow(request, config) {
         // If the flow is disrupted, then we know that a step either completed successfully or failed
         if (e instanceof FlowDisrupt) {
           // TODO: Send FlowRunUpdated event with run_completed = false
-
           return createJSONRPCSuccessResponse(request.id, {
             runId: runId,
             runCompleted: false,

--- a/packages/functions-runtime/src/routes/customResponse.ts
+++ b/packages/functions-runtime/src/routes/customResponse.ts
@@ -4,13 +4,13 @@ const handler: RouteFunction = async (request, ctx) => {
   return {
     body: JSON.stringify({
       message: "This is a raw HTTP response",
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     }),
     statusCode: 200,
     headers: {
-      "Content-Type": "application/json"
-    }
+      "Content-Type": "application/json",
+    },
   };
 };
 
-export default handler; 
+export default handler;

--- a/runtime/flows/flow.go
+++ b/runtime/flows/flow.go
@@ -48,14 +48,16 @@ func (Run) TableName() string {
 }
 
 type Step struct {
-	ID        string    `json:"id" gorm:"primaryKey;not null;default:null"`
-	Name      string    `json:"name"`
-	RunID     string    `json:"runId"`
-	Status    Status    `json:"status"`
-	Type      StepType  `json:"type"`
-	Value     *JSONB    `json:"value" gorm:"type:jsonb"`
-	CreatedAt time.Time `json:"createdAt"`
-	UpdatedAt time.Time `json:"updatedAt"`
+	ID          string    `json:"id" gorm:"primaryKey;not null;default:null"`
+	Name        string    `json:"name"`
+	RunID       string    `json:"runId"`
+	Status      Status    `json:"status"`
+	Type        StepType  `json:"type"`
+	Value       *JSONB    `json:"value" gorm:"type:jsonb"`
+	MaxRetries  int       `json:"max_retries"`
+	TimeoutInMs int       `json:"timeout_in_ms"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
 }
 
 func (Step) TableName() string {

--- a/runtime/flows/orchestrator.go
+++ b/runtime/flows/orchestrator.go
@@ -109,23 +109,28 @@ func (o *Orchestrator) orchestrateRun(ctx context.Context, runID string) error {
 		}
 
 		if respBody.RunCompleted {
-			stepsMap := map[string][]Step{}
-			for _, step := range run.Steps {
-				stepsMap[step.Name] = append(stepsMap[step.Name], step)
-			}
-
-			// Check to see if the retries have been exceeded
-			if len(run.Steps) > 0 {
-				lastStep := run.Steps[len(run.Steps)-1]
-				if lastStep.Status == "FAILED" && len(stepsMap[lastStep.Name]) >= lastStep.MaxRetries {
-					_, err := UpdateRun(ctx, run.ID, StatusFailed)
-					return err
-				}
-			}
-
 			_, err = UpdateRun(ctx, run.ID, StatusCompleted)
 			return err
 		}
+
+		//if !respBody.RunCompleted {
+		stepsMap := map[string][]Step{}
+		for _, step := range run.Steps {
+			stepsMap[step.Name] = append(stepsMap[step.Name], step)
+		}
+
+		// Check to see if the retries have been exceeded
+		if len(run.Steps) > 0 {
+			lastStep := run.Steps[len(run.Steps)-1]
+			if lastStep.Status == "FAILED" && len(stepsMap[lastStep.Name]) >= lastStep.MaxRetries {
+				_, err := UpdateRun(ctx, run.ID, StatusFailed)
+				return err
+			}
+		}
+		// } else {
+		// 	_, err = UpdateRun(ctx, run.ID, StatusCompleted)
+		// 	return err
+		// }
 
 		payload := FlowRunUpdated{RunID: respBody.RunID}
 		wrap, err := payload.Wrap()

--- a/runtime/flows/orchestrator.go
+++ b/runtime/flows/orchestrator.go
@@ -109,6 +109,20 @@ func (o *Orchestrator) orchestrateRun(ctx context.Context, runID string) error {
 		}
 
 		if respBody.RunCompleted {
+			stepsMap := map[string][]Step{}
+			for _, step := range run.Steps {
+				stepsMap[step.Name] = append(stepsMap[step.Name], step)
+			}
+
+			// Check to see if the retries have been exceeded
+			if len(run.Steps) > 0 {
+				lastStep := run.Steps[len(run.Steps)-1]
+				if lastStep.Status == "FAILED" && len(stepsMap[lastStep.Name]) >= lastStep.MaxRetries {
+					_, err := UpdateRun(ctx, run.ID, StatusFailed)
+					return err
+				}
+			}
+
 			_, err = UpdateRun(ctx, run.ID, StatusCompleted)
 			return err
 		}


### PR DESCRIPTION
Steps can now be configured with a max retry limit and a timeout as shown in the example below.

If not provided, max retries is 5 and the timeout is 10 minutes.

```ts
export default MyFlow(async (ctx, inputs) => {
  const thing = await ctx.step("insert thing", async () => {
      return await models.thing.create({
        name: inputs.name,
      });
    },
    {
      maxRetries: 3,
      timeoutInMs: 500,
    }
  );
});
```

Note that the API design still needs to be addressed.