### PR TITLE
fix: flow step overload

### DIFF
--- a/integration/testdata/flows/schema.keel
+++ b/integration/testdata/flows/schema.keel
@@ -3,6 +3,7 @@ flow MyFlow {
         name Text
         age Number
     }
+    @permission(roles: [Admin])
 }
 
 model Thing {
@@ -10,4 +11,10 @@ model Thing {
         name Text?
         age Number?
     }
+}
+
+role Admin {
+    domains {
+        "keel.xyz"
+    }   
 }


### PR DESCRIPTION
This change overloads the step function definition so that is it possible to omit the options argument.  i.e. these are both valid:

With options:
```
await ctx.step(
    "my step", 
    { stage: "stage 1" }, 
    async() => {
        ...
    }
);
```

Without options:
```
await ctx.step(
    "my step", 
    async() => {
        ...
    }
);
```