### PR TITLE
fix: store spanId when completing a flow step

### DIFF
--- a/migrations/flows.sql
+++ b/migrations/flows.sql
@@ -18,6 +18,7 @@ CREATE TABLE IF NOT EXISTS keel_flow_step (
 	"value" JSONB DEFAULT NULL,
 	"max_retries" INTEGER NOT NULL,
 	"timeout_in_ms" INTEGER NOT NULL,
+	"span_id" TEXT,
 	"created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
 	"updated_at" TIMESTAMPTZ NOT NULL DEFAULT now()
 );

--- a/packages/functions-runtime/src/flows/index.ts
+++ b/packages/functions-runtime/src/flows/index.ts
@@ -67,7 +67,8 @@ type Opts = {
 
 export function createStepContext<C extends FlowConfig>(
   runId: string,
-  data: any
+  data: any,
+  spanId: string
 ): StepContext<C> {
   return {
     step: async <T = any>(name: string, fn: () => Promise<T>, opts?: Opts) => {
@@ -108,6 +109,7 @@ export function createStepContext<C extends FlowConfig>(
           .updateTable("keel_flow_step")
           .set({
             status: STEP_STATUS.FAILED,
+            spanId: spanId,
             // TODO: store error message
           })
           .where("id", "=", step.id)
@@ -125,6 +127,7 @@ export function createStepContext<C extends FlowConfig>(
         .set({
           status: STEP_STATUS.COMPLETED,
           value: JSON.stringify(result),
+          spanId: spanId,
         })
         .where("id", "=", step.id)
         .returningAll()
@@ -188,6 +191,7 @@ export function createStepContext<C extends FlowConfig>(
             .set({
               status: STEP_STATUS.COMPLETED,
               value: JSON.stringify(data),
+              spanId: spanId,
             })
             .where("id", "=", step.id)
             .returningAll()

--- a/packages/functions-runtime/src/handleFlow.js
+++ b/packages/functions-runtime/src/handleFlow.js
@@ -65,7 +65,11 @@ async function handleFlow(request, config) {
           throw new Error("no flow run found");
         }
 
-        const ctx = createStepContext(request.meta.runId, request.meta.data);
+        const ctx = createStepContext(
+          request.meta.runId,
+          request.meta.data,
+          span.spanContext().spanId
+        );
 
         const flowFunction = flows[request.method];
 


### PR DESCRIPTION
Adds a `span_id` column to steps and populates it with the OTEL span id 