### PR TITLE
feat: add endpoint to list flow runs

### DIFF
--- a/runtime/apis/flowsapi/flow_handler.go
+++ b/runtime/apis/flowsapi/flow_handler.go
@@ -31,22 +31,31 @@ func FlowHandler(s *proto.Schema) common.HandlerFunc {
 
 		switch len(pathParts) {
 		case 1:
-			// Start flow - POST flows/json/[flowName]
-			if r.Method != http.MethodPost {
-				return httpjson.NewErrorResponse(ctx, common.NewHttpMethodNotAllowedError("only HTTP POST accepted"), nil)
+			switch r.Method {
+			case http.MethodPost:
+				// Start flow - POST flows/json/[flowName]
+				inputs, err := common.ParseRequestData(r)
+				if err != nil {
+					return httpjson.NewErrorResponse(ctx, common.NewInputMalformedError("error parsing POST body"), nil)
+				}
+
+				run, err := flows.StartFlow(ctx, flow, inputs)
+				if err != nil {
+					return httpjson.NewErrorResponse(ctx, err, nil)
+				}
+
+				return common.NewJsonResponse(http.StatusOK, run, nil)
+			case http.MethodGet:
+				// List Flow runs - GET flows/json/[flowName]
+				runs, err := flows.ListFlowRuns(ctx, flow, common.ParseQueryParams(r))
+				if err != nil {
+					return httpjson.NewErrorResponse(ctx, err, nil)
+				}
+
+				return common.NewJsonResponse(http.StatusOK, runs, nil)
 			}
 
-			inputs, err := common.ParseRequestData(r)
-			if err != nil {
-				return httpjson.NewErrorResponse(ctx, common.NewInputMalformedError("error parsing POST body"), nil)
-			}
-
-			run, err := flows.StartFlow(ctx, flow, inputs)
-			if err != nil {
-				return httpjson.NewErrorResponse(ctx, err, nil)
-			}
-
-			return common.NewJsonResponse(http.StatusOK, run, nil)
+			return httpjson.NewErrorResponse(ctx, common.NewHttpMethodNotAllowedError("only HTTP POST or GET accepted"), nil)
 		case 2:
 			// Check for progress - GET flows/json/[flowName]/[runID]
 			if r.Method != http.MethodGet {

--- a/runtime/flows/run.go
+++ b/runtime/flows/run.go
@@ -55,6 +55,24 @@ func StartFlow(ctx context.Context, flow *proto.Flow, inputs any) (run *Run, err
 	return run, nil
 }
 
+func ListFlowRuns(ctx context.Context, flow *proto.Flow, inputs map[string]any) (runs []*Run, err error) {
+	ctx, span := tracer.Start(ctx, "ListFlowRuns")
+	defer span.End()
+
+	defer func() {
+		if err != nil {
+			span.RecordError(err, trace.WithStackTrace(true))
+			span.SetStatus(codes.Error, err.Error())
+		}
+	}()
+
+	pf := paginationFields{}
+	pf.Parse(inputs)
+
+	runs, err = listRuns(ctx, flow, &pf)
+	return
+}
+
 // GetFlowRunState retrieves the state of the given flow run. If the run has a pending UI step, the UI component will be
 // injected into the step before returning it
 func GetFlowRunState(ctx context.Context, runID string) (run *Run, err error) {


### PR DESCRIPTION
Handles a new endpoint: 
```
GET flows/json/[flowName]
```

The endpoint supports cursor pagination through query fields:
* `limit` = number of items to return
* `after` & `before` = run ids