### PR TITLE
fix: amend cursor pagination for flows

### DIFF
--- a/runtime/flows/flow.go
+++ b/runtime/flows/flow.go
@@ -174,7 +174,7 @@ func (p *paginationFields) GetLimit() int {
 }
 
 func (p *paginationFields) IsBackwards() bool {
-	return p.After == nil
+	return p.Before != nil
 }
 
 // getRun returns the flow run with the given ID. If no flow run found, nil nil is returned.
@@ -256,16 +256,16 @@ func listRuns(ctx context.Context, flow *proto.Flow, page *paginationFields) ([]
 
 	if page != nil {
 		if page.IsBackwards() {
-			q = q.Order("id DESC")
-		} else {
 			q = q.Order("id ASC")
+		} else {
+			q = q.Order("id DESC")
 		}
 
 		if page.Before != nil {
-			q.Where("id < ?", *page.Before)
+			q.Where("id > ?", *page.Before)
 		}
 		if page.After != nil {
-			q.Where("id > ?", *page.After)
+			q.Where("id < ?", *page.After)
 		}
 	}
 
@@ -274,8 +274,7 @@ func listRuns(ctx context.Context, flow *proto.Flow, page *paginationFields) ([]
 		return nil, result.Error
 	}
 
-	if !page.IsBackwards() {
-		// we always want to return items backwards (i.e. the most recent at the top)
+	if page.IsBackwards() {
 		slices.Reverse(runs)
 	}
 


### PR DESCRIPTION
Previously the cursor pagination was implemented with before & after being.. time based; i.e. retrieve items that happened before the cursor. This PR changes this behaviour to enforce a consistent ordering (newest flows at the top) and `before` & `after` take in consideration the position of the items rather than the time they happened: e.g.
* retrieve 5 items after x will return the 5 flows that would be displayed after x in a list where the newest flows are at the top; i.e. the 5 flows that took place before x