### PR TITLE
fix: page name, step config, stage persistence

### DIFF
--- a/integration/testdata/flows/flows/myFlow.ts
+++ b/integration/testdata/flows/flows/myFlow.ts
@@ -18,33 +18,36 @@ export default MyFlow(
     ],
   },
   async (ctx, inputs) => {
-    const thing = await ctx.step("insert thing", async () => {
-      const thing = await models.thing.create({
-        name: inputs.name,
-        age: inputs.age,
-      });
+    const thing = await ctx.step("insert thing",
+      { stage: "stage1" },
+      async () => {
+        const thing = await models.thing.create({
+          name: inputs.name,
+          age: inputs.age,
+        });
 
-      return { id: thing.id };
+        return { id: thing.id };
+      }
+    );
+
+    const values = await ctx.ui.page("page1", {
+      title: "Update thing",
+      stage: "stage2",
+      description: "Overwrite the existing data in thing",
+      content: [
+        ctx.ui.inputs.text("name", {
+          label: "Name",
+          defaultValue: inputs.name,
+        }),
+        ctx.ui.display.divider(),
+        ctx.ui.inputs.number("age", {
+          label: "Age",
+          defaultValue: inputs.age,
+        }),
+      ],
     });
 
-  const values = await ctx.ui.page({
-    title: "Update thing",
-    stage: "stage1",
-    description: "Overwrite the existing data in thing",
-    content: [
-      ctx.ui.inputs.text("name", {
-        label: "Name",
-        defaultValue: inputs.name,
-      }),
-      ctx.ui.display.divider(),
-      ctx.ui.inputs.number("age", {
-        label: "Age",
-        defaultValue: inputs.age,
-      }),
-    ],
-  });
-
-    await ctx.step("update thing", async () => {
+    await ctx.step("update thing", {}, async () => {
       return await models.thing.update(
         { id: thing.id },
         {

--- a/migrations/flows.sql
+++ b/migrations/flows.sql
@@ -13,6 +13,7 @@ CREATE TABLE IF NOT EXISTS keel_flow_step (
 	"id" text NOT NULL DEFAULT ksuid() PRIMARY KEY,
 	"run_id" text NOT NULL REFERENCES "keel_flow_run" ("id") ON UPDATE CASCADE ON DELETE CASCADE,
 	"name" TEXT NOT NULL,
+	"stage" TEXT NULL,
 	"status" TEXT NOT NULL,
 	"type" TEXT NOT NULL,
 	"value" JSONB DEFAULT NULL,

--- a/packages/functions-runtime/src/flows/ui/elements/display/table.ts
+++ b/packages/functions-runtime/src/flows/ui/elements/display/table.ts
@@ -28,8 +28,8 @@ export const table: DisplayElementImplementation<
   const filteredData = options.columns
     ? options.data.map((item) => {
         return Object.fromEntries(
-          Object.entries(item).filter(
-            ([key]) => options.columns?.includes(key as any)
+          Object.entries(item).filter(([key]) =>
+            options.columns?.includes(key as any)
           )
         );
       })

--- a/packages/functions-runtime/src/flows/ui/elements/select/single.ts
+++ b/packages/functions-runtime/src/flows/ui/elements/select/single.ts
@@ -12,7 +12,7 @@ type ElementDataType = string | number | boolean | Date;
 // So having to duplicate the types of the inputs
 export type UiElementSelectOne = <
   TValue extends ElementDataType,
-  N extends string,
+  N extends string
 >(
   name: N,
   options?: BaseInputConfig<TValue> & {

--- a/packages/functions-runtime/src/flows/ui/index.ts
+++ b/packages/functions-runtime/src/flows/ui/index.ts
@@ -87,7 +87,7 @@ type UiDisplayElements = {
 
 // The base input element function. All inputs must be named and can optionally have a config
 export type InputElement<TValueType, TConfig extends any = never> = <
-  N extends string,
+  N extends string
 >(
   name: N,
   options?: BaseInputConfig<TValueType> & TConfig
@@ -175,7 +175,7 @@ export type ElementApiResponses = {
 export type InputElementImplementation<
   TData,
   TConfig extends (...args: any) => any,
-  TApiResponse,
+  TApiResponse
 > = (
   ...args: Parameters<TConfig>
 ) => InputElementImplementationResponse<TApiResponse, TData>;
@@ -188,7 +188,7 @@ export type InputElementImplementationResponse<TApiResponse, TData> = {
 
 export type DisplayElementImplementation<
   TConfig extends (...args: any) => any,
-  TApiResponse,
+  TApiResponse
 > = (
   ...args: Parameters<TConfig>
 ) => DisplayElementImplementationResponse<TApiResponse>;

--- a/packages/functions-runtime/src/flows/ui/page.ts
+++ b/packages/functions-runtime/src/flows/ui/page.ts
@@ -1,19 +1,22 @@
 import { InputElementResponse } from ".";
 
 import { UIElements } from ".";
-import { FlowConfig } from "..";
+import { FlowConfig, ExtractStageKeys } from "..";
 
 export type UiPage<C extends FlowConfig> = <
   T extends UIElements,
   A extends PageActions[] = []
->(options: {
-  stage?: ExtractStageKeys<C>;
-  title?: string;
-  description?: string;
-  content: T;
-  validate?: (data: ExtractFormData<T>) => Promise<true | string>;
-  actions?: A;
-}) => A["length"] extends 0
+>(
+  name: string,
+  options: {
+    stage?: ExtractStageKeys<C>;
+    title?: string;
+    description?: string;
+    content: T;
+    validate?: (data: ExtractFormData<T>) => Promise<true | string>;
+    actions?: A;
+  }
+) => A["length"] extends 0
   ? ExtractFormData<T>
   : { data: ExtractFormData<T>; action: ActionValue<A[number]> };
 
@@ -43,14 +46,3 @@ type ExtractFormData<T extends UIElements> = {
     InputElementResponse<K, any>
   >["valueType"];
 };
-
-// Extract the stage keys from the flow config supporting either a string or an object with a key property
-type ExtractStageKeys<T extends FlowConfig> = T extends { stages: infer S }
-  ? S extends ReadonlyArray<infer U>
-    ? U extends string
-      ? U
-      : U extends { key: infer K extends string }
-      ? K
-      : never
-    : never
-  : never;

--- a/packages/functions-runtime/src/handleFlow.js
+++ b/packages/functions-runtime/src/handleFlow.js
@@ -9,7 +9,7 @@ const opentelemetry = require("@opentelemetry/api");
 const { withSpan } = require("./tracing");
 const { tryExecuteFlow } = require("./tryExecuteFlow");
 const { parseInputs } = require("./parsing");
-const { createStepContext } = require("./flows");
+const { createFlowContext } = require("./flows");
 const {
   StepCompletedDisrupt,
   StepErrorDisrupt,
@@ -65,7 +65,7 @@ async function handleFlow(request, config) {
           throw new Error("no flow run found");
         }
 
-        const ctx = createStepContext(
+        const ctx = createFlowContext(
           request.meta.runId,
           request.meta.data,
           span.spanContext().spanId

--- a/packages/functions-runtime/src/index.ts
+++ b/packages/functions-runtime/src/index.ts
@@ -43,5 +43,10 @@ export function ksuid() {
 
 // Export TS
 export * from "./types";
-export { UI, StepContext, FlowConfig, FlowFunction } from "./flows";
+export {
+  UI,
+  FlowContext as StepContext,
+  FlowConfig,
+  FlowFunction,
+} from "./flows";
 export { type ElementApiResponses } from "./flows/ui/index";


### PR DESCRIPTION
New argument on the page function for the unique name of the step:

```ts
const values = await ctx.ui.page("Update page", {
  title: "Update thing",
  stage: "Updating",
  description: "Overwrite the existing data in thing",
  // ..
});
```

Function steps now have a configuration argument, which includes `stage`.  Timeout and retry configuration also moved here.

```ts
const thing = await ctx.step("insert thing",
  { stage: "Updating" },
  async () => {
    // ..
  }
);
```

Step stages now persisted:

![image](https://github.com/user-attachments/assets/cbe11913-3c49-47fa-9afc-5836183d2bf3)
