### PR TITLE
fix: handle panic when starting local servers

### DIFF
--- a/cmd/program/commands.go
+++ b/cmd/program/commands.go
@@ -453,6 +453,10 @@ type RuntimeRequestMsg struct {
 	done chan bool
 }
 
+type StartServerError struct {
+	Err error
+}
+
 func StartRuntimeServer(port string, customHostname string, ch chan tea.Msg) tea.Cmd {
 	return func() tea.Msg {
 		if customHostname != "" {
@@ -477,7 +481,9 @@ func StartRuntimeServer(port string, customHostname string, ch chan tea.Msg) tea
 		err := runtimeServer.ListenAndServe()
 		if err != nil {
 			err = errors.Join(errors.New("could not start the http server"), err)
-			panic(err.Error())
+			return StartServerError{
+				Err: err,
+			}
 		}
 
 		return nil
@@ -508,7 +514,9 @@ func StartRpcServer(port string, ch chan tea.Msg) tea.Cmd {
 		err := rpcServer.ListenAndServe()
 		if err != nil {
 			err = errors.Join(errors.New("could not start the local rpc server"), err)
-			panic(err.Error())
+			return StartServerError{
+				Err: err,
+			}
 		}
 
 		return nil
@@ -538,7 +546,9 @@ func StartTraceServer(port string) tea.Cmd {
 		err := traceServer.ListenAndServe()
 		if err != nil {
 			err = errors.Join(errors.New("could not start the local tracing server"), err)
-			panic(err.Error())
+			return StartServerError{
+				Err: err,
+			}
 		}
 
 		return nil

--- a/cmd/program/model.go
+++ b/cmd/program/model.go
@@ -66,6 +66,7 @@ const (
 	StatusSeedCompleted
 	StatusSnapshotDatabase
 	StatusSnapshotCompleted
+	StatusErrorStartingServers
 )
 
 const (
@@ -275,6 +276,13 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		m.Status = StatusSetupDatabase
 		return m, StartDatabase(m.ResetDatabase, m.Mode, m.ProjectDir)
+	case StartServerError:
+		m.Err = msg.Err
+		// If the servers can't be started we exit
+		if m.Err != nil {
+			m.Status = StatusErrorStartingServers
+			return m, tea.Quit
+		}
 	case StartDatabaseMsg:
 		m.DatabaseConnInfo = msg.ConnInfo
 		m.Err = msg.Err

--- a/cmd/program/views.go
+++ b/cmd/program/views.go
@@ -306,6 +306,10 @@ func renderError(m *Model) string {
 			b.WriteString("\n\n")
 			b.WriteString(startFunctionsError.Output)
 		}
+	case StatusErrorStartingServers:
+		b.WriteString("❌ There was an error starting the local servers:\n\n")
+		b.WriteString(m.Err.Error())
+
 	default:
 		b.WriteString("❌ Oh no, looks like something went wrong:\n\n")
 		b.WriteString(m.Err.Error())


### PR DESCRIPTION
When attempting to run keel twice, the local servers (rpc & http & tracing) will error as the ports are already in use. This would trigger a unsightly panic:

```
                                                                                                                                             
Caught panic:

could not start the local tracing server
listen tcp :4318: bind: address already in use

Restoring terminal...

Caught panic:

could not start the local rpc server
listen tcp :34087: bind: address already in use

Restoring terminal...

Caught panic:

could not start the http server
listen tcp :8000: bind: address already in use

Restoring terminal...

goroutine 58 [running]:
runtime/debug.Stack()
        /opt/homebrew/Cellar/go/1.23.3/libexec/src/runtime/debug/stack.go:26 +0x64
runtime/debug.PrintStack()
        /opt/homebrew/Cellar/go/1.23.3/libexec/src/runtime/debug/stack.go:18 +0x1c
github.com/charmbracelet/bubbletea.(*Program).recoverFromPanic(0x1400062c8c0)
        /Users/radugruia/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.2.4/tea.go:705 +0x84
panic({0x106ad7520?, 0x14000621440?})
        /opt/homebrew/Cellar/go/1.23.3/libexec/src/runtime/panic.go:785 +0x124
github.com/teamkeel/keel/cmd/program.(*Model).Update.StartTraceServer.func12()
        /Users/radugruia/htdocs/keel/keel/cmd/program/commands.go:541 +0x17c
github.com/charmbracelet/bubbletea.(*Program).handleCommands.func1.1()
        /Users/radugruia/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.2.4/tea.go:324 +0x64
created by github.com/charmbracelet/bubbletea.(*Program).handleCommands.func1 in goroutine 14
        /Users/radugruia/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.2.4/tea.go:318 +0x10c
goroutine 28 [running]:
runtime/debug.Stack()
        /opt/homebrew/Cellar/go/1.23.3/libexec/src/runtime/debug/stack.go:26 +0x64
runtime/debug.PrintStack()
        /opt/homebrew/Cellar/go/1.23.3/libexec/src/runtime/debug/stack.go:18 +0x1c
github.com/charmbracelet/bubbletea.(*Program).recoverFromPanic(0x1400062c8c0)
        /Users/radugruia/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.2.4/tea.go:705 +0x84
panic({0x106ad7520?, 0x14000bac4e0?})
        /opt/homebrew/Cellar/go/1.23.3/libexec/src/runtime/panic.go:785 +0x124
github.com/teamkeel/keel/cmd/program.(*Model).Update.StartRuntimeServer.func7()
        /Users/radugruia/htdocs/keel/keel/cmd/program/commands.go:480 +0x220
github.com/charmbracelet/bubbletea.(*Program).handleCommands.func1.1()
        /Users/radugruia/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.2.4/tea.go:324 +0x64
created by github.com/charmbracelet/bubbletea.(*Program).handleCommands.func1 in goroutine 14
        /Users/radugruia/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.2.4/tea.go:318 +0x10c
goroutine 29 [running]:
runtime/debug.Stack()
        /opt/homebrew/Cellar/go/1.23.3/libexec/src/runtime/debug/stack.go:26 +0x64
runtime/debug.PrintStack()
        /opt/homebrew/Cellar/go/1.23.3/libexec/src/runtime/debug/stack.go:18 +0x1c
github.com/charmbracelet/bubbletea.(*Program).recoverFromPanic(0x1400062c8c0)
        /Users/radugruia/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.2.4/tea.go:705 +0x84
panic({0x106ad7520?, 0x140006e5270?})
        /opt/homebrew/Cellar/go/1.23.3/libexec/src/runtime/panic.go:785 +0x124
github.com/teamkeel/keel/cmd/program.(*Model).Update.StartRpcServer.func8()
        /Users/radugruia/htdocs/keel/keel/cmd/program/commands.go:511 +0x1b4
github.com/charmbracelet/bubbletea.(*Program).handleCommands.func1.1()
        /Users/radugruia/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.2.4/tea.go:324 +0x64
created by github.com/charmbracelet/bubbletea.(*Program).handleCommands.func1 in goroutine 14
        /Users/radugruia/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.2.4/tea.go:318 +0x10c
```

This PR changes the behaviour to not throw panics but instead render an error:

```
                                                                                                                                                                         
Running Keel app in directory: ./../projects/flows/                                                                                            
Connect to your database using: psql -Atx "postgresql://postgres:postgres@127.0.0.1:5432/keel_27d6a21c17c6acbed0cb7c6d0f5319ef?sslmode=disable"
                                                                                                                                               
                                                                                                                                                         
❌ There was an error starting the local servers:                                                                                              
                                                                                                                                               
could not start the local tracing server                                                                                                       
listen tcp :4318: bind: address already in use                                                                                                 
                                                                                                                                               
exit status 1
```