### PR TITLE
fix: missing scripts in functions runtime

### DIFF
--- a/packages/functions-runtime/package.json
+++ b/packages/functions-runtime/package.json
@@ -30,6 +30,7 @@
   },
   "files": [
     "dist",
+    "scripts",
     "README.md"
   ],
   "devDependencies": {


### PR DESCRIPTION
We need to include the `scripts` path when publishing to NPM as we now have scripts which we run on post install