### PR TITLE
fix: use TrimSpace to support Windows

### DIFF
--- a/node/bootstrap.go
+++ b/node/bootstrap.go
@@ -274,8 +274,10 @@ func CheckNodeVersion() error {
 		return err
 	}
 
-	nodeVersion := strings.TrimPrefix(string(output), "v")
-	nodeVersion = strings.TrimSuffix(nodeVersion, "\n")
+	// Output will be something like "v22.15.0" with a new line at the end
+	// So trim space and remove "v"
+	nodeVersion := strings.TrimSpace(string(output))
+	nodeVersion = strings.TrimPrefix(nodeVersion, "v")
 
 	validVersionNumber, err := regexp.MatchString(`(\d+)\.(\d+)\.(\d+)`, nodeVersion)
 	if err != nil {


### PR DESCRIPTION
Pretty sure this is just because on Windows a newline is "\r\n"... `TrimSpace` should handle this.

```
PS C:\Users\source\repos\KeelDemos\inventory_management_mm> keel validate
✨ Everything's looking good!
PS C:\Users\source\repos\KeelDemos\inventory_management_mm> keel run     

Running Keel app in directory: C:\Users\source\repos\KeelDemos\inventory_management_mm


Press q to quit
❌ There is an issue with your dependencies:
Malformed version: 22.15.0
```