### PR TITLE
feat: add openapi.json endpoint to the flows API

### DIFF
--- a/runtime/openapi/openapi_test.go
+++ b/runtime/openapi/openapi_test.go
@@ -15,13 +15,30 @@ import (
 	"github.com/teamkeel/keel/schema"
 )
 
+// There are multiple types of openAPI schemas:
+// * API schema - the openAPI schema generated for the runtime API
+// * Job schemas - generated for each job defined in the keel schema
+// * Flow schema - generated for all the workflows defined in your schema
+//
+// Test cases will detect what type of schema is asserted by looking at the prefix of the files:
+//   - if the file starts with "job", the schema for the first job defined will be tested
+//   - if the file starts with "flow", the schema for all the flows will be tested
+//   - then default to the keel api schema
 func TestGeneration(t *testing.T) {
 	entries, err := os.ReadDir("./testdata")
 	require.NoError(t, err)
 
+	type schemaType string
+	const (
+		jobType  schemaType = "job"
+		apiType  schemaType = "api"
+		flowType schemaType = "flow"
+	)
+
 	type testCase struct {
 		keelSchema string
 		jsonSchema string
+		schemaType schemaType // job, flow or keel
 	}
 
 	cases := map[string]*testCase{}
@@ -41,6 +58,15 @@ func TestGeneration(t *testing.T) {
 		case ".json":
 			c.jsonSchema = string(b)
 		}
+
+		switch {
+		case strings.HasPrefix(caseName, "job"):
+			c.schemaType = jobType
+		case strings.HasPrefix(caseName, "flow"):
+			c.schemaType = flowType
+		default:
+			c.schemaType = apiType
+		}
 	}
 
 	for name, c := range cases {
@@ -49,32 +75,25 @@ func TestGeneration(t *testing.T) {
 			schema, err := builder.MakeFromString(c.keelSchema, config.Empty)
 			require.NoError(t, err)
 
-			if len(schema.Jobs) == 0 {
-				jsonSchema := openapi.Generate(context.Background(), schema, schema.Apis[0])
-				actual, err := json.Marshal(jsonSchema)
-				require.NoError(t, err)
-
-				opts := jsondiff.DefaultConsoleOptions()
-				diff, explanation := jsondiff.Compare([]byte(c.jsonSchema), actual, &opts)
-
-				if diff != jsondiff.FullMatch {
-					t.Error(string(actual))
-					t.Errorf("actual JSON schema does not match expected: %s", explanation)
-				}
+			jsonSchema := openapi.OpenAPI{}
+			switch c.schemaType {
+			case apiType:
+				jsonSchema = openapi.Generate(context.Background(), schema, schema.Apis[0])
+			case jobType:
+				jsonSchema = openapi.GenerateJob(context.Background(), schema, schema.Jobs[0].Name)
+			case flowType:
+				jsonSchema = openapi.GenerateFlows(context.Background(), schema)
 			}
 
-			if len(schema.Jobs) > 0 {
-				jsonSchema := openapi.GenerateJob(context.Background(), schema, schema.Jobs[0].Name)
-				actual, err := json.Marshal(jsonSchema)
-				require.NoError(t, err)
+			actual, err := json.Marshal(jsonSchema)
+			require.NoError(t, err)
 
-				opts := jsondiff.DefaultConsoleOptions()
-				diff, explanation := jsondiff.Compare([]byte(c.jsonSchema), actual, &opts)
+			opts := jsondiff.DefaultConsoleOptions()
+			diff, explanation := jsondiff.Compare([]byte(c.jsonSchema), actual, &opts)
 
-				if diff != jsondiff.FullMatch {
-					t.Error(string(actual))
-					t.Errorf("actual JSON schema does not match expected: %s", explanation)
-				}
+			if diff != jsondiff.FullMatch {
+				t.Error(string(actual))
+				t.Errorf("actual JSON schema does not match expected: %s", explanation)
 			}
 		})
 	}

--- a/runtime/openapi/testdata/flow.json
+++ b/runtime/openapi/testdata/flow.json
@@ -1,0 +1,153 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+        "title": "FlowsAPI",
+        "version": "1"
+    },
+    "paths": {
+        "flows/json/AnotherWorkflow": {
+            "post": {
+                "operationId": "AnotherWorkflow",
+                "requestBody": {
+                    "description": "AnotherWorkflow Request",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "age": {
+                                        "type": "number"
+                                    }
+                                },
+                                "unevaluatedProperties": false,
+                                "required": [
+                                    "age"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "AnotherWorkflow Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Run"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "AnotherWorkflow Response Errors",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "code": {
+                                            "type": "string"
+                                        },
+                                        "data": {
+                                            "type": [
+                                                "object",
+                                                "null"
+                                            ],
+                                            "properties": {
+                                                "errors": {
+                                                    "type": "array",
+                                                    "properties": {
+                                                        "error": {
+                                                            "type": "string"
+                                                        },
+                                                        "field": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Run": {
+                "type": "object",
+                "properties": {
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "steps": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Step"
+                        }
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                }
+            },
+            "Step": {
+                "type": "object",
+                "properties": {
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "max_retries": {
+                        "type": "number"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "runId": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "timeout_in_ms": {
+                        "type": "number"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "ui": {
+                        "type": "object"
+                    },
+                    "value": {
+                        "type": "object"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/runtime/openapi/testdata/flow.keel
+++ b/runtime/openapi/testdata/flow.keel
@@ -1,0 +1,13 @@
+flow MyWorkflow {
+    inputs {
+        name Text
+        age Number
+    }
+}
+
+flow AnotherWorkflow {
+    inputs {
+        age Number
+    }
+}
+

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -194,7 +194,8 @@ func NewFlowsHandler(s *proto.Schema) common.HandlerFunc {
 	defaultFlowHandler := flowsapi.FlowHandler(s)
 
 	explicitHandlers := map[string]common.HandlerFunc{
-		"/flows/json": flowsapi.ListFlowsHandler(s),
+		"/flows/json":              flowsapi.ListFlowsHandler(s),
+		"/flows/json/openapi.json": flowsapi.OpenAPISchemaHandler(s),
 		// TODO: "/flows/json/myRuns"
 	}
 


### PR DESCRIPTION
Adds a new endpoint: `GET /flows/json/openapi.json` 

Generates a openapi schema with the input messages used to start each flow.

Refactored the openapi test to assert either job schemas, flow schemas or general API schemas