### PR TITLE
fix: negation of timestamp types to produce a duration

### DIFF
--- a/expressions/options/options.go
+++ b/expressions/options/options.go
@@ -48,21 +48,23 @@ var typeCompatibilityMapping = map[string][][]*types.Type{
 	},
 	operators.Less: {
 		{types.IntType, types.DoubleType, typing.Number, typing.Decimal},
-		{typing.Date, typing.Timestamp, types.TimestampType},
+		{typing.Date, typing.Timestamp, types.TimestampType, typing.Date},
 		{typing.Duration},
 	},
 	operators.LessEquals: {
 		{types.IntType, types.DoubleType, typing.Number, typing.Decimal},
-		{typing.Date, typing.Timestamp, types.TimestampType},
+		{typing.Date, typing.Timestamp, types.TimestampType, typing.Date},
 		{typing.Duration},
 	},
 	operators.Add: {
 		{types.IntType, types.DoubleType, typing.Number, typing.Decimal},
+		//{typing.Date, typing.Timestamp, types.TimestampType, typing.Date},
 		{typing.Duration},
 		{types.StringType, typing.Text},
 	},
 	operators.Subtract: {
 		{types.IntType, types.DoubleType, typing.Number, typing.Decimal},
+		//{typing.Date, typing.Timestamp, types.TimestampType, typing.Date},
 		{typing.Duration},
 	},
 	operators.Multiply: {
@@ -348,6 +350,14 @@ func WithComparisonOperators() expressions.Option {
 				}
 			}
 		}
+
+		// Subtracting two date/time variants will produce a duration. We define these separately because the return type is different to the operand types which doesnt fit with the generic mapping.
+		options = append(options,
+			cel.Function(operators.Subtract, cel.Overload(overloadName(operators.Subtract, typing.Date, typing.Timestamp), argTypes(typing.Date, typing.Timestamp), typing.Duration)),
+			cel.Function(operators.Subtract, cel.Overload(overloadName(operators.Subtract, typing.Date, typing.Date), argTypes(typing.Date, typing.Date), typing.Duration)),
+			cel.Function(operators.Subtract, cel.Overload(overloadName(operators.Subtract, typing.Timestamp, typing.Timestamp), argTypes(typing.Timestamp, typing.Timestamp), typing.Duration)),
+			cel.Function(operators.Subtract, cel.Overload(overloadName(operators.Subtract, typing.Timestamp, typing.Date), argTypes(typing.Timestamp, typing.Date), typing.Duration)),
+		)
 
 		p.CelEnv, err = p.CelEnv.Extend(options...)
 		if err != nil {

--- a/expressions/options/options.go
+++ b/expressions/options/options.go
@@ -48,23 +48,21 @@ var typeCompatibilityMapping = map[string][][]*types.Type{
 	},
 	operators.Less: {
 		{types.IntType, types.DoubleType, typing.Number, typing.Decimal},
-		{typing.Date, typing.Timestamp, types.TimestampType, typing.Date},
+		{typing.Date, typing.Timestamp, types.TimestampType},
 		{typing.Duration},
 	},
 	operators.LessEquals: {
 		{types.IntType, types.DoubleType, typing.Number, typing.Decimal},
-		{typing.Date, typing.Timestamp, types.TimestampType, typing.Date},
+		{typing.Date, typing.Timestamp, types.TimestampType},
 		{typing.Duration},
 	},
 	operators.Add: {
 		{types.IntType, types.DoubleType, typing.Number, typing.Decimal},
-		//{typing.Date, typing.Timestamp, types.TimestampType, typing.Date},
 		{typing.Duration},
 		{types.StringType, typing.Text},
 	},
 	operators.Subtract: {
 		{types.IntType, types.DoubleType, typing.Number, typing.Decimal},
-		//{typing.Date, typing.Timestamp, types.TimestampType, typing.Date},
 		{typing.Duration},
 	},
 	operators.Multiply: {

--- a/integration/testdata/computed_fields/schema.keel
+++ b/integration/testdata/computed_fields/schema.keel
@@ -53,3 +53,11 @@ model ComputedDepends {
         total Decimal @computed(computedDepends.quantity * computedDepends.price)
     }
 }
+
+model ComputedDuration {
+    fields {
+        orderDate Date 
+        deliveryDate Timestamp?
+        leadTime Duration? @computed(computedDuration.deliveryDate - computedDuration.orderDate)
+    }
+}

--- a/integration/testdata/computed_fields/tests.test.ts
+++ b/integration/testdata/computed_fields/tests.test.ts
@@ -146,3 +146,11 @@ test("computed fields - with dependencies", async () => {
   expect(updatePrice.totalWithShipping).toEqual(93);
   expect(updatePrice.totalWithDiscount).toEqual(84.2);
 });
+
+test("computed fields - duration", async () => {
+  const item = await models.computedDuration.create({ orderDate: new Date("2025-01-06") });
+  expect(item.leadTime).toBeNull();
+
+  const updatedItem = await models.computedDuration.update({ id: item.id }, { deliveryDate: new Date("2025-01-08T14:30:00Z") });
+  expect(updatedItem.leadTime?.toISOString()).toEqual("P2DT14H30M");
+});

--- a/integration/testdata/computed_fields/tests.test.ts
+++ b/integration/testdata/computed_fields/tests.test.ts
@@ -149,10 +149,15 @@ test("computed fields - with dependencies", async () => {
 });
 
 test("computed fields - duration", async () => {
-  const item = await models.computedDuration.create({ orderDate: new Date("2025-01-06") });
+  const item = await models.computedDuration.create({
+    orderDate: new Date("2025-01-06"),
+  });
   expect(item.leadTime).toBeNull();
 
-  const updatedItem = await models.computedDuration.update({ id: item.id }, { deliveryDate: new Date("2025-01-08T14:30:00Z") });
+  const updatedItem = await models.computedDuration.update(
+    { id: item.id },
+    { deliveryDate: new Date("2025-01-08T14:30:00Z") }
+  );
   expect(updatedItem.leadTime?.toISOString()).toEqual("P2DT14H30M");
 });
 

--- a/migrations/sql.go
+++ b/migrations/sql.go
@@ -304,7 +304,7 @@ func fieldFromComputedFnName(schema *proto.Schema, fn string) *proto.Field {
 func addComputedFieldFuncStmt(schema *proto.Schema, model *proto.Model, field *proto.Field) (string, string, error) {
 	var sqlType string
 	switch field.Type.Type {
-	case proto.Type_TYPE_DECIMAL, proto.Type_TYPE_INT, proto.Type_TYPE_BOOL, proto.Type_TYPE_STRING:
+	case proto.Type_TYPE_DECIMAL, proto.Type_TYPE_INT, proto.Type_TYPE_BOOL, proto.Type_TYPE_STRING, proto.Type_TYPE_DURATION:
 		sqlType = PostgresFieldTypes[field.Type.Type]
 	case proto.Type_TYPE_MODEL:
 		sqlType = "TEXT"

--- a/schema/validation/computed_attribute.go
+++ b/schema/validation/computed_attribute.go
@@ -35,12 +35,13 @@ func ComputedAttributeRules(asts []*parser.AST, errs *errorhandling.ValidationEr
 				return
 			}
 
-			// Basic types supported with computed fields
+			// Basic field types supported with computed fields
 			supportedTypes := []string{
 				parser.FieldTypeBoolean,
 				parser.FieldTypeNumber,
 				parser.FieldTypeDecimal,
 				parser.FieldTypeText,
+				parser.FieldTypeDuration,
 			}
 
 			// Model fields are also supported


### PR DESCRIPTION
Support for negation of timestamps in computed expressions on `Duration` field types.   For example:

```
model Order {
    fields {
        orderDate Timestamp 
        deliveryDate Timestamp?
        leadTime Duration? @computed(computedDuration.deliveryDate - computedDuration.orderDate)
    }
}
```