### PR TITLE
fix: maintain the same otel trace for step updates

### DIFF
--- a/migrations/flows.sql
+++ b/migrations/flows.sql
@@ -4,6 +4,7 @@ CREATE TABLE IF NOT EXISTS "keel"."flow_run" (
 	"id" text NOT NULL DEFAULT ksuid() PRIMARY KEY,
 	"name" TEXT NOT NULL,
 	"trace_id" TEXT,
+	"traceparent" TEXT,
 	"status" TEXT NOT NULL,
 	"input" JSONB DEFAULT NULL,
 	"created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),

--- a/runtime/flows/run.go
+++ b/runtime/flows/run.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/teamkeel/keel/proto"
+	"github.com/teamkeel/keel/util"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -29,7 +30,7 @@ func StartFlow(ctx context.Context, flow *proto.Flow, inputs map[string]any) (ru
 		return
 	}
 
-	run, err = createRun(ctx, flow, inputs, span.SpanContext().TraceID().String())
+	run, err = createRun(ctx, flow, inputs, util.GetTraceparent(span.SpanContext()))
 	if err != nil {
 		err = fmt.Errorf("creating flow run: %w", err)
 		return

--- a/runtime/openapi/uiConfig.json
+++ b/runtime/openapi/uiConfig.json
@@ -133,14 +133,14 @@
         "defaultValue": {
           "type": "string"
         },
-        "helpText": {
-          "type": "string"
-        },
         "optional": {
           "type": "boolean"
         },
         "disabled": {
           "type": "boolean"
+        },
+        "helpText": {
+          "type": "string"
         },
         "validationError": {
           "type": "string"
@@ -149,15 +149,17 @@
       "additionalProperties": false,
       "required": [
         "__type",
+        "disabled",
         "label",
-        "name"
+        "name",
+        "optional"
       ]
     },
     "UiElementInputNumberApiResponse": {
       "type": "object",
       "properties": {
         "placeholder": {
-          "type": "number"
+          "type": "string"
         },
         "min": {
           "type": "number"
@@ -178,14 +180,14 @@
         "defaultValue": {
           "type": "number"
         },
-        "helpText": {
-          "type": "string"
-        },
         "optional": {
           "type": "boolean"
         },
         "disabled": {
           "type": "boolean"
+        },
+        "helpText": {
+          "type": "string"
         },
         "validationError": {
           "type": "string"
@@ -194,8 +196,10 @@
       "additionalProperties": false,
       "required": [
         "__type",
+        "disabled",
         "label",
-        "name"
+        "name",
+        "optional"
       ]
     },
     "UiElementDividerApiResponse": {
@@ -234,14 +238,14 @@
         "defaultValue": {
           "type": "boolean"
         },
-        "helpText": {
-          "type": "string"
-        },
         "optional": {
           "type": "boolean"
         },
         "disabled": {
           "type": "boolean"
+        },
+        "helpText": {
+          "type": "string"
         },
         "validationError": {
           "type": "string"
@@ -250,9 +254,11 @@
       "additionalProperties": false,
       "required": [
         "__type",
+        "disabled",
         "label",
         "mode",
-        "name"
+        "name",
+        "optional"
       ]
     },
     "UiElementMarkdownApiResponse": {
@@ -358,14 +364,14 @@
             }
           ]
         },
-        "helpText": {
-          "type": "string"
-        },
         "optional": {
           "type": "boolean"
         },
         "disabled": {
           "type": "boolean"
+        },
+        "helpText": {
+          "type": "string"
         },
         "validationError": {
           "type": "string"
@@ -374,8 +380,10 @@
       "additionalProperties": false,
       "required": [
         "__type",
+        "disabled",
         "label",
         "name",
+        "optional",
         "options"
       ]
     },
@@ -472,7 +480,7 @@
           ],
           "type": "string"
         },
-        "title": {
+        "caption": {
           "type": "string"
         },
         "__type": {


### PR DESCRIPTION
When updating a flow step with ui data, we are now setting the `UpdateStep` span on the parent trace that was created when the flow was started. In order to do this, we need to keep track of the traceparent of a flow run - used to recreate the span context. This traceparent has the parent trace id, span id and any otel trace flags.