### PR TITLE
fix: my flow runs endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.34.0
 	go.opentelemetry.io/otel/trace v1.34.0
 	go.opentelemetry.io/proto/otlp v1.5.0
-	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8
 	golang.org/x/oauth2 v0.25.0
 	golang.org/x/sync v0.12.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20250115164207-1a7da9e5054f
@@ -193,6 +192,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.34.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8 // indirect
 	golang.org/x/term v0.30.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f // indirect

--- a/integration/testdata/flows/tests.test.ts
+++ b/integration/testdata/flows/tests.test.ts
@@ -46,6 +46,7 @@ test("flows - scalar step", async () => {
     status: "COMPLETED",
     name: "ScalarStep",
     input: {},
+    startedBy: expect.any(String),
     steps: [
       {
         id: expect.any(String),
@@ -87,6 +88,7 @@ test("flows - only functions with config", async () => {
     traceId: expect.any(String),
     status: "RUNNING",
     name: "OnlyFunctions",
+    startedBy: expect.any(String),
     input: {
       name: "My Thing",
       age: 25,
@@ -139,6 +141,7 @@ test("flows - only functions with config", async () => {
     traceId: expect.any(String),
     status: "COMPLETED",
     name: "OnlyFunctions",
+    startedBy: expect.any(String),
     input: {
       name: "My Thing",
       age: 25,
@@ -198,6 +201,7 @@ test("flows - only pages", async () => {
     traceId: expect.any(String),
     status: "AWAITING_INPUT",
     name: "OnlyPages",
+    startedBy: expect.any(String),
     input: {},
     steps: [
       {
@@ -243,6 +247,7 @@ test("flows - only pages", async () => {
     traceId: expect.any(String),
     status: "AWAITING_INPUT",
     name: "OnlyPages",
+    startedBy: expect.any(String),
     input: {},
     steps: [
       {
@@ -309,6 +314,7 @@ test("flows - only pages", async () => {
     traceId: expect.any(String),
     status: "COMPLETED",
     name: "OnlyPages",
+    startedBy: expect.any(String),
     input: {},
     steps: [
       {
@@ -371,6 +377,7 @@ test("flows - stepless flow", async () => {
     id: body.id,
     input: {},
     name: "Stepless",
+    startedBy: expect.any(String),
     status: "COMPLETED",
     steps: [],
     config: null,
@@ -399,6 +406,7 @@ test("flows - first step is a function", async () => {
     id: expect.any(String),
     input: {},
     name: "SingleStep",
+    startedBy: expect.any(String),
     status: "RUNNING",
     steps: [
       {
@@ -437,6 +445,7 @@ test("flows - first step is a function", async () => {
     id: body.id,
     input: {},
     name: "SingleStep",
+    startedBy: expect.any(String),
     status: "COMPLETED",
     steps: [
       {
@@ -485,6 +494,7 @@ test("flows - alternating step types", async () => {
       age: 23,
     },
     name: "MixedStepTypes",
+    startedBy: expect.any(String),
     status: "RUNNING",
     steps: [
       {
@@ -524,6 +534,7 @@ test("flows - alternating step types", async () => {
   expect(body).toEqual({
     id: runId,
     name: "MixedStepTypes",
+    startedBy: expect.any(String),
     status: "AWAITING_INPUT", // Flow is now awaiting input
     input: {
       name: "Keelson",
@@ -623,6 +634,7 @@ test("flows - alternating step types", async () => {
   expect(body).toEqual({
     id: runId,
     name: "MixedStepTypes",
+    startedBy: expect.any(String),
     status: "RUNNING",
     input: {
       name: "Keelson",
@@ -861,6 +873,7 @@ test("flows - all inputs", async () => {
       markdown: "**Hello**",
     },
     name: "AllInputs",
+    startedBy: expect.any(String),
     status: "FAILED",
     steps: [],
     traceId: expect.any(String),
@@ -876,6 +889,7 @@ test("flows - error in step with retries", async () => {
     id: expect.any(String),
     traceId: expect.any(String),
     status: "RUNNING",
+    startedBy: expect.any(String),
     name: "ErrorInStep",
     input: {},
     steps: [
@@ -914,6 +928,7 @@ test("flows - error in step with retries", async () => {
     traceId: res.body.traceId,
     status: "FAILED",
     name: "ErrorInStep",
+    startedBy: expect.any(String),
     input: {},
     steps: [
       {
@@ -977,6 +992,7 @@ test("flows - error in flow", async () => {
     traceId: expect.any(String),
     status: "FAILED",
     name: "ErrorInFlow",
+    startedBy: expect.any(String),
     input: {},
     steps: [],
     createdAt: expect.any(String),
@@ -996,6 +1012,7 @@ test("flows - timeout step", async () => {
     traceId: expect.any(String),
     status: "RUNNING",
     name: "TimeoutStep",
+    startedBy: expect.any(String),
     input: {},
     steps: [
       {
@@ -1033,6 +1050,7 @@ test("flows - timeout step", async () => {
     traceId: res.body.traceId,
     status: "FAILED",
     name: "TimeoutStep",
+    startedBy: expect.any(String),
     input: {},
     steps: [
       {

--- a/migrations/flows.sql
+++ b/migrations/flows.sql
@@ -29,3 +29,8 @@ CREATE TABLE IF NOT EXISTS "keel"."flow_step" (
 CREATE OR REPLACE TRIGGER "keel_flow_step_updated_at" BEFORE UPDATE ON "keel"."flow_step" FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
 
 ALTER TABLE "keel"."flow_run" ADD COLUMN IF NOT EXISTS "traceparent" TEXT;
+
+ALTER TABLE "keel"."flow_run" ADD COLUMN IF NOT EXISTS "started_by" TEXT;
+
+DROP INDEX IF EXISTS "keel"."flow_run_started_by_idx";
+CREATE INDEX "flow_run_started_by_idx" ON "keel"."flow_run" USING BTREE ("started_by");

--- a/runtime/apis/flowsapi/my_runs_endpoint.go
+++ b/runtime/apis/flowsapi/my_runs_endpoint.go
@@ -1,0 +1,58 @@
+package flowsapi
+
+import (
+	"net/http"
+
+	"github.com/teamkeel/keel/proto"
+	"github.com/teamkeel/keel/runtime/actions"
+	"github.com/teamkeel/keel/runtime/apis/httpjson"
+	"github.com/teamkeel/keel/runtime/auth"
+	"github.com/teamkeel/keel/runtime/common"
+	"github.com/teamkeel/keel/runtime/flows"
+	"github.com/teamkeel/keel/runtime/locale"
+	"github.com/teamkeel/keel/schema/parser"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+// MyRunsHandler handles a request to /flows/json/myRuns and returns data about all flow runs ran by the current logged in user
+func MyRunsHandler(p *proto.Schema) common.HandlerFunc {
+	return func(r *http.Request) common.Response {
+		ctx, span := tracer.Start(r.Context(), "FlowsAPI")
+		defer span.End()
+		span.SetAttributes(
+			attribute.String("api.protocol", "HTTP JSON"),
+		)
+
+		identity, err := actions.HandleAuthorizationHeader(ctx, p, r.Header)
+		if err != nil {
+			return httpjson.NewErrorResponse(ctx, err, nil)
+		}
+		if identity == nil {
+			return httpjson.NewErrorResponse(ctx, common.NewPermissionError(), nil)
+		}
+		ctx = auth.WithIdentity(ctx, identity)
+
+		identityID := identity[parser.FieldNameId].(string)
+		if identityID == "" {
+			return httpjson.NewErrorResponse(ctx, common.NewPermissionError(), nil)
+		}
+
+		// handle any Time-Zone headers
+		location, err := locale.HandleTimezoneHeader(ctx, r.Header)
+		if err != nil {
+			return httpjson.NewErrorResponse(ctx, common.NewInputMalformedError(err.Error()), nil)
+		}
+		ctx = locale.WithTimeLocation(ctx, location)
+
+		if r.Method != http.MethodGet {
+			return httpjson.NewErrorResponse(ctx, common.NewHttpMethodNotAllowedError("only HTTP GET accepted"), nil)
+		}
+
+		runs, err := flows.ListUserFlowRuns(ctx, identityID, common.ParseQueryParams(r))
+		if err != nil {
+			return httpjson.NewErrorResponse(ctx, err, nil)
+		}
+
+		return common.NewJsonResponse(http.StatusOK, runs, nil)
+	}
+}

--- a/runtime/apis/flowsapi/my_runs_endpoint.go
+++ b/runtime/apis/flowsapi/my_runs_endpoint.go
@@ -14,7 +14,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
-// MyRunsHandler handles a request to /flows/json/myRuns and returns data about all flow runs ran by the current logged in user
+// MyRunsHandler handles a request to /flows/json/myRuns and returns data about all flow runs ran by the current logged in user.
 func MyRunsHandler(p *proto.Schema) common.HandlerFunc {
 	return func(r *http.Request) common.Response {
 		ctx, span := tracer.Start(r.Context(), "FlowsAPI")

--- a/runtime/common/common.go
+++ b/runtime/common/common.go
@@ -246,7 +246,11 @@ func ParseQueryParams(r *http.Request) map[string]any {
 	q := r.URL.Query()
 	inputs := map[string]any{}
 	for k := range q {
-		inputs[k] = q.Get(k)
+		if len(q[k]) > 1 {
+			inputs[k] = q[k]
+		} else {
+			inputs[k] = q.Get(k)
+		}
 	}
 	return inputs
 }

--- a/runtime/flows/flow.go
+++ b/runtime/flows/flow.go
@@ -52,6 +52,7 @@ type Run struct {
 	CreatedAt   time.Time `json:"createdAt"`
 	UpdatedAt   time.Time `json:"updatedAt"`
 	Config      JSON      `json:"config"    gorm:"-"` // Stages config component, omitted from db operations
+	StartedBy   *string   `json:"startedBy"`
 }
 
 func (Run) TableName() string {
@@ -214,8 +215,8 @@ func updateRun(ctx context.Context, runID string, status Status) (*Run, error) {
 	return &run, result.Error
 }
 
-// createRun will create a new flow run with the given input.
-func createRun(ctx context.Context, flow *proto.Flow, inputs any, traceparent string) (*Run, error) {
+// createRun will create a new flow run with the given input
+func createRun(ctx context.Context, flow *proto.Flow, inputs any, traceparent string, identityID *string) (*Run, error) {
 	if flow == nil {
 		return nil, fmt.Errorf("invalid flow")
 	}
@@ -226,6 +227,7 @@ func createRun(ctx context.Context, flow *proto.Flow, inputs any, traceparent st
 		Name:        flow.GetName(),
 		Traceparent: traceparent,
 		TraceID:     util.ParseTraceparent(traceparent).TraceID().String(),
+		StartedBy:   identityID,
 	}
 
 	database, err := db.GetDatabase(ctx)

--- a/runtime/flows/flow.go
+++ b/runtime/flows/flow.go
@@ -157,7 +157,7 @@ type filterFields struct {
 	Statuses  []Status
 }
 
-// Parse will set the values for the filter fields from the given map; the only applicable field is `Status`
+// Parse will set the values for the filter fields from the given map; the only applicable field is `Status`.
 func (ff *filterFields) Parse(inputs map[string]any) {
 	for f, v := range inputs {
 		switch f {
@@ -242,7 +242,7 @@ func updateRun(ctx context.Context, runID string, status Status) (*Run, error) {
 	return &run, result.Error
 }
 
-// createRun will create a new flow run with the given input
+// createRun will create a new flow run with the given input.
 func createRun(ctx context.Context, flow *proto.Flow, inputs any, traceparent string, identityID *string) (*Run, error) {
 	if flow == nil {
 		return nil, fmt.Errorf("invalid flow")
@@ -270,7 +270,7 @@ func createRun(ctx context.Context, flow *proto.Flow, inputs any, traceparent st
 	return &run, nil
 }
 
-// listRuns will list the flow runs for the given flow using cursor pagination. It defaults to
+// listRuns will list the flow runs for the given flow using cursor pagination. It defaults to.
 func listRuns(ctx context.Context, filters *filterFields, page *paginationFields) ([]*Run, error) {
 	database, err := db.GetDatabase(ctx)
 	if err != nil {

--- a/runtime/flows/orchestrator.go
+++ b/runtime/flows/orchestrator.go
@@ -200,7 +200,7 @@ func (o *Orchestrator) HandleEvent(ctx context.Context, event *EventWrapper) err
 		}
 
 		traceID := util.ParseTraceparent(event.Traceparent).TraceID().String()
-		run, err := createRun(ctx, flow, ev.Inputs, traceID)
+		run, err := createRun(ctx, flow, ev.Inputs, traceID, nil)
 		if err != nil {
 			return err
 		}

--- a/runtime/flows/run.go
+++ b/runtime/flows/run.go
@@ -70,7 +70,7 @@ func StartFlow(ctx context.Context, flow *proto.Flow, inputs map[string]any) (ru
 	return run, nil
 }
 
-// ListFlowRuns will return the runs for the given flow; with pagination
+// ListFlowRuns will return the runs for the given flow; with pagination.
 func ListFlowRuns(ctx context.Context, flow *proto.Flow, pageInputs map[string]any) (runs []*Run, err error) {
 	ctx, span := tracer.Start(ctx, "ListFlowRuns")
 	defer span.End()
@@ -89,7 +89,7 @@ func ListFlowRuns(ctx context.Context, flow *proto.Flow, pageInputs map[string]a
 	return
 }
 
-// ListUserFlowRuns will return the runs initiated by the given identity ID
+// ListUserFlowRuns will return the runs initiated by the given identity ID.
 func ListUserFlowRuns(ctx context.Context, identityID string, inputs map[string]any) (runs []*Run, err error) {
 	ctx, span := tracer.Start(ctx, "ListUserFlowRuns")
 	defer span.End()

--- a/runtime/openapi/openapi.go
+++ b/runtime/openapi/openapi.go
@@ -300,6 +300,7 @@ func GenerateFlows(ctx context.Context, schema *proto.Schema) OpenAPI {
 			"steps":     {Type: "array", Items: &jsonschema.JSONSchema{Ref: "#/components/schemas/Step"}},
 			"config":    flowConfigSchema,
 			"input":     {Type: []string{"object", "null"}, AdditionalProperties: BoolPointer(true)},
+			"startedBy": {Type: []string{"string", "null"}},
 		},
 		Required: []string{"id", "status", "name", "traceId", "createdAt", "updatedAt", "steps", "config", "input"},
 	}

--- a/runtime/openapi/openapi.go
+++ b/runtime/openapi/openapi.go
@@ -278,6 +278,27 @@ func GenerateFlows(ctx context.Context, schema *proto.Schema) OpenAPI {
 	var flowConfigSchema jsonschema.JSONSchema
 	_ = json.Unmarshal(flowConfigRaw, &flowConfigSchema)
 
+	paginationParams := []ParameterObject{
+		{
+			Name:     "limit",
+			In:       "query",
+			Required: false,
+			Schema:   jsonschema.JSONSchema{Type: "number"},
+		},
+		{
+			Name:     "before",
+			In:       "query",
+			Required: false,
+			Schema:   jsonschema.JSONSchema{Type: "string"},
+		},
+		{
+			Name:     "after",
+			In:       "query",
+			Required: false,
+			Schema:   jsonschema.JSONSchema{Type: "string"},
+		},
+	}
+
 	runResponseSchema := jsonschema.JSONSchema{
 		Type: "object",
 		Properties: map[string]jsonschema.JSONSchema{
@@ -455,17 +476,60 @@ func GenerateFlows(ctx context.Context, schema *proto.Schema) OpenAPI {
 		},
 	}
 
+	spec.Paths["/flows/json/myRuns"] = PathItemObject{
+		Parameters: func() []ParameterObject {
+			return append(paginationParams, ParameterObject{
+				Name:     "status",
+				In:       "query",
+				Required: false,
+				Schema: jsonschema.JSONSchema{
+					Type: "string",
+					Enum: []*string{
+						StringPointer(string(flows.StatusNew)),
+						StringPointer(string(flows.StatusRunning)),
+						StringPointer(string(flows.StatusAwaitingInput)),
+						StringPointer(string(flows.StatusFailed)),
+						StringPointer(string(flows.StatusCompleted)),
+						StringPointer(string(flows.StatusCancelled)),
+					},
+				},
+			})
+		}(),
+		Get: &OperationObject{
+			OperationID: StringPointer("getMyRuns"),
+			Responses: map[string]ResponseObject{
+				"200": {
+					Content: map[string]MediaTypeObject{
+						"application/json": {
+							Schema: jsonschema.JSONSchema{
+								Type:  "array",
+								Items: &jsonschema.JSONSchema{Ref: "#/components/schemas/Run"},
+							},
+						},
+					},
+				},
+				"400": {
+					Content: map[string]MediaTypeObject{
+						"application/json": {
+							Schema: responseErrorSchema,
+						},
+					},
+				},
+			},
+		},
+	}
+
 	spec.Paths["/flows/json/{flow}"] = PathItemObject{
-		Parameters: []ParameterObject{
-			{
+		Parameters: func() []ParameterObject {
+			return append(paginationParams, ParameterObject{
 				Name:     "flow",
 				In:       "path",
 				Required: true,
 				Schema: jsonschema.JSONSchema{
 					Type: "string",
 				},
-			},
-		},
+			})
+		}(),
 		Post: &OperationObject{
 			OperationID: StringPointer("startFlow"),
 			RequestBody: &RequestBodyObject{

--- a/runtime/openapi/testdata/flow.json
+++ b/runtime/openapi/testdata/flow.json
@@ -476,6 +476,7 @@
           "id": { "type": "string" },
           "input": { "type": ["object", "null"], "additionalProperties": true },
           "name": { "type": "string" },
+          "startedBy": { "type": ["string", "null"] },
           "status": {
             "type": "string",
             "enum": [

--- a/runtime/openapi/testdata/flow.json
+++ b/runtime/openapi/testdata/flow.json
@@ -162,6 +162,105 @@
         }
       }
     },
+    "/flows/json/myRuns": {
+      "get": {
+        "operationId": "getMyRuns",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Run"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": ["object", "null"],
+                      "properties": {
+                        "errors": {
+                          "type": "array",
+                          "properties": {
+                            "error": {
+                              "type": "string"
+                            },
+                            "field": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "limit",
+          "in": "query",
+          "required": false,
+          "description": "",
+          "schema": {
+            "type": "number"
+          }
+        },
+        {
+          "name": "before",
+          "in": "query",
+          "required": false,
+          "description": "",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "after",
+          "in": "query",
+          "required": false,
+          "description": "",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "status",
+          "in": "query",
+          "required": false,
+          "description": "",
+          "schema": {
+            "type": "string",
+            "enum": [
+              "NEW",
+              "RUNNING",
+              "AWAITING_INPUT",
+              "FAILED",
+              "COMPLETED",
+              "CANCELLED"
+            ]
+          }
+        }
+      ]
+    },
     "/flows/json/{flow}": {
       "post": {
         "operationId": "startFlow",
@@ -251,6 +350,33 @@
         }
       },
       "parameters": [
+        {
+          "name": "limit",
+          "in": "query",
+          "required": false,
+          "description": "",
+          "schema": {
+            "type": "number"
+          }
+        },
+        {
+          "name": "before",
+          "in": "query",
+          "required": false,
+          "description": "",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "after",
+          "in": "query",
+          "required": false,
+          "description": "",
+          "schema": {
+            "type": "string"
+          }
+        },
         {
           "name": "flow",
           "in": "path",

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -196,7 +196,7 @@ func NewFlowsHandler(s *proto.Schema) common.HandlerFunc {
 	explicitHandlers := map[string]common.HandlerFunc{
 		"/flows/json":              flowsapi.ListFlowsHandler(s),
 		"/flows/json/openapi.json": flowsapi.OpenAPISchemaHandler(s),
-		// TODO: "/flows/json/myRuns"
+		"/flows/json/myruns":       flowsapi.MyRunsHandler(s),
 	}
 
 	return withRequestResponseLogging(func(r *http.Request) common.Response {


### PR DESCRIPTION
This PR introduces a `started_by` field on flow runs. This holds the identity of the user that started the flow, if applicable.

Alongside this, we are introducing a new endpoint to list the current user's flow runs:

``` GET /flows/json/myRuns?limit=10&status=AWAITING_INPUT,COMPLETED```
or 
``` GET /flows/json/myRuns?limit=10&status=COMPLETED&status=AWAITING_INPUT```

This endpoint accepts pagination parameters: `limit`, `after` and `before`, together with an optional `status` parameter which is used to filter the runs based on their current status. The `status` parameter is a string containing a comma separated list of statuses, or a single status, passed as a query param multiple times e.g. `?status=COMPLETED&status=AWAITING_INPUT`