### PR TITLE
fix: flow step errors, timeouts and retry handling

### DIFF
--- a/migrations/flows.sql
+++ b/migrations/flows.sql
@@ -17,11 +17,9 @@ CREATE TABLE IF NOT EXISTS keel_flow_step (
 	"status" TEXT NOT NULL,
 	"type" TEXT NOT NULL,
 	"value" JSONB DEFAULT NULL,
-	"max_retries" INTEGER NOT NULL,
-	"timeout_in_ms" INTEGER NOT NULL,
+	"error" TEXT DEFAULT NULL,
 	"span_id" TEXT,
 	"created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
 	"updated_at" TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 CREATE OR REPLACE TRIGGER keel_flow_step_updated_at BEFORE UPDATE ON "keel_flow_step" FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
-

--- a/packages/functions-runtime/src/flows/disrupts.ts
+++ b/packages/functions-runtime/src/flows/disrupts.ts
@@ -23,3 +23,9 @@ export class StepCompletedDisrupt extends FlowDisrupt {
     super();
   }
 }
+
+export class ExhuastedRetriesDisrupt extends FlowDisrupt {
+  constructor() {
+    super();
+  }
+}

--- a/packages/functions-runtime/src/flows/index.ts
+++ b/packages/functions-runtime/src/flows/index.ts
@@ -172,20 +172,6 @@ export function createFlowContext<C extends FlowConfig>(
           .returningAll()
           .executeTakeFirst();
 
-        // if (past.length < (options.maxRetries ?? defaultOpts.maxRetries)) {
-        //   await db
-        //     .insertInto("keel_flow_step")
-        //     .values({
-        //       run_id: runId,
-        //       name: name,
-        //       stage: options.stage,
-        //       status: STEP_STATUS.NEW,
-        //       type: STEP_TYPE.FUNCTION,
-        //     })
-        //     .returningAll()
-        //     .executeTakeFirst();
-        // }
-
         throw new StepErrorDisrupt(
           e instanceof Error ? e.message : "An error occurred"
         );

--- a/packages/functions-runtime/src/flows/index.ts
+++ b/packages/functions-runtime/src/flows/index.ts
@@ -159,7 +159,10 @@ export function createFlowContext<C extends FlowConfig>(
 
       let result = null;
       try {
-        result = await withTimeout(actualFn(), options.timeoutInMs ?? defaultOpts.timeoutInMs);
+        result = await withTimeout(
+          actualFn(),
+          options.timeoutInMs ?? defaultOpts.timeoutInMs
+        );
       } catch (e) {
         await db
           .updateTable("keel_flow_step")

--- a/packages/functions-runtime/src/flows/index.ts
+++ b/packages/functions-runtime/src/flows/index.ts
@@ -159,7 +159,7 @@ export function createFlowContext<C extends FlowConfig>(
 
       let result = null;
       try {
-        result = await withTimeout(actualFn(), step.timeoutInMs);
+        result = await withTimeout(actualFn(), options.timeoutInMs ?? defaultOpts.timeoutInMs);
       } catch (e) {
         await db
           .updateTable("keel_flow_step")

--- a/packages/functions-runtime/src/handleFlow.js
+++ b/packages/functions-runtime/src/handleFlow.js
@@ -114,7 +114,7 @@ async function handleFlow(request, config) {
           message: e.message,
         });
 
-        // The flow is disrupted by a flow failure
+        // The flow has failed due to exhausted step retries
         if (e instanceof ExhuastedRetriesDisrupt) {
           return createJSONRPCErrorResponse(
             request.id,

--- a/packages/functions-runtime/src/handleFlow.js
+++ b/packages/functions-runtime/src/handleFlow.js
@@ -14,6 +14,7 @@ import {
   StepCompletedDisrupt,
   StepErrorDisrupt,
   UIRenderDisrupt,
+  ExhuastedRetriesDisrupt,
 } from "./flows/disrupts";
 
 async function handleFlow(request, config) {
@@ -112,6 +113,15 @@ async function handleFlow(request, config) {
           code: opentelemetry.SpanStatusCode.ERROR,
           message: e.message,
         });
+
+        // The flow is disrupted by a flow failure
+        if (e instanceof ExhuastedRetriesDisrupt) {
+          return createJSONRPCErrorResponse(
+            request.id,
+            JSONRPCErrorCode.InternalError,
+            "flow failed due to exhausted step retries"
+          );
+        }
 
         return createJSONRPCSuccessResponse(request.id, {
           runId: runId,

--- a/runtime/flows/orchestrator.go
+++ b/runtime/flows/orchestrator.go
@@ -113,11 +113,6 @@ func (o *Orchestrator) orchestrateRun(ctx context.Context, runID string, data ma
 			return err
 		}
 
-		stepsMap := map[string][]Step{}
-		for _, step := range run.Steps {
-			stepsMap[step.Name] = append(stepsMap[step.Name], step)
-		}
-
 		// Check to see if we're in a Pending UI step, break orchestration
 		if run.PendingUI() {
 			return nil

--- a/runtime/flows/orchestrator.go
+++ b/runtime/flows/orchestrator.go
@@ -97,6 +97,8 @@ func (o *Orchestrator) orchestrateRun(ctx context.Context, runID string, data ma
 		// call the flow runtime
 		resp, err := o.CallFlow(ctx, run, data)
 		if err != nil {
+			_, _ = updateRun(ctx, run.ID, StatusFailed)
+
 			return err
 		}
 
@@ -114,15 +116,6 @@ func (o *Orchestrator) orchestrateRun(ctx context.Context, runID string, data ma
 		stepsMap := map[string][]Step{}
 		for _, step := range run.Steps {
 			stepsMap[step.Name] = append(stepsMap[step.Name], step)
-		}
-
-		// Check to see if the retries have been exceeded
-		if len(run.Steps) > 0 {
-			lastStep := run.Steps[len(run.Steps)-1]
-			if lastStep.Status == StepStatusFailed && len(stepsMap[lastStep.Name]) >= lastStep.MaxRetries {
-				_, err := updateRun(ctx, run.ID, StatusFailed)
-				return err
-			}
 		}
 
 		// Check to see if we're in a Pending UI step, break orchestration

--- a/runtime/flows/orchestrator.go
+++ b/runtime/flows/orchestrator.go
@@ -119,7 +119,7 @@ func (o *Orchestrator) orchestrateRun(ctx context.Context, runID string, data ma
 		}
 
 		// Continue running the flow
-		payload := FlowRunUpdated{RunID: resp.RunID, Data: data}
+		payload := FlowRunUpdated{RunID: resp.RunID}
 		wrap, err := payload.Wrap()
 		if err != nil {
 			return err


### PR DESCRIPTION
`error` column
--
If an error occurs on a step, this will be stored in the new `error` column.

Timeouts and retries handling
--
These columns have been removed from the database, and now the functions runtime handles them.