### PR TITLE
fix: step support for scalar return values

### DIFF
--- a/integration/testdata/flows/flows/scalarStep.ts
+++ b/integration/testdata/flows/flows/scalarStep.ts
@@ -1,0 +1,7 @@
+import { ScalarStep, models } from "@teamkeel/sdk";
+
+export default ScalarStep({}, async (ctx) => {
+  await ctx.step("scalar step", async () => {
+    return 10;
+  });
+});

--- a/integration/testdata/flows/schema.keel
+++ b/integration/testdata/flows/schema.keel
@@ -1,3 +1,7 @@
+flow ScalarStep {
+    @permission(roles: [Admin])
+}
+
 flow MixedStepTypes {
     inputs {
         name Text

--- a/integration/testdata/flows/tests.test.ts
+++ b/integration/testdata/flows/tests.test.ts
@@ -12,7 +12,7 @@ TEST CASES
 [x] Flow function with alternating function and UI steps
 [ ] Error thrown in flow function
 [ ] Error thrown in step function
-[ ] Step returning scalar value
+[x] Step returning scalar value
 [ ] Step function retrying  
 [ ] Step function timing out 
 [ ] UI step validation
@@ -21,6 +21,49 @@ TEST CASES
 [ ] Test all Keel types as inputs
 [x] Permissions and identity tests
 */
+
+test("flows - scalar step", async () => {
+  const token = await getToken({ email: "admin@keel.xyz" });
+
+  let { status, body } = await startFlow({
+    name: "scalarStep",
+    token,
+    body: {},
+  });
+  expect(status).toEqual(200);
+
+  const flow = await untilFlowFinished({
+    name: "scalarStep",
+    id: body.id,
+    token,
+  });
+
+  expect(flow).toEqual({
+    id: expect.any(String),
+    traceId: expect.any(String),
+    status: "COMPLETED",
+    name: "ScalarStep",
+    input: {},
+    steps: [
+      {
+        id: expect.any(String),
+        name: "scalar step",
+        runId: expect.any(String),
+        status: "COMPLETED",
+        type: "FUNCTION",
+        value: 10,
+        startTime: expect.any(String),
+        endTime: expect.any(String),
+        createdAt: expect.any(String),
+        updatedAt: expect.any(String),
+        ui: null,
+      },
+    ],
+    createdAt: expect.any(String),
+    updatedAt: expect.any(String),
+    config: null,
+  });
+});
 
 test("flows - stepless flow", async () => {
   const token = await getToken({ email: "admin@keel.xyz" });
@@ -359,7 +402,7 @@ test("flows - authorised starting, getting and listing flows", async () => {
 
   const resListAdmin = await listFlows({ token: adminToken });
   expect(resListAdmin.status).toBe(200);
-  expect(resListAdmin.body.flows.length).toBe(3);
+  expect(resListAdmin.body.flows.length).toBe(4);
   expect(resListAdmin.body.flows[0].name).toBe("MixedStepTypes");
   expect(resListAdmin.body.flows[1].name).toBe("Stepless");
 

--- a/integration/testdata/flows/tests.test.ts
+++ b/integration/testdata/flows/tests.test.ts
@@ -14,9 +14,9 @@ TEST CASES
 [x] Error thrown in step function
 [x] Step returning scalar value
 [x] Step function retrying  
-[ ] Step function timing out 
-[x] UI step validation
-[ ] Check full API responses
+[x] Step function timing out 
+[ ] UI step validation
+[x] Check full API responses
 [ ] All UI elements response
 [ ] Test all Keel types as inputs
 [x] Permissions and identity tests
@@ -52,6 +52,7 @@ test("flows - scalar step", async () => {
         status: "COMPLETED",
         type: "FUNCTION",
         value: 10,
+        error: null,
         startTime: expect.any(String),
         endTime: expect.any(String),
         createdAt: expect.any(String),
@@ -619,9 +620,13 @@ test("flows - authorised starting, getting and listing flows", async () => {
 
   const resListAdmin = await listFlows({ token: adminToken });
   expect(resListAdmin.status).toBe(200);
-  expect(resListAdmin.body.flows.length).toBe(5);
-  expect(resListAdmin.body.flows[0].name).toBe("MixedStepTypes");
-  expect(resListAdmin.body.flows[1].name).toBe("Stepless");
+  expect(resListAdmin.body.flows.length).toBe(6);
+  expect(resListAdmin.body.flows[0].name).toBe("ScalarStep");
+  expect(resListAdmin.body.flows[1].name).toBe("MixedStepTypes");
+  expect(resListAdmin.body.flows[2].name).toBe("Stepless");
+  expect(resListAdmin.body.flows[3].name).toBe("SingleStep");
+  expect(resListAdmin.body.flows[4].name).toBe("ErrorInStep");
+  expect(resListAdmin.body.flows[5].name).toBe("TimeoutStep");
 
   const resListUser = await listFlows({ token: userToken });
   expect(resListUser.status).toBe(200);

--- a/runtime/apis/flowsapi/flow_handler.go
+++ b/runtime/apis/flowsapi/flow_handler.go
@@ -58,7 +58,12 @@ func FlowHandler(s *proto.Schema) common.HandlerFunc {
 					return httpjson.NewErrorResponse(ctx, common.NewInputMalformedError("error parsing POST body"), nil)
 				}
 
-				run, err := flows.StartFlow(ctx, flow, inputs)
+				inputsMap, ok := inputs.(map[string]any)
+				if !ok {
+					return httpjson.NewErrorResponse(ctx, common.NewInputMalformedError("data not correctly formatted"), nil)
+				}
+
+				run, err := flows.StartFlow(ctx, flow, inputsMap)
 				if err != nil {
 					return httpjson.NewErrorResponse(ctx, err, nil)
 				}

--- a/runtime/flows/flow.go
+++ b/runtime/flows/flow.go
@@ -72,7 +72,7 @@ func (r *Run) HasPendingUIStep() bool {
 }
 
 // SetUIComponent will set the given UI component on the first pending UI step of the flow
-func (r *Run) SetUIComponent(ui any) {
+func (r *Run) SetUIComponent(ui JSON) {
 	if !r.HasPendingUIStep() {
 		return
 	}

--- a/runtime/flows/flow.go
+++ b/runtime/flows/flow.go
@@ -2,8 +2,6 @@ package flows
 
 import (
 	"context"
-	"database/sql/driver"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
@@ -47,11 +45,11 @@ type Run struct {
 	TraceID   string    `json:"traceId"`
 	Status    Status    `json:"status"`
 	Name      string    `json:"name"`
-	Input     *JSONB    `json:"input" gorm:"type:jsonb"`
+	Input     JSON      `json:"input" gorm:"type:jsonb;serializer:json"`
 	Steps     []Step    `json:"steps"`
 	CreatedAt time.Time `json:"createdAt"`
 	UpdatedAt time.Time `json:"updatedAt"`
-	Config    *JSONB    `json:"config" gorm:"-"` // Stages config component, omitted from db operations
+	Config    JSON      `json:"config" gorm:"-"` // Stages config component, omitted from db operations
 }
 
 func (Run) TableName() string {
@@ -74,7 +72,7 @@ func (r *Run) HasPendingUIStep() bool {
 }
 
 // SetUIComponent will set the given UI component on the first pending UI step of the flow
-func (r *Run) SetUIComponent(ui *JSONB) {
+func (r *Run) SetUIComponent(ui any) {
 	if !r.HasPendingUIStep() {
 		return
 	}
@@ -92,33 +90,19 @@ type Step struct {
 	RunID     string     `json:"runId"`
 	Status    StepStatus `json:"status"`
 	Type      StepType   `json:"type"`
-	Value     *JSONB     `json:"value" gorm:"type:jsonb"`
+	Value     JSON       `json:"value" gorm:"type:jsonb;serializer:json"`
 	StartTime *time.Time `json:"startTime"`
 	EndTime   *time.Time `json:"endTime"`
 	CreatedAt time.Time  `json:"createdAt"`
 	UpdatedAt time.Time  `json:"updatedAt"`
-	UI        *JSONB     `json:"ui" gorm:"-"` // UI component, omitted from db operations
+	UI        JSON       `json:"ui" gorm:"-"` // UI component, omitted from db operations
 }
 
 func (Step) TableName() string {
 	return "keel_flow_step"
 }
 
-// JSONB Interface for JSONB fields
-type JSONB map[string]any
-
-func (jsonField JSONB) Value() (driver.Value, error) {
-	b, err := json.Marshal(jsonField)
-	return string(b), err
-}
-
-func (jsonField *JSONB) Scan(value any) error {
-	data, ok := value.([]byte)
-	if !ok {
-		return errors.New("type assertion to []byte failed")
-	}
-	return json.Unmarshal(data, &jsonField)
-}
+type JSON interface{}
 
 type paginationFields struct {
 	Limit  int
@@ -210,14 +194,9 @@ func createRun(ctx context.Context, flow *proto.Flow, inputs any, traceID string
 		return nil, fmt.Errorf("invalid flow")
 	}
 
-	var jsonInputs JSONB
-	if inputsMap, ok := inputs.(map[string]any); ok {
-		jsonInputs = inputsMap
-	}
-
 	run := Run{
 		Status:  StatusNew,
-		Input:   &jsonInputs,
+		Input:   inputs,
 		Name:    flow.Name,
 		TraceID: traceID,
 	}

--- a/runtime/flows/orchestrator.go
+++ b/runtime/flows/orchestrator.go
@@ -70,8 +70,8 @@ func NewOrchestrator(s *proto.Schema, opts ...OrchestratorOpt) *Orchestrator {
 type FunctionsResponsePayload struct {
 	RunID        string `json:"runId"`
 	RunCompleted bool   `json:"runCompleted"`
-	Config       any    `json:"config"`
-	UI           any    `json:"ui"` // UI component for the current step, if applicable
+	Config       JSON   `json:"config"`
+	UI           JSON   `json:"ui"` // UI component for the current step, if applicable
 }
 
 // orchestrateRun will decide based on the db state if the flow should be ran or not

--- a/runtime/flows/orchestrator.go
+++ b/runtime/flows/orchestrator.go
@@ -70,8 +70,8 @@ func NewOrchestrator(s *proto.Schema, opts ...OrchestratorOpt) *Orchestrator {
 type FunctionsResponsePayload struct {
 	RunID        string `json:"runId"`
 	RunCompleted bool   `json:"runCompleted"`
-	Config       *JSONB `json:"config"`
-	UI           *JSONB `json:"ui"` // UI component for the current step, if applicable
+	Config       any    `json:"config"`
+	UI           any    `json:"ui"` // UI component for the current step, if applicable
 }
 
 // orchestrateRun will decide based on the db state if the flow should be ran or not

--- a/runtime/flows/run.go
+++ b/runtime/flows/run.go
@@ -11,7 +11,7 @@ import (
 )
 
 // StartFlow will start a new run for the given flow with the given input
-func StartFlow(ctx context.Context, flow *proto.Flow, inputs any) (run *Run, err error) {
+func StartFlow(ctx context.Context, flow *proto.Flow, inputs map[string]any) (run *Run, err error) {
 	ctx, span := tracer.Start(ctx, "StartFlow")
 	defer span.End()
 


### PR DESCRIPTION
Support scalar types being returned from steps.  E.g.

```ts
export default ScalarStep({}, async (ctx) => {
  await ctx.step("scalar step", async () => {
    return 10;
  });
});
```