### PR TITLE
chore: add a AWAITING_INPUT run status

### DIFF
--- a/integration/testdata/flows/tests.test.ts
+++ b/integration/testdata/flows/tests.test.ts
@@ -6,7 +6,50 @@ import { sql } from "kysely";
 beforeEach(resetDatabase);
 
 test("flows - basic execution", async () => {
-  await flows.myFlow({ name: "Keelson", age: 25 });
+  const response = await fetch(
+    process.env.KEEL_TESTING_AUTH_API_URL + "/token",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        grant_type: "password",
+        username: "admin@keel.xyz",
+        password: "1234",
+      }),
+    }
+  );
+  expect(response.status).toEqual(200);
+
+  const token = (await response.json()).access_token;
+  await models.identity.update(
+    {
+      email: "admin@keel.xyz",
+      issuer: "https://keel.so",
+    },
+    {
+      emailVerified: true,
+    }
+  );
+
+  const flowStartResponse = await fetch(
+    `${process.env.KEEL_TESTING_API_URL}/flows/json/myFlow`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer " + token,
+      },
+      body: JSON.stringify({
+        name: "Keelson",
+        age: 23,
+      }),
+    }
+  );
+  expect(flowStartResponse.status).toEqual(200);
+  const flowStartData = await flowStartResponse.json();
+  const runId = flowStartData.id;
 
   const things = await models.thing.findMany();
   expect(things.length).toBe(1);
@@ -18,4 +61,55 @@ test("flows - basic execution", async () => {
     useDatabase()
   );
   expect(dbSteps.rows.length).toBe(2);
+
+  const flowStateResponse = await fetch(
+    `${process.env.KEEL_TESTING_API_URL}/flows/json/myFlow/${runId}`,
+    {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer " + token,
+      },
+    }
+  );
+  expect(flowStateResponse.status).toEqual(200);
+  const flowStateData = await flowStateResponse.json();
+  expect(flowStateData.status).toBe("AWAITING_INPUT");
+
+  const stepId = flowStateData.steps.find(
+    (step) => step.type === "UI" && step.status === "PENDING"
+  )?.id;
+
+  const flowStepPutResponse = await fetch(
+    `${process.env.KEEL_TESTING_API_URL}/flows/json/myFlow/${runId}/${stepId}`,
+    {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer " + token,
+      },
+      body: JSON.stringify({
+        name: "Keelson updated",
+        age: 32,
+      }),
+    }
+  );
+  expect(flowStepPutResponse.status).toEqual(200);
+  const newThings = await models.thing.findMany();
+  expect(newThings.length).toBe(1);
+  expect(newThings[0].name).toBe("Keelson updated");
+
+  const finalFlowStateResponse = await fetch(
+    `${process.env.KEEL_TESTING_API_URL}/flows/json/myFlow/${runId}`,
+    {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer " + token,
+      },
+    }
+  );
+  expect(finalFlowStateResponse.status).toEqual(200);
+  const finalFlowStateData = await finalFlowStateResponse.json();
+  expect(finalFlowStateData.status).toBe("COMPLETED");
 });

--- a/runtime/flows/orchestrator.go
+++ b/runtime/flows/orchestrator.go
@@ -114,7 +114,7 @@ func (o *Orchestrator) orchestrateRun(ctx context.Context, runID string, data ma
 		}
 
 		// Check to see if we're in a Pending UI step, break orchestration
-		if run.PendingUI() {
+		if run.HasPendingUIStep() {
 			return nil
 		}
 

--- a/runtime/flows/run.go
+++ b/runtime/flows/run.go
@@ -103,7 +103,7 @@ func GetFlowRunState(ctx context.Context, runID string) (run *Run, err error) {
 	)
 
 	// if we're not waiting for a UI step, return
-	if !run.PendingUI() {
+	if !run.HasPendingUIStep() {
 		return
 	}
 


### PR DESCRIPTION
Adds a new flow run status: `AWAITING_INPUT`. Whenever a flow run is orchestrated and it is pending a UI step, the status will be set to awaiting input. Once a flow is orchestrated again, with data when in an `AWAITING_INPUT` status, the status will be updated to `RUNNING` and the flow runtime invoked. 

This will allow FE to differentiate between flow runs that are currently in progress (executing) and the ones that are awaiting user input.