### PR TITLE
feat: set UI step value endpoint

### DIFF
--- a/runtime/apis/flowsapi/flow_handler.go
+++ b/runtime/apis/flowsapi/flow_handler.go
@@ -58,12 +58,27 @@ func FlowHandler(s *proto.Schema) common.HandlerFunc {
 
 			return common.NewJsonResponse(http.StatusOK, run, nil)
 		case 3:
-			// TODO: # Send step updates
-			// PUT flows/json/[flowName]/[runID]/[stepID]
+			if pathParts[2] == "cancel" {
+				// TODO: # Cancel run
+				// POST flows/json/[flowName]/[runID]/cancel
+				return common.NewJsonResponse(http.StatusNotImplemented, pathParts, nil)
+			}
+			// Send step updates: PUT flows/json/[flowName]/[runID]/[stepID]
+			if r.Method != http.MethodPut {
+				return httpjson.NewErrorResponse(ctx, common.NewHttpMethodNotAllowedError("only HTTP PUT accepted"), nil)
+			}
 
-			// TODO: # Cancel run
-			// POST flows/json/[flowName]/[runID]/cancel
-			return common.NewJsonResponse(http.StatusNotImplemented, pathParts, nil)
+			inputs, err := common.ParseRequestData(r)
+			if err != nil {
+				return httpjson.NewErrorResponse(ctx, common.NewInputMalformedError("error parsing POST body"), nil)
+			}
+
+			run, err := flows.UpdateStep(ctx, pathParts[2], inputs)
+			if err != nil {
+				return httpjson.NewErrorResponse(ctx, err, nil)
+			}
+
+			return common.NewJsonResponse(http.StatusOK, run, nil)
 		}
 		return common.Response{
 			Status: http.StatusNotFound,

--- a/runtime/flows/orchestrator.go
+++ b/runtime/flows/orchestrator.go
@@ -124,12 +124,10 @@ func (o *Orchestrator) orchestrateRun(ctx context.Context, runID string) error {
 			return err
 		}
 
-		return o.sendEvent(ctx, wrap)
+		return o.SendEvent(ctx, wrap)
 	case StatusFailed, StatusCompleted:
 		// Do nothing
 		return nil
-	case StatusWaiting:
-		return fmt.Errorf("not implemented")
 	}
 
 	return nil
@@ -166,9 +164,9 @@ func (o *Orchestrator) HandleEvent(ctx context.Context, event *EventWrapper) err
 	return nil
 }
 
-// sendEvent sends the given event to the flow runtime's queue or directly invokes the function depending on the
+// SendEvent sends the given event to the flow runtime's queue or directly invokes the function depending on the
 // orchestrator's settings
-func (o *Orchestrator) sendEvent(ctx context.Context, payload *EventWrapper) error {
+func (o *Orchestrator) SendEvent(ctx context.Context, payload *EventWrapper) error {
 	if payload == nil {
 		return fmt.Errorf("invalid event payload")
 	}


### PR DESCRIPTION
Introduces a new workflow API endpoint:

* `PUT flows/json/[flowName]/[runID]/[stepID]`

This sets the given user input as the value of the given `PENDING` `UI` step. It marks the step as `COMPLETED` and then triggers the orchestrator to continue running the flow.