### PR TITLE
fix: return flow config when returning ui components

### DIFF
--- a/node/codegen.go
+++ b/node/codegen.go
@@ -43,7 +43,7 @@ func generateSdkPackage(schema *proto.Schema, cfg *config.ProjectConfig) codegen
 	sdkTypes.Writeln(`import { Kysely, Generated } from "kysely"`)
 	sdkTypes.Writeln(`import * as runtime from "@teamkeel/functions-runtime"`)
 	sdkTypes.Writeln(`import { Headers } from 'node-fetch'`)
-	sdkTypes.Writeln(`export { InlineFile, File, Duration, FileWriteTypes, SortDirection } from "@teamkeel/functions-runtime"`)
+	sdkTypes.Writeln(`export { InlineFile, File, Duration, FileWriteTypes, SortDirection, FlowConfig } from "@teamkeel/functions-runtime"`)
 	sdkTypes.Writeln("")
 
 	writePermissions(sdk, schema)

--- a/runtime/flows/flow.go
+++ b/runtime/flows/flow.go
@@ -50,6 +50,7 @@ type Run struct {
 	Steps     []Step    `json:"steps"`
 	CreatedAt time.Time `json:"createdAt"`
 	UpdatedAt time.Time `json:"updatedAt"`
+	Config    *JSONB    `json:"config" gorm:"-"` // Stages config component, omitted from db operations
 }
 
 func (Run) TableName() string {

--- a/runtime/flows/run.go
+++ b/runtime/flows/run.go
@@ -123,6 +123,12 @@ func GetFlowRunState(ctx context.Context, runID string) (run *Run, err error) {
 
 	// setting the ui component on the pending UI step
 	run.SetUIComponent(resp.UI)
+
+	// set stages config if any
+	if resp.Config != nil {
+		run.Config = resp.Config
+	}
+
 	return
 }
 


### PR DESCRIPTION
Return stages config as part of the get flow run response. 

This stage config will be set with the flow config returned from the functions runtime when retrieving ui components of a pending UI step.

Also, this PR exports the FlowConfig runtime type as part of the generated sdk