### PR TITLE
fix: moved flows tables to keel db schema

### DIFF
--- a/migrations/columns.sql
+++ b/migrations/columns.sql
@@ -16,7 +16,7 @@ LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
 LEFT JOIN pg_catalog.pg_index i on i.indexrelid = a.attrelid
 WHERE
 	n.nspname = 'public'
-	AND c.relname not in ('keel_schema', 'keel_refresh_token', 'keel_storage', 'keel_flow_run', 'keel_flow_step', 'keel_auth_code', 'pg_stat_statements_info', 'pg_stat_statements')
+	AND c.relname not in ('keel_schema', 'keel_refresh_token', 'keel_storage', 'flow_run', 'flow_step', 'keel_auth_code', 'pg_stat_statements_info', 'pg_stat_statements')
 	AND c.relname not like '%__sequence_seq'
 	AND a.attnum > 0
 	AND NOT a.attisdropped

--- a/migrations/flows.sql
+++ b/migrations/flows.sql
@@ -1,4 +1,7 @@
-CREATE TABLE IF NOT EXISTS keel_flow_run (
+CREATE SCHEMA IF NOT EXISTS "keel";
+
+
+CREATE TABLE IF NOT EXISTS "keel"."flow_run" (
 	"id" text NOT NULL DEFAULT ksuid() PRIMARY KEY,
 	"name" TEXT NOT NULL,
 	"trace_id" TEXT,
@@ -7,11 +10,11 @@ CREATE TABLE IF NOT EXISTS keel_flow_run (
 	"created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
 	"updated_at" TIMESTAMPTZ NOT NULL DEFAULT now()
 );
-CREATE OR REPLACE TRIGGER keel_flow_run_updated_at BEFORE UPDATE ON "keel_flow_run" FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+CREATE OR REPLACE TRIGGER "keel_flow_run_updated_at" BEFORE UPDATE ON "keel"."flow_run" FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
 
-CREATE TABLE IF NOT EXISTS keel_flow_step (
+CREATE TABLE IF NOT EXISTS "keel"."flow_step" (
 	"id" text NOT NULL DEFAULT ksuid() PRIMARY KEY,
-	"run_id" text NOT NULL REFERENCES "keel_flow_run" ("id") ON UPDATE CASCADE ON DELETE CASCADE,
+	"run_id" text NOT NULL REFERENCES "keel"."flow_run" ("id") ON UPDATE CASCADE ON DELETE CASCADE,
 	"name" TEXT NOT NULL,
 	"stage" TEXT NULL,
 	"status" TEXT NOT NULL,
@@ -24,4 +27,4 @@ CREATE TABLE IF NOT EXISTS keel_flow_step (
 	"created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
 	"updated_at" TIMESTAMPTZ NOT NULL DEFAULT now()
 );
-CREATE OR REPLACE TRIGGER keel_flow_step_updated_at BEFORE UPDATE ON "keel_flow_step" FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+CREATE OR REPLACE TRIGGER "keel_flow_step_updated_at" BEFORE UPDATE ON "keel"."flow_step" FOR EACH ROW EXECUTE PROCEDURE set_updated_at();

--- a/migrations/flows.sql
+++ b/migrations/flows.sql
@@ -1,6 +1,5 @@
 CREATE SCHEMA IF NOT EXISTS "keel";
 
-
 CREATE TABLE IF NOT EXISTS "keel"."flow_run" (
 	"id" text NOT NULL DEFAULT ksuid() PRIMARY KEY,
 	"name" TEXT NOT NULL,

--- a/packages/functions-runtime/src/flows/index.ts
+++ b/packages/functions-runtime/src/flows/index.ts
@@ -122,7 +122,7 @@ export function createFlowContext<C extends FlowConfig>(
 
       // First check if we already have a result for this step
       const past = await db
-        .selectFrom("keel_flow_step")
+        .selectFrom("keel.flow_step")
         .where("run_id", "=", runId)
         .where("name", "=", name)
         .selectAll()
@@ -158,7 +158,7 @@ export function createFlowContext<C extends FlowConfig>(
       if (newSteps.length === 1) {
         let result = null;
         await db
-          .updateTable("keel_flow_step")
+          .updateTable("keel.flow_step")
           .set({
             startTime: new Date(),
           })
@@ -173,7 +173,7 @@ export function createFlowContext<C extends FlowConfig>(
           );
         } catch (e) {
           await db
-            .updateTable("keel_flow_step")
+            .updateTable("keel.flow_step")
             .set({
               status: STEP_STATUS.FAILED,
               spanId: spanId,
@@ -193,7 +193,7 @@ export function createFlowContext<C extends FlowConfig>(
 
           // If we have retries left, create a new step
           await db
-            .insertInto("keel_flow_step")
+            .insertInto("keel.flow_step")
             .values({
               run_id: runId,
               name: name,
@@ -209,7 +209,7 @@ export function createFlowContext<C extends FlowConfig>(
 
         // Store the result in the database
         await db
-          .updateTable("keel_flow_step")
+          .updateTable("keel.flow_step")
           .set({
             status: STEP_STATUS.COMPLETED,
             value: JSON.stringify(result),
@@ -225,7 +225,7 @@ export function createFlowContext<C extends FlowConfig>(
 
       // The step hasn't yet run successfully, so we need to create a NEW run
       await db
-        .insertInto("keel_flow_step")
+        .insertInto("keel.flow_step")
         .values({
           run_id: runId,
           name: name,
@@ -258,7 +258,7 @@ export function createFlowContext<C extends FlowConfig>(
 
         // First check if this step exists
         let step = await db
-          .selectFrom("keel_flow_step")
+          .selectFrom("keel.flow_step")
           .where("run_id", "=", runId)
           .where("name", "=", name)
           .selectAll()
@@ -272,7 +272,7 @@ export function createFlowContext<C extends FlowConfig>(
         if (!step) {
           // The step hasn't yet run so we create a new the step with state PENDING.
           step = await db
-            .insertInto("keel_flow_step")
+            .insertInto("keel.flow_step")
             .values({
               run_id: runId,
               name: name,
@@ -297,7 +297,7 @@ export function createFlowContext<C extends FlowConfig>(
 
         // If the data has been passed in and is valid, persist the data and mark the step as COMPLETED, and then return the data.
         await db
-          .updateTable("keel_flow_step")
+          .updateTable("keel.flow_step")
           .set({
             status: STEP_STATUS.COMPLETED,
             value: JSON.stringify(data),

--- a/packages/functions-runtime/src/handleFlow.js
+++ b/packages/functions-runtime/src/handleFlow.js
@@ -56,7 +56,7 @@ async function handleFlow(request, config) {
         });
 
         const flowRun = await db
-          .selectFrom("keel_flow_run")
+          .selectFrom("keel.flow_run")
           .where("id", "=", runId)
           .selectAll()
           .executeTakeFirst();

--- a/runtime/flows/flow.go
+++ b/runtime/flows/flow.go
@@ -53,7 +53,7 @@ type Run struct {
 }
 
 func (Run) TableName() string {
-	return "keel_flow_run"
+	return "keel.flow_run"
 }
 
 // HasPendingUIStep tells us if the current run is waiting for UI input
@@ -106,7 +106,7 @@ type Step struct {
 }
 
 func (Step) TableName() string {
-	return "keel_flow_step"
+	return "keel.flow_step"
 }
 
 type JSON interface{}


### PR DESCRIPTION
Moved the flows database tables to the new `keel` database schema.  Note that these tables are now not visible in the Console's database viewer.