### PR TITLE
feat: add env and secrets to flow context

### DIFF
--- a/deploy/lambdas/functions/main.js.go.tmpl
+++ b/deploy/lambdas/functions/main.js.go.tmpl
@@ -10,6 +10,7 @@ const {
 const {
   createContextAPI,
   createJobContextAPI,
+  createFlowContextAPI,
   createSubscriberContextAPI,
   permissionFns,
 } = require("@teamkeel/sdk");
@@ -85,6 +86,7 @@ export async function handler(event) {
       case "flow":
         rpcResponse = await handleFlow(event, {
           flows,
+          createFlowContextAPI,
         });
         break;
       case "route":

--- a/integration/testdata/flows/flows/envStep.ts
+++ b/integration/testdata/flows/flows/envStep.ts
@@ -1,0 +1,7 @@
+import { EnvStep } from "@teamkeel/sdk";
+
+export default EnvStep({}, async (ctx) => {
+  await ctx.step("env step", async () => {
+    return ctx.env.PERSON_NAME;
+  });
+});

--- a/integration/testdata/flows/keelconfig.yaml
+++ b/integration/testdata/flows/keelconfig.yaml
@@ -1,0 +1,3 @@
+environment:
+  - name: PERSON_NAME
+    value: "Pedro"

--- a/integration/testdata/flows/schema.keel
+++ b/integration/testdata/flows/schema.keel
@@ -76,6 +76,10 @@ flow AllInputs {
     @permission(roles: [Admin])
 }
 
+flow EnvStep {
+    @permission(roles: [Admin])
+}
+
 model Thing {
     fields {
         name Text?

--- a/integration/testdata/flows/tests.test.ts
+++ b/integration/testdata/flows/tests.test.ts
@@ -23,6 +23,7 @@ TEST CASES
 [x] Permissions and identity tests
 [ ] Stages
 [x] List my runs
+[x] ctx env
 */
 
 test("flows - scalar step", async () => {
@@ -1175,7 +1176,7 @@ test("flows - authorised starting, getting and listing flows", async () => {
 
   const resListAdmin = await listFlows({ token: adminToken });
   expect(resListAdmin.status).toBe(200);
-  expect(resListAdmin.body.flows.length).toBe(12);
+  expect(resListAdmin.body.flows.length).toBe(13);
   expect(resListAdmin.body.flows[0].name).toBe("ScalarStep");
   expect(resListAdmin.body.flows[1].name).toBe("MixedStepTypes");
   expect(resListAdmin.body.flows[2].name).toBe("Stepless");
@@ -1188,6 +1189,7 @@ test("flows - authorised starting, getting and listing flows", async () => {
   expect(resListAdmin.body.flows[9].name).toBe("ValidationText");
   expect(resListAdmin.body.flows[10].name).toBe("ValidationBoolean");
   expect(resListAdmin.body.flows[11].name).toBe("AllInputs");
+  expect(resListAdmin.body.flows[12].name).toBe("EnvStep");
 
   const resListUser = await listFlows({ token: userToken });
   expect(resListUser.status).toBe(200);
@@ -1249,6 +1251,52 @@ test("flows - unauthenticated getting flow", async () => {
 test("flows - unauthenticated listing flows", async () => {
   const resGet = await listFlows({ token: null });
   expect(resGet.status).toBe(401);
+});
+
+test("flows - env step", async () => {
+  const token = await getToken({ email: "admin@keel.xyz" });
+
+  let { status, body } = await startFlow({
+    name: "envStep",
+    token,
+    body: {},
+  });
+  expect(status).toEqual(200);
+
+  const flow = await untilFlowFinished({
+    name: "envStep",
+    id: body.id,
+    token,
+  });
+
+  expect(flow).toEqual({
+    id: expect.any(String),
+    traceId: expect.any(String),
+    status: "COMPLETED",
+    name: "EnvStep",
+    input: {},
+    startedBy: expect.any(String),
+    steps: [
+      {
+        id: expect.any(String),
+        name: "env step",
+        runId: expect.any(String),
+        stage: null,
+        status: "COMPLETED",
+        type: "FUNCTION",
+        value: "Pedro",
+        error: null,
+        startTime: expect.any(String),
+        endTime: expect.any(String),
+        createdAt: expect.any(String),
+        updatedAt: expect.any(String),
+        ui: null,
+      },
+    ],
+    createdAt: expect.any(String),
+    updatedAt: expect.any(String),
+    config: null,
+  });
 });
 
 async function getToken({ email }) {

--- a/node/codegen.go
+++ b/node/codegen.go
@@ -1069,6 +1069,33 @@ func writeAPIFactory(w *codegen.Writer, schema *proto.Schema) {
 	w.Dedent()
 	w.Writeln("};")
 
+	w.Writeln("function createFlowContextAPI({ meta }) {")
+	w.Indent()
+	w.Writeln("const now = () => { return new Date(); };")
+	w.Writeln("const env = {")
+	w.Indent()
+
+	for _, variable := range schema.GetEnvironmentVariables() {
+		// fetch the value of the env var from the process.env (will pull the value based on the current environment)
+		// outputs "key: process.env["key"] || []"
+		w.Writef("%s: process.env[\"%s\"] || \"\",\n", variable.GetName(), variable.GetName())
+	}
+
+	w.Dedent()
+	w.Writeln("};")
+	w.Writeln("const secrets = {")
+	w.Indent()
+
+	for _, secret := range schema.GetSecrets() {
+		w.Writef("%s: meta.secrets.%s || \"\",\n", secret.GetName(), secret.GetName())
+	}
+
+	w.Dedent()
+	w.Writeln("};")
+	w.Writeln("return { env, now, secrets };")
+	w.Dedent()
+	w.Writeln("};")
+
 	w.Writeln("function createSubscriberContextAPI({ meta }) {")
 	w.Indent()
 	w.Writeln("const now = () => { return new Date(); };")
@@ -1125,7 +1152,7 @@ func writeAPIFactory(w *codegen.Writer, schema *proto.Schema) {
 
 	w.Writeln("export const models = createModelAPI();")
 	w.Writeln("export const permissions = createPermissionApi();")
-	w.Writeln("export { createContextAPI, createJobContextAPI, createSubscriberContextAPI };")
+	w.Writeln("export { createContextAPI, createJobContextAPI, createSubscriberContextAPI, createFlowContextAPI };")
 }
 
 func writeTableConfig(w *codegen.Writer, models []*proto.Model) {

--- a/node/codegen.go
+++ b/node/codegen.go
@@ -1434,9 +1434,9 @@ func writeSubscriberFunctionWrapperType(w *codegen.Writer, subscriber *proto.Sub
 
 func writeFlowFunctionWrapperType(w *codegen.Writer, flow *proto.Flow) {
 	if flow.GetInputMessageName() == "" {
-		w.Writef("export declare const %s: { <const C extends runtime.FlowConfig>(config: C, fn: runtime.FlowFunction<C>) };", flow.GetName())
+		w.Writef("export declare const %s: { <const C extends runtime.FlowConfig>(config: C, fn: runtime.FlowFunction<C, Environment, Secrets>) };", flow.GetName())
 	} else {
-		w.Writef("export declare const %s: { <const C extends runtime.FlowConfig>(config: C, fn: runtime.FlowFunction<C, %s>) };", flow.GetName(), flow.GetInputMessageName())
+		w.Writef("export declare const %s: { <const C extends runtime.FlowConfig>(config: C, fn: runtime.FlowFunction<C, Environment, Secrets, %s>) };", flow.GetName(), flow.GetInputMessageName())
 	}
 
 	w.Writeln("")

--- a/node/codegen_test.go
+++ b/node/codegen_test.go
@@ -438,6 +438,16 @@ function createJobContextAPI({ meta }) {
 	};
 	return { identity, env, now, secrets, isAuthenticated };
 };
+function createFlowContextAPI({ meta }) {
+	const now = () => { return new Date(); };
+	const env = {
+		TEST: process.env["TEST"] || "",
+	};
+	const secrets = {
+		SECRET_KEY: meta.secrets.SECRET_KEY || "",
+	};
+	return { env, now, secrets };
+};
 function createSubscriberContextAPI({ meta }) {
 	const now = () => { return new Date(); };
 	const env = {
@@ -459,7 +469,7 @@ function createPermissionApi() {
 };
 export const models = createModelAPI();
 export const permissions = createPermissionApi();
-export { createContextAPI, createJobContextAPI, createSubscriberContextAPI };
+export { createContextAPI, createJobContextAPI, createSubscriberContextAPI, createFlowContextAPI };
 `
 
 	runWriterTest(t, testSchema, expected, func(s *proto.Schema, w *codegen.Writer) {

--- a/node/codegen_test.go
+++ b/node/codegen_test.go
@@ -1962,8 +1962,8 @@ flow MyFlow {
 flow MyFlowWithoutInputs {}`
 
 	expected := `
-export declare const MyFlow: { <const C extends runtime.FlowConfig>(config: C, fn: runtime.FlowFunction<C, MyFlowMessage>) };
-export declare const MyFlowWithoutInputs: { <const C extends runtime.FlowConfig>(config: C, fn: runtime.FlowFunction<C>) };`
+export declare const MyFlow: { <const C extends runtime.FlowConfig>(config: C, fn: runtime.FlowFunction<C, Environment, Secrets, MyFlowMessage>) };
+export declare const MyFlowWithoutInputs: { <const C extends runtime.FlowConfig>(config: C, fn: runtime.FlowFunction<C, Environment, Secrets>) };`
 
 	runWriterTest(t, schema, expected, func(s *proto.Schema, w *codegen.Writer) {
 		for _, f := range s.GetFlows() {

--- a/packages/functions-runtime/src/flows/index.ts
+++ b/packages/functions-runtime/src/flows/index.ts
@@ -43,7 +43,7 @@ export interface FlowContext<C extends FlowConfig> {
   step: Step<C>;
   ui: UI<C>;
   env: any;
-  now: any;
+  now: Date;
   secrets: any;
 }
 

--- a/packages/functions-runtime/src/flows/index.ts
+++ b/packages/functions-runtime/src/flows/index.ts
@@ -42,6 +42,9 @@ const defaultOpts = {
 export interface FlowContext<C extends FlowConfig> {
   step: Step<C>;
   ui: UI<C>;
+  env: any;
+  now: any;
+  secrets: any;
 }
 
 // Steps can only return values that can be serialized to JSON and then
@@ -126,9 +129,13 @@ type StageConfig = string | StageConfigObject;
 export function createFlowContext<C extends FlowConfig>(
   runId: string,
   data: any,
-  spanId: string
+  spanId: string,
+  ctx: any
 ): FlowContext<C> {
   return {
+    env: ctx.env,
+    now: ctx.now,
+    secrets: ctx.secrets,
     step: async (name, optionsOrFn, fn?) => {
       // We need to check the type of the arguments due to the step function being overloaded
       const options = typeof optionsOrFn === "function" ? {} : optionsOrFn;

--- a/packages/functions-runtime/src/flows/index.ts
+++ b/packages/functions-runtime/src/flows/index.ts
@@ -114,8 +114,8 @@ export type ExtractStageKeys<T extends FlowConfig> = T extends {
     ? U extends string
       ? U
       : U extends { key: infer K extends string }
-        ? K
-        : never
+      ? K
+      : never
     : never
   : never;
 

--- a/packages/functions-runtime/src/flows/index.ts
+++ b/packages/functions-runtime/src/flows/index.ts
@@ -39,12 +39,12 @@ const defaultOpts = {
   timeoutInMs: 60000,
 };
 
-export interface FlowContext<C extends FlowConfig> {
+export interface FlowContext<C extends FlowConfig, E = any, S = any> {
   step: Step<C>;
   ui: UI<C>;
-  env: any;
+  env: E;
   now: Date;
-  secrets: any;
+  secrets: S;
 }
 
 // Steps can only return values that can be serialized to JSON and then
@@ -99,10 +99,12 @@ export interface FlowConfigAPI {
   description?: string;
 }
 
-export type FlowFunction<C extends FlowConfig, I extends any = {}> = (
-  ctx: FlowContext<C>,
-  inputs: I
-) => Promise<void>;
+export type FlowFunction<
+  C extends FlowConfig,
+  E extends any = {},
+  S extends any = {},
+  I extends any = {},
+> = (ctx: FlowContext<C, E, S>, inputs: I) => Promise<void>;
 
 // Extract the stage keys from the flow config supporting either a string or an object with a key property
 export type ExtractStageKeys<T extends FlowConfig> = T extends {
@@ -112,8 +114,8 @@ export type ExtractStageKeys<T extends FlowConfig> = T extends {
     ? U extends string
       ? U
       : U extends { key: infer K extends string }
-      ? K
-      : never
+        ? K
+        : never
     : never
   : never;
 
@@ -126,12 +128,16 @@ type StageConfigObject = {
 
 type StageConfig = string | StageConfigObject;
 
-export function createFlowContext<C extends FlowConfig>(
+export function createFlowContext<C extends FlowConfig, E = any, S = any>(
   runId: string,
   data: any,
   spanId: string,
-  ctx: any
-): FlowContext<C> {
+  ctx: {
+    env: E;
+    now: Date;
+    secrets: S;
+  }
+): FlowContext<C, E, S> {
   return {
     env: ctx.env,
     now: ctx.now,

--- a/packages/functions-runtime/src/handleFlow.ts
+++ b/packages/functions-runtime/src/handleFlow.ts
@@ -37,7 +37,7 @@ async function handleFlow(request: any, config: any) {
           throw new Error("no runId provided");
         }
 
-        const { flows } = config;
+        const { flows, createFlowContextAPI } = config;
 
         if (!(request.method in flows)) {
           const message = `no corresponding flow found for '${request.method}'`;
@@ -59,7 +59,10 @@ async function handleFlow(request: any, config: any) {
         const ctx = createFlowContext(
           request.meta.runId,
           request.meta.data,
-          span.spanContext().spanId
+          span.spanContext().spanId,
+          createFlowContextAPI({
+            meta: request.meta,
+          })
         );
 
         const flowFunction = flows[request.method].fn;


### PR DESCRIPTION
Adding the schema defined secrets & env vars to the flows context:

Given a keel config:
```
environment:
  - name: PERSON_NAME
    value: "Pedro"
  - name: MY_ENV_VAR
    value: "my env value"

secrets:
  - name: MY_SECRET
```

The env vars and secrets will now be available in the flow
```
import { MyFlow } from "@teamkeel/sdk";

export default MyFlow({}, async (ctx) => {
  await ctx.step("env step", async () => {
    console.log(ctx.secrets.MY_SECRET);
    console.log(ctx.env.MY_ENV_VAR);
    return ctx.env.PERSON_NAME;
  });
});
```

## NOTE

This feature requires a lambda handler change to instantiate the flow handler with the new context values 