### PR TITLE
feat: support custom TS paths in testing

### DIFF
--- a/node/bootstrap.go
+++ b/node/bootstrap.go
@@ -48,10 +48,11 @@ func GetDependencies(options *bootstrapOptions) (map[string]string, map[string]s
 	}
 
 	devDeps := map[string]string{
-		"@types/node": "22.13.5",
-		"tsx":         "4.19.3",
-		"typescript":  "5.8.3",
-		"vitest":      "3.1.1",
+		"@types/node":         "22.13.5",
+		"tsx":                 "4.19.3",
+		"typescript":          "5.8.3",
+		"vitest":              "3.1.1",
+		"vite-tsconfig-paths": "5.1.4",
 	}
 
 	return deps, devDeps

--- a/node/codegen.go
+++ b/node/codegen.go
@@ -1477,9 +1477,13 @@ func generateTestingSetup() codegen.GeneratedFiles {
 			Path: ".build/vitest.config.mjs",
 			Contents: `
 import { defineConfig } from "vitest/config";
+import tsconfigPaths from 'vite-tsconfig-paths'
 import * as path from 'path';
 
 export default defineConfig({
+	plugins: [
+        tsconfigPaths(),
+    ],
 	test: {
 		setupFiles: [__dirname + "/vitest.setup"],
 		testTimeout: 100000,
@@ -1489,13 +1493,13 @@ export default defineConfig({
 		// imports so that they actually exist in the .build directory underneath the hood, for vitest we need to also add
 		// the below alias section which enables vitest to pickup the same paths configuration for the code generated
 		// npm modules. This is necessary because vitest isn't aware of the 'paths' configuration in typescript world at all
-    alias: {
+		alias: {
 			// the __dirname below is relative to the .build directory which contains the sdk and testing directories containing
 			// the codegenned sdk and testing packages.
-      '@teamkeel/testing': path.resolve(__dirname, './testing'),
+			'@teamkeel/testing': path.resolve(__dirname, './testing'),
 			'@teamkeel/sdk': path.resolve(__dirname, './sdk')
-    }
-  }
+		}
+	}
 });
 			`,
 		},


### PR DESCRIPTION
Use `vite-tsconfig-paths` to support additional user configured paths via TS config