### PR TITLE
fix: store traceIDs with flow runs

### DIFF
--- a/migrations/flows.sql
+++ b/migrations/flows.sql
@@ -1,6 +1,7 @@
 CREATE TABLE IF NOT EXISTS keel_flow_run (
 	"id" text NOT NULL DEFAULT ksuid() PRIMARY KEY,
 	"name" TEXT NOT NULL,
+	"trace_id" TEXT,
 	"status" TEXT NOT NULL,
 	"input" JSONB DEFAULT NULL,
 	"created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),

--- a/runtime/flows/flow.go
+++ b/runtime/flows/flow.go
@@ -43,6 +43,7 @@ const (
 
 type Run struct {
 	ID        string    `json:"id" gorm:"primaryKey;not null;default:null"`
+	TraceID   string    `json:"traceId"`
 	Status    Status    `json:"status"`
 	Name      string    `json:"name"`
 	Input     *JSONB    `json:"input" gorm:"type:jsonb"`
@@ -211,7 +212,7 @@ func updateRun(ctx context.Context, runID string, status Status) (*Run, error) {
 }
 
 // createRun will create a new flow run with the given input
-func createRun(ctx context.Context, flow *proto.Flow, inputs any) (*Run, error) {
+func createRun(ctx context.Context, flow *proto.Flow, inputs any, traceID string) (*Run, error) {
 	if flow == nil {
 		return nil, fmt.Errorf("invalid flow")
 	}
@@ -222,9 +223,10 @@ func createRun(ctx context.Context, flow *proto.Flow, inputs any) (*Run, error) 
 	}
 
 	run := Run{
-		Status: StatusNew,
-		Input:  &jsonInputs,
-		Name:   flow.Name,
+		Status:  StatusNew,
+		Input:   &jsonInputs,
+		Name:    flow.Name,
+		TraceID: traceID,
 	}
 
 	database, err := db.GetDatabase(ctx)

--- a/runtime/flows/orchestrator.go
+++ b/runtime/flows/orchestrator.go
@@ -167,7 +167,9 @@ func (o *Orchestrator) HandleEvent(ctx context.Context, event *EventWrapper) err
 		if flow == nil {
 			return fmt.Errorf("unknown flow: %s", ev.Name)
 		}
-		run, err := createRun(ctx, flow, ev.Inputs)
+
+		traceID := util.ParseTraceparent(event.Traceparent).TraceID().String()
+		run, err := createRun(ctx, flow, ev.Inputs, traceID)
 		if err != nil {
 			return err
 		}

--- a/runtime/flows/run.go
+++ b/runtime/flows/run.go
@@ -29,7 +29,7 @@ func StartFlow(ctx context.Context, flow *proto.Flow, inputs any) (run *Run, err
 		return
 	}
 
-	run, err = createRun(ctx, flow, inputs)
+	run, err = createRun(ctx, flow, inputs, span.SpanContext().TraceID().String())
 	if err != nil {
 		err = fmt.Errorf("creating flow run: %w", err)
 		return


### PR DESCRIPTION
* Adds a new column to the keel flow runs db: traceID
* Sets the traceID to the flow run at point of creation