### PR TITLE
fix: add step error to openapi schema

### DIFF
--- a/runtime/openapi/openapi.go
+++ b/runtime/openapi/openapi.go
@@ -313,6 +313,7 @@ func GenerateFlows(ctx context.Context, schema *proto.Schema) OpenAPI {
 			"ui":        {Ref: "#/components/schemas/UiConfig"},
 			"startTime": {Type: []string{"string", "null"}, Format: "date-time"},
 			"endTime":   {Type: []string{"string", "null"}, Format: "date-time"},
+			"error":     {Type: []string{"string", "null"}},
 		},
 	}
 

--- a/runtime/openapi/testdata/flow.json
+++ b/runtime/openapi/testdata/flow.json
@@ -541,6 +541,9 @@
             "format": "date-time",
             "type": ["string", "null"]
           },
+          "error": {
+            "type": ["string", "null"]
+          },
           "id": {
             "type": "string"
           },


### PR DESCRIPTION
Adds the newly introduced step `error` field to the openapi schema