### PR TITLE
fix: flow step errors, timeouts, retry handling and tests

### DIFF
--- a/integration/testdata/flows/flows/errorInStep.ts
+++ b/integration/testdata/flows/flows/errorInStep.ts
@@ -1,0 +1,7 @@
+import { ErrorInStep } from "@teamkeel/sdk";
+
+export default ErrorInStep({}, async (ctx) => {
+  await ctx.step("erroring step", { maxRetries: 3 }, async () => {
+    throw new Error("Error in step");
+  });
+});

--- a/integration/testdata/flows/flows/timeoutStep.ts
+++ b/integration/testdata/flows/flows/timeoutStep.ts
@@ -1,0 +1,7 @@
+import { TimeoutStep } from "@teamkeel/sdk";
+
+export default TimeoutStep({}, async (ctx) => {
+  await ctx.step("timeout step", { timeoutInMs: 1 }, async () => {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  });
+});

--- a/integration/testdata/flows/schema.keel
+++ b/integration/testdata/flows/schema.keel
@@ -18,6 +18,14 @@ flow SingleStep {
     @permission(roles: [Admin])
 }
 
+flow ErrorInStep {
+    @permission(roles: [Admin])
+}
+
+flow TimeoutStep {
+    @permission(roles: [Admin])
+}
+
 model Thing {
     fields {
         name Text?

--- a/packages/functions-runtime/src/flows/index.ts
+++ b/packages/functions-runtime/src/flows/index.ts
@@ -10,7 +10,6 @@ import { selectOne } from "./ui/elements/select/single";
 import { UiPage } from "./ui/page";
 import {
   StepCreatedDisrupt,
-  StepErrorDisrupt,
   UIRenderDisrupt,
   ExhuastedRetriesDisrupt,
 } from "./disrupts";
@@ -145,10 +144,17 @@ export function createFlowContext<C extends FlowConfig>(
         throw new Error("Multiple completed steps found for the same step");
       }
 
+      if (completedSteps.length > 1 && newSteps.length > 1) {
+        throw new Error(
+          "Multiple completed and new steps found for the same step"
+        );
+      }
+
       if (completedSteps.length === 1) {
         return completedSteps[0].value;
       }
 
+      // Do we have a NEW step waiting to be run?
       if (newSteps.length === 1) {
         let result = null;
         try {
@@ -169,18 +175,29 @@ export function createFlowContext<C extends FlowConfig>(
             .executeTakeFirst();
 
           if (
-            failedSteps.length + 1 >
+            failedSteps.length + 1 >=
             (options.maxRetries ?? defaultOpts.maxRetries)
           ) {
             throw new ExhuastedRetriesDisrupt();
           }
 
-          throw new StepErrorDisrupt(
-            e instanceof Error ? e.message : "An error occurred"
-          );
+          // If we have retries left, create a new step
+          await db
+            .insertInto("keel_flow_step")
+            .values({
+              run_id: runId,
+              name: name,
+              stage: options.stage,
+              status: STEP_STATUS.NEW,
+              type: STEP_TYPE.FUNCTION,
+            })
+            .returningAll()
+            .executeTakeFirst();
+
+          throw new StepCreatedDisrupt();
         }
 
-        // Very crudely store the result in the database
+        // Store the result in the database
         await db
           .updateTable("keel_flow_step")
           .set({
@@ -194,7 +211,6 @@ export function createFlowContext<C extends FlowConfig>(
 
         return result;
       }
-      // There is no NEW or COMPLETED steps at this point, so we need to check if the step has failed too many times
 
       // The step hasn't yet run successfully, so we need to create a NEW run
       await db
@@ -210,6 +226,7 @@ export function createFlowContext<C extends FlowConfig>(
         .executeTakeFirst();
 
       throw new StepCreatedDisrupt();
+
       // TODO: Incorporate when we have support error handling
       // const stepPromise = fn({} as any);
       // const stepWithCatch = Object.assign(stepPromise, {

--- a/packages/functions-runtime/src/handleFlow.js
+++ b/packages/functions-runtime/src/handleFlow.js
@@ -12,7 +12,6 @@ import { parseInputs } from "./parsing";
 import { createFlowContext } from "./flows";
 import {
   StepCreatedDisrupt,
-  StepErrorDisrupt,
   UIRenderDisrupt,
   ExhuastedRetriesDisrupt,
 } from "./flows/disrupts";
@@ -123,11 +122,11 @@ async function handleFlow(request, config) {
           );
         }
 
-        return createJSONRPCSuccessResponse(request.id, {
-          runId: runId,
-          runCompleted: false,
-          config: flowConfig,
-        });
+        return createJSONRPCErrorResponse(
+          request.id,
+          JSONRPCErrorCode.InternalError,
+          e.message
+        );
       } finally {
         if (db) {
           await db.destroy();

--- a/runtime/flows/flow.go
+++ b/runtime/flows/flow.go
@@ -87,17 +87,16 @@ func (r *Run) SetUIComponent(ui *JSONB) {
 }
 
 type Step struct {
-	ID          string     `json:"id" gorm:"primaryKey;not null;default:null"`
-	Name        string     `json:"name"`
-	RunID       string     `json:"runId"`
-	Status      StepStatus `json:"status"`
-	Type        StepType   `json:"type"`
-	Value       *JSONB     `json:"value" gorm:"type:jsonb"`
-	MaxRetries  int        `json:"max_retries"`
-	TimeoutInMs int        `json:"timeout_in_ms"`
-	CreatedAt   time.Time  `json:"createdAt"`
-	UpdatedAt   time.Time  `json:"updatedAt"`
-	UI          *JSONB     `json:"ui" gorm:"-"` // UI component, omitted from db operations
+	ID        string     `json:"id" gorm:"primaryKey;not null;default:null"`
+	Name      string     `json:"name"`
+	RunID     string     `json:"runId"`
+	Status    StepStatus `json:"status"`
+	Type      StepType   `json:"type"`
+	Value     *JSONB     `json:"value" gorm:"type:jsonb"`
+	Error     *string    `json:"error"`
+	CreatedAt time.Time  `json:"createdAt"`
+	UpdatedAt time.Time  `json:"updatedAt"`
+	UI        *JSONB     `json:"ui" gorm:"-"` // UI component, omitted from db operations
 }
 
 func (Step) TableName() string {


### PR DESCRIPTION
**Fixes, improvements and tests for when an error is thrown in a flow step function.**

- Step retries were not triggering, so this has now been fixed.
- Returning the step `error` column in the API responses.
- Removed `max_retries` and `timeout_in_ms` from the API responses.
- Tests for step errors, retries and timeouts.