### PR TITLE
refactor: retrieval of flow ui components through orchestration

### DIFF
--- a/integration/testdata/flows/flows/onlyPages.ts
+++ b/integration/testdata/flows/flows/onlyPages.ts
@@ -1,0 +1,25 @@
+import { OnlyPages } from "@teamkeel/sdk";
+
+// To learn more about flows, visit https://docs.keel.so/flows
+export default OnlyPages({}, async (ctx, inputs) => {
+  const grid = ctx.ui.display.grid({
+    data: [{ a: "A thing" }],
+    render: (d) => ({
+      title: d.a,
+    }),
+  });
+
+  await ctx.ui.page("first page", {
+    title: "Grid of things",
+    content: [grid],
+  });
+
+  await ctx.ui.page("question", {
+    title: "My flow",
+    content: [
+      ctx.ui.inputs.boolean("yesno", {
+        label: "Did you like the things?",
+      }),
+    ],
+  });
+});

--- a/integration/testdata/flows/schema.keel
+++ b/integration/testdata/flows/schema.keel
@@ -29,6 +29,10 @@ flow ErrorInStep {
 flow TimeoutStep {
     @permission(roles: [Admin])
 }
+flow OnlyPages {
+    @permission(roles: [Admin])
+}
+
 
 model Thing {
     fields {

--- a/integration/testdata/flows/tests.test.ts
+++ b/integration/testdata/flows/tests.test.ts
@@ -514,7 +514,7 @@ test("flows - alternating step types", async () => {
         endTime: null,
       },
     ],
-    config: null,
+    config: {},
     traceId,
     createdAt: expect.any(String),
     updatedAt: expect.any(String),
@@ -774,13 +774,14 @@ test("flows - authorised starting, getting and listing flows", async () => {
 
   const resListAdmin = await listFlows({ token: adminToken });
   expect(resListAdmin.status).toBe(200);
-  expect(resListAdmin.body.flows.length).toBe(6);
+  expect(resListAdmin.body.flows.length).toBe(7);
   expect(resListAdmin.body.flows[0].name).toBe("ScalarStep");
   expect(resListAdmin.body.flows[1].name).toBe("MixedStepTypes");
   expect(resListAdmin.body.flows[2].name).toBe("Stepless");
   expect(resListAdmin.body.flows[3].name).toBe("SingleStep");
   expect(resListAdmin.body.flows[4].name).toBe("ErrorInStep");
   expect(resListAdmin.body.flows[5].name).toBe("TimeoutStep");
+  expect(resListAdmin.body.flows[6].name).toBe("OnlyPages");
 
   const resListUser = await listFlows({ token: userToken });
   expect(resListUser.status).toBe(200);

--- a/runtime/flows/flow.go
+++ b/runtime/flows/flow.go
@@ -71,15 +71,21 @@ func (r *Run) HasPendingUIStep() bool {
 	return false
 }
 
-// SetUIComponent will set the given UI component on the first pending UI step of the flow
-func (r *Run) SetUIComponent(ui JSON) {
-	if !r.HasPendingUIStep() {
+// SetUIComponents will set the given UI component on the first pending UI step of the flow
+func (r *Run) SetUIComponents(c *FlowUIComponents) {
+	if c == nil {
 		return
 	}
 
-	for i, step := range r.Steps {
-		if step.Type == StepTypeUI && step.Status == StepStatusPending {
-			r.Steps[i].UI = ui
+	if c.Config != nil {
+		r.Config = c.Config
+	}
+
+	if r.HasPendingUIStep() && c.UI != nil {
+		for i, step := range r.Steps {
+			if step.Type == StepTypeUI && step.Status == StepStatusPending {
+				r.Steps[i].UI = c.UI
+			}
 		}
 	}
 }

--- a/runtime/flows/orchestrator.go
+++ b/runtime/flows/orchestrator.go
@@ -88,8 +88,8 @@ func (r *FunctionsResponsePayload) GetUIComponents() *FlowUIComponents {
 
 // FlowUIComponents contains data returned from the functions runtime which is used for frontend rendering
 type FlowUIComponents struct {
-	Config *JSONB `json:"config"`
-	UI     *JSONB `json:"ui"`
+	Config JSON `json:"config"`
+	UI     JSON `json:"ui"`
 }
 
 // orchestrateRun will decide based on the db state if the flow should be ran or not

--- a/runtime/flows/orchestrator.go
+++ b/runtime/flows/orchestrator.go
@@ -75,14 +75,31 @@ type FunctionsResponsePayload struct {
 	Error        string `json:"error"`
 }
 
+func (r *FunctionsResponsePayload) GetUIComponents() *FlowUIComponents {
+	if r.Config != nil || r.UI != nil {
+		return &FlowUIComponents{
+			Config: r.Config,
+			UI:     r.UI,
+		}
+	}
+
+	return nil
+}
+
+// FlowUIComponents contains data returned from the functions runtime which is used for frontend rendering
+type FlowUIComponents struct {
+	Config *JSONB `json:"config"`
+	UI     *JSONB `json:"ui"`
+}
+
 // orchestrateRun will decide based on the db state if the flow should be ran or not
-func (o *Orchestrator) orchestrateRun(ctx context.Context, runID string, data map[string]any) error {
+func (o *Orchestrator) orchestrateRun(ctx context.Context, runID string, data map[string]any) (error, *FlowUIComponents) {
 	run, err := getRun(ctx, runID)
 	if err != nil {
-		return err
+		return err, nil
 	}
 	if run == nil {
-		return fmt.Errorf("invalid run ID: %s", runID)
+		return fmt.Errorf("invalid run ID: %s", runID), nil
 	}
 
 	switch run.Status {
@@ -91,7 +108,7 @@ func (o *Orchestrator) orchestrateRun(ctx context.Context, runID string, data ma
 			// this is a new run, set it to running and trigger the flows runtime
 			run, err = updateRun(ctx, run.ID, StatusRunning)
 			if err != nil {
-				return err
+				return err, nil
 			}
 		}
 
@@ -99,7 +116,7 @@ func (o *Orchestrator) orchestrateRun(ctx context.Context, runID string, data ma
 			// we have been awaiting input, we're now going to continue running
 			run, err = updateRun(ctx, run.ID, StatusRunning)
 			if err != nil {
-				return err
+				return err, nil
 			}
 		}
 
@@ -108,7 +125,7 @@ func (o *Orchestrator) orchestrateRun(ctx context.Context, runID string, data ma
 		if err != nil {
 			// failed orchestrating, mark the run as failed and return the error
 			_, _ = updateRun(ctx, run.ID, StatusFailed)
-			return err
+			return err, nil
 		}
 
 		if resp.RunCompleted {
@@ -116,39 +133,39 @@ func (o *Orchestrator) orchestrateRun(ctx context.Context, runID string, data ma
 				// run was orchestrated and completed successfully, but with an error (e.g. exhaused retries)
 				// TODO: store error message against the flow run
 				_, err = updateRun(ctx, run.ID, StatusFailed)
-				return err
+				return err, resp.GetUIComponents()
 			}
 
 			_, err = updateRun(ctx, run.ID, StatusCompleted)
-			return err
+			return err, resp.GetUIComponents()
 		}
 
 		// reload state from db
 		run, err := getRun(ctx, run.ID)
 		if err != nil {
-			return err
+			return err, nil
 		}
 
 		// Check to see if we're in a Pending UI step, break orchestration
 		if run.HasPendingUIStep() {
 			_, err = updateRun(ctx, run.ID, StatusAwaitingInput)
-			return err
+			return err, resp.GetUIComponents()
 		}
 
 		// Continue running the flow
 		payload := FlowRunUpdated{RunID: resp.RunID}
 		wrap, err := payload.Wrap()
 		if err != nil {
-			return err
+			return err, nil
 		}
 
-		return o.SendEvent(ctx, wrap)
+		return o.SendEvent(ctx, wrap), resp.GetUIComponents()
 	case StatusFailed, StatusCompleted, StatusCancelled:
 		// Do nothing
-		return nil
+		return nil, nil
 	}
 
-	return nil
+	return nil, nil
 }
 
 // HandleEvent will handle an event received by the orchestrator from the flows runtime; The only events handled at the
@@ -161,7 +178,9 @@ func (o *Orchestrator) HandleEvent(ctx context.Context, event *EventWrapper) err
 			return err
 		}
 
-		return o.orchestrateRun(ctx, ev.RunID, ev.Data)
+		err, _ := o.orchestrateRun(ctx, ev.RunID, ev.Data)
+
+		return err
 	case EventNameFlowRunStarted:
 		// a new flow has started; create the run and start orchestrating it
 		var ev FlowRunStarted
@@ -179,7 +198,9 @@ func (o *Orchestrator) HandleEvent(ctx context.Context, event *EventWrapper) err
 		if err != nil {
 			return err
 		}
-		return o.orchestrateRun(ctx, run.ID, nil)
+		err, _ = o.orchestrateRun(ctx, run.ID, nil)
+
+		return err
 	}
 	return nil
 }
@@ -259,7 +280,6 @@ func (o *Orchestrator) CallFlow(ctx context.Context, run *Run, data map[string]a
 		err := fmt.Errorf("invalid response from flows runtime")
 		span.SetStatus(codes.Error, err.Error())
 		span.SetAttributes(attribute.String("response.body", string(b)))
-
 		return nil, err
 	}
 


### PR DESCRIPTION
Whenever we invoke the functions runtime to execute a flow, we receive some UI components data: Flow config, and page UI components to be displayed for the currently pending UI step. 

This PR refactors the internal orchestration to return these components when applicable. These components then are injected onto the current flow run struct as part of the WAPi responses.

Now we will have the flow config and any page UI components as part of the response of the startFlow WAPI endpoint (Note: page UI components data will be available only if the first step is a UI step)