### PR TITLE
fix: fix datamapping configs on tool links

### DIFF
--- a/tools/config.go
+++ b/tools/config.go
@@ -478,6 +478,9 @@ func (cfg *LinkConfig) applyOn(link *toolsproto.ActionLink) *toolsproto.ActionLi
 	if cfg.VisibleCondition != nil {
 		link.VisibleCondition = cfg.VisibleCondition
 	}
+	if dm := cfg.getDataMapping(); dm != nil {
+		link.Data = dm
+	}
 
 	return link
 }


### PR DESCRIPTION
When configuring links and amending data mappings, we were failing to apply the user added data mapping. This is now fixed.