### PR TITLE
feat: make text input filters case insensitive

### DIFF
--- a/integration/testdata/built_in_actions/main.test.ts
+++ b/integration/testdata/built_in_actions/main.test.ts
@@ -201,6 +201,34 @@ test("list action - endsWith", async () => {
   expect(results.length).toEqual(2);
 });
 
+test("list action - case insensitive text filters", async () => {
+  await models.post.create({ title: "Star Wars", subTitle: "abc" });
+  await models.post.create({ title: "star wars", subTitle: "def" });
+  await models.post.create({ title: "STAR WARS", subTitle: "ghi" });
+  await models.post.create({ title: "not star wars", subTitle: "jkl" });
+
+  const startsWithResults = await actions.listPosts({
+    where: {
+      title: { startsWith: "star" },
+    },
+  });
+  expect(startsWithResults.results.length).toEqual(3);
+
+  const containsResults = await actions.listPosts({
+    where: {
+      title: { contains: "star" },
+    },
+  });
+  expect(containsResults.results.length).toEqual(4);
+
+  const endsWithResults = await actions.listPosts({
+    where: {
+      title: { endsWith: "wars" },
+    },
+  });
+  expect(endsWithResults.results.length).toEqual(4);
+});
+
 test("list action - oneOf text", async () => {
   await models.post.create({ title: "pear", subTitle: "lmn" });
   await models.post.create({ title: "mango", subTitle: "mno" });

--- a/runtime/actions/query.go
+++ b/runtime/actions/query.go
@@ -1649,9 +1649,9 @@ func (query *QueryBuilder) generateConditionTemplate(lhs *QueryOperand, operator
 	case NotEquals:
 		template = fmt.Sprintf("%s IS DISTINCT FROM %s", lhsSqlOperand, rhsSqlOperand)
 	case StartsWith, EndsWith, Contains:
-		template = fmt.Sprintf("%s LIKE %s", lhsSqlOperand, rhsSqlOperand)
+		template = fmt.Sprintf("%s ILIKE %s", lhsSqlOperand, rhsSqlOperand)
 	case NotContains:
-		template = fmt.Sprintf("%s NOT LIKE %s", lhsSqlOperand, rhsSqlOperand)
+		template = fmt.Sprintf("%s NOT ILIKE %s", lhsSqlOperand, rhsSqlOperand)
 	case OneOf:
 		if rhs.IsInlineQuery() {
 			template = fmt.Sprintf("%s IN %s", lhsSqlOperand, rhsSqlOperand)

--- a/runtime/actions/query_test.go
+++ b/runtime/actions/query_test.go
@@ -733,11 +733,11 @@ var testCases = []testCase{
 		expectedTemplate: `
 			SELECT
 				DISTINCT ON("thing"."id") "thing".*, CASE WHEN LEAD("thing"."id") OVER (ORDER BY "thing"."id" ASC) IS NOT NULL THEN true ELSE false END AS hasNext,
-				(SELECT COUNT(DISTINCT "thing"."id") FROM "thing" WHERE "thing"."name" LIKE ?) AS totalCount
+				(SELECT COUNT(DISTINCT "thing"."id") FROM "thing" WHERE "thing"."name" ILIKE ?) AS totalCount
 			FROM
 				"thing"
 			WHERE
-				"thing"."name" LIKE ?
+				"thing"."name" ILIKE ?
 			ORDER BY
 				"thing"."id" ASC LIMIT ?`,
 		expectedArgs: []any{"%%bob%%", "%%bob%%", 50},
@@ -762,11 +762,11 @@ var testCases = []testCase{
 		expectedTemplate: `
 			SELECT
 				DISTINCT ON("thing"."id") "thing".*, CASE WHEN LEAD("thing"."id") OVER (ORDER BY "thing"."id" ASC) IS NOT NULL THEN true ELSE false END AS hasNext,
-				(SELECT COUNT(DISTINCT "thing"."id") FROM "thing" WHERE "thing"."name" LIKE ?) AS totalCount
+				(SELECT COUNT(DISTINCT "thing"."id") FROM "thing" WHERE "thing"."name" ILIKE ?) AS totalCount
 			FROM
 				"thing"
 			WHERE
-				"thing"."name" LIKE ?
+				"thing"."name" ILIKE ?
 			ORDER BY
 				"thing"."id" ASC LIMIT ?`,
 		expectedArgs: []any{"bob%%", "bob%%", 50},
@@ -791,11 +791,11 @@ var testCases = []testCase{
 		expectedTemplate: `
 			SELECT
 				DISTINCT ON("thing"."id") "thing".*, CASE WHEN LEAD("thing"."id") OVER (ORDER BY "thing"."id" ASC) IS NOT NULL THEN true ELSE false END AS hasNext,
-				(SELECT COUNT(DISTINCT "thing"."id") FROM "thing" WHERE "thing"."name" LIKE ?) AS totalCount
+				(SELECT COUNT(DISTINCT "thing"."id") FROM "thing" WHERE "thing"."name" ILIKE ?) AS totalCount
 			FROM
 				"thing"
 			WHERE
-				"thing"."name" LIKE ?
+				"thing"."name" ILIKE ?
 			ORDER BY
 				"thing"."id" ASC LIMIT ?`,
 		expectedArgs: []any{"%%bob", "%%bob", 50},


### PR DESCRIPTION
Text filters for list actions are currently case sensitive. This makes them case insensitive 