### PR TITLE
fix: add the traceparent column in a backwards compatible migration

### DIFF
--- a/migrations/flows.sql
+++ b/migrations/flows.sql
@@ -4,7 +4,6 @@ CREATE TABLE IF NOT EXISTS "keel"."flow_run" (
 	"id" text NOT NULL DEFAULT ksuid() PRIMARY KEY,
 	"name" TEXT NOT NULL,
 	"trace_id" TEXT,
-	"traceparent" TEXT,
 	"status" TEXT NOT NULL,
 	"input" JSONB DEFAULT NULL,
 	"created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -28,3 +27,5 @@ CREATE TABLE IF NOT EXISTS "keel"."flow_step" (
 	"updated_at" TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 CREATE OR REPLACE TRIGGER "keel_flow_step_updated_at" BEFORE UPDATE ON "keel"."flow_step" FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+
+ALTER TABLE "keel"."flow_run" ADD COLUMN IF NOT EXISTS "traceparent" TEXT;


### PR DESCRIPTION
Recently we've added the `traceparent` column to the keel flow run db table. Already deployed projects will not have this column, therefore we need to add the new column in a separate sql query to gracefully migrate new projects when they use the latest keel version