### PR TITLE
fix: type never for empty inputs in functions

### DIFF
--- a/integration/testdata/functions_custom/functions/noInputs.ts
+++ b/integration/testdata/functions_custom/functions/noInputs.ts
@@ -1,6 +1,6 @@
 import { models, permissions, NoInputs } from "@teamkeel/sdk";
 
-export default NoInputs(async (ctx) => {
+export default NoInputs(async (ctx, inputs) => {
   permissions.allow();
   return { success: true };
 });

--- a/integration/testdata/functions_hooks/functions/createBookNoInputs.ts
+++ b/integration/testdata/functions_hooks/functions/createBookNoInputs.ts
@@ -5,16 +5,16 @@ import { createExpect } from "vitest";
 const hooks: CreateBookNoInputsHooks = {};
 
 export default CreateBookNoInputs({
-  beforeWrite(ctx, values) {
+  beforeWrite(ctx, inputs, values) {
     return {
       ...values,
       title: "The Farseer",
     };
   },
-  afterWrite(ctx, data) {
-    if (data.title !== "The Farseer") {
-      return new Error("Title must be 'The Farseer'");
-    }
+  afterWrite(ctx, inputs, data) {
+    // if (data.title !== "The Farseer") {
+    //   return new Error("Title must be 'The Farseer'");
+    // }
     return {
       ...data,
       title: "The Farseer 2",

--- a/integration/testdata/functions_hooks/functions/createBookNoInputs.ts
+++ b/integration/testdata/functions_hooks/functions/createBookNoInputs.ts
@@ -12,9 +12,9 @@ export default CreateBookNoInputs({
     };
   },
   afterWrite(ctx, inputs, data) {
-    // if (data.title !== "The Farseer") {
-    //   return new Error("Title must be 'The Farseer'");
-    // }
+    if (data.title !== "The Farseer") {
+      return new Error("Title must be 'The Farseer'");
+    }
     return {
       ...data,
       title: "The Farseer 2",

--- a/integration/testdata/functions_hooks/functions/deleteBookNoInputs.ts
+++ b/integration/testdata/functions_hooks/functions/deleteBookNoInputs.ts
@@ -4,7 +4,7 @@ import { DeleteBookNoInputs, DeleteBookNoInputsHooks } from "@teamkeel/sdk";
 const hooks: DeleteBookNoInputsHooks = {};
 
 export default DeleteBookNoInputs({
-  beforeQuery(ctx, query) {
+  beforeQuery(ctx, inputs, query) {
     return query.where({
       title: "The Farseer 2",
     });

--- a/integration/testdata/functions_hooks/functions/getBookNoInputs.ts
+++ b/integration/testdata/functions_hooks/functions/getBookNoInputs.ts
@@ -10,9 +10,9 @@ export default GetBookNoInputs({
     });
   },
   afterQuery(ctx, inputs, data) {
-    // if (data.title !== "The Farseer") {
-    //   return new Error("Title must be 'The Farseer'");
-    // }
+    if (data.title !== "The Farseer") {
+      return new Error("Title must be 'The Farseer'");
+    }   
     return {
       ...data,
       title: "The Farseer 2",

--- a/integration/testdata/functions_hooks/functions/getBookNoInputs.ts
+++ b/integration/testdata/functions_hooks/functions/getBookNoInputs.ts
@@ -12,7 +12,7 @@ export default GetBookNoInputs({
   afterQuery(ctx, inputs, data) {
     if (data.title !== "The Farseer") {
       return new Error("Title must be 'The Farseer'");
-    }   
+    }
     return {
       ...data,
       title: "The Farseer 2",

--- a/integration/testdata/functions_hooks/functions/getBookNoInputs.ts
+++ b/integration/testdata/functions_hooks/functions/getBookNoInputs.ts
@@ -4,15 +4,15 @@ import { GetBookNoInputs, GetBookNoInputsHooks } from "@teamkeel/sdk";
 const hooks: GetBookNoInputsHooks = {};
 
 export default GetBookNoInputs({
-  beforeQuery(ctx, query) {
+  beforeQuery(ctx, inputs, query) {
     return query.where({
       title: "The Farseer",
     });
   },
-  afterQuery(ctx, data) {
-    if (data.title !== "The Farseer") {
-      return new Error("Title must be 'The Farseer'");
-    }
+  afterQuery(ctx, inputs, data) {
+    // if (data.title !== "The Farseer") {
+    //   return new Error("Title must be 'The Farseer'");
+    // }
     return {
       ...data,
       title: "The Farseer 2",

--- a/integration/testdata/functions_hooks/functions/updateBookNoInputs.ts
+++ b/integration/testdata/functions_hooks/functions/updateBookNoInputs.ts
@@ -4,13 +4,13 @@ import { UpdateBookNoInputs, UpdateBookNoInputsHooks } from "@teamkeel/sdk";
 const hooks: UpdateBookNoInputsHooks = {};
 
 export default UpdateBookNoInputs({
-  beforeWrite(ctx, values) {
+  beforeWrite(ctx, inputs, values) {
     return {
       ...values,
       title: "The Farseer 2",
     };
   },
-  afterWrite(ctx, data) {
+  afterWrite(ctx, inputs, data) {
     return {
       ...data,
       title: "The Farseer",

--- a/integration/testdata/functions_hooks/main.test.ts
+++ b/integration/testdata/functions_hooks/main.test.ts
@@ -154,23 +154,23 @@ test("create - with nested create (has many)", async () => {
 
 test("hook functions with no inputs", async () => {
   const createBook = await actions.createBookNoInputs();
-  //expect(createBook.title).toEqual("The Farseer 2");
+  expect(createBook.title).toEqual("The Farseer 2");
 
   const insertedBook = await models.book.findOne({
     id: createBook.id,
   });
-  //expect(insertedBook?.title).toEqual("The Farseer");
+  expect(insertedBook?.title).toEqual("The Farseer");
 
   const getBook = await actions.getBookNoInputs();
-  // expect(getBook?.title).toEqual("The Farseer 2");
+  expect(getBook?.title).toEqual("The Farseer 2");
 
   const updateBook = await actions.updateBookNoInputs();
-  //expect(updateBook.title).toEqual("The Farseer");
+  expect(updateBook.title).toEqual("The Farseer");
 
   const updatedBook = await models.book.findOne({
     id: updateBook.id,
   });
-  //expect(updatedBook?.title).toEqual("The Farseer 2");
+  expect(updatedBook?.title).toEqual("The Farseer 2");
 
   const deleteBook = await actions.deleteBookNoInputs();
   expect(deleteBook).toEqual(createBook.id);

--- a/integration/testdata/functions_hooks/main.test.ts
+++ b/integration/testdata/functions_hooks/main.test.ts
@@ -65,7 +65,7 @@ test("create afterWrite - create additional records", async () => {
 });
 
 test("create afterWrite - error and rollback", async () => {
-  expect(
+  await expect(
     actions.createBookAfterWriteErrorRollback({
       title: "Lady Chatterley's Lover",
     })
@@ -154,23 +154,23 @@ test("create - with nested create (has many)", async () => {
 
 test("hook functions with no inputs", async () => {
   const createBook = await actions.createBookNoInputs();
-  expect(createBook.title).toEqual("The Farseer 2");
+  //expect(createBook.title).toEqual("The Farseer 2");
 
   const insertedBook = await models.book.findOne({
     id: createBook.id,
   });
-  expect(insertedBook?.title).toEqual("The Farseer");
+  //expect(insertedBook?.title).toEqual("The Farseer");
 
   const getBook = await actions.getBookNoInputs();
-  expect(getBook?.title).toEqual("The Farseer 2");
+  // expect(getBook?.title).toEqual("The Farseer 2");
 
   const updateBook = await actions.updateBookNoInputs();
-  expect(updateBook.title).toEqual("The Farseer");
+  //expect(updateBook.title).toEqual("The Farseer");
 
   const updatedBook = await models.book.findOne({
     id: updateBook.id,
   });
-  expect(updatedBook?.title).toEqual("The Farseer 2");
+  //expect(updatedBook?.title).toEqual("The Farseer 2");
 
   const deleteBook = await actions.deleteBookNoInputs();
   expect(deleteBook).toEqual(createBook.id);
@@ -244,7 +244,7 @@ test("get afterQuery - permission denied", async () => {
     published: false,
   });
 
-  expect(
+  await expect(
     actions.getBookAfterQueryPermissions({
       id: dbBook.id,
       onlyPublished: true,

--- a/node/codegen.go
+++ b/node/codegen.go
@@ -1306,7 +1306,7 @@ func writeFunctionWrapperType(w *codegen.Writer, schema *proto.Schema, model *pr
 		case parser.MessageFieldTypeAny:
 			w.Write("(fn: (ctx: ContextAPI, inputs: any) => ")
 		case "":
-			w.Write("(fn: (ctx: ContextAPI) => ")
+			w.Write("(fn: (ctx: ContextAPI, inputs: never) => ")
 		default:
 			w.Writef("(fn: (ctx: ContextAPI, inputs: %s) => ", action.GetInputMessageName())
 		}

--- a/node/codegen_test.go
+++ b/node/codegen_test.go
@@ -1963,7 +1963,7 @@ flow MyFlowWithoutInputs {}`
 
 	expected := `
 export declare const MyFlow: { <const C extends runtime.FlowConfig>(config: C, fn: runtime.FlowFunction<C, Environment, Secrets, MyFlowMessage>) };
-export declare const MyFlowWithoutInputs: { <const C extends runtime.FlowConfig>(config: C, fn: runtime.FlowFunction<C, Environment, Secrets>) };`
+export declare const MyFlowWithoutInputs: { <const C extends runtime.FlowConfig>(config: C, fn: runtime.FlowFunction<C, Environment, Secrets, never>) };`
 
 	runWriterTest(t, schema, expected, func(s *proto.Schema, w *codegen.Writer) {
 		for _, f := range s.GetFlows() {

--- a/node/templates/functions/create.js
+++ b/node/templates/functions/create.js
@@ -10,11 +10,7 @@ function createFunction({ model, valueInputs }) {
 
       if (hooks.beforeWrite) {
         values = await runtime.tracing.withSpan("beforeWrite", () => {
-          if (!inputs || Object.keys(inputs).length === 0) {
-            return hooks.beforeWrite(ctx, values);
-          } else {
-            return hooks.beforeWrite(ctx, inputs, values);
-          }
+          return hooks.beforeWrite(ctx, inputs, values);
         });
       }
 
@@ -22,11 +18,7 @@ function createFunction({ model, valueInputs }) {
 
       if (hooks.afterWrite) {
         const v = await runtime.tracing.withSpan("afterWrite", () => {
-          if (!inputs || Object.keys(inputs).length === 0) {
-            return hooks.afterWrite(ctx, data);
-          } else {
-            return hooks.afterWrite(ctx, inputs, data);
-          }
+          return hooks.afterWrite(ctx, inputs, data);
         });
         if (v !== undefined) {
           data = v;

--- a/node/templates/functions/delete.js
+++ b/node/templates/functions/delete.js
@@ -12,11 +12,7 @@ function deleteFunction({ model, whereInputs }) {
 
       if (hooks.beforeQuery) {
         data = await runtime.tracing.withSpan("beforeQuery", () => {
-          if (!inputs || Object.keys(inputs).length === 0) {
-            return hooks.beforeQuery(ctx, data);
-          } else {
-            return hooks.beforeQuery(ctx, inputs, data);
-          }
+          return hooks.beforeQuery(ctx, inputs, data);
         });
       }
 
@@ -31,11 +27,7 @@ function deleteFunction({ model, whereInputs }) {
 
       if (hooks.beforeWrite) {
         await runtime.tracing.withSpan("beforeWrite", () => {
-          if (!inputs || Object.keys(inputs).length === 0) {
-            return hooks.beforeWrite(ctx, data);
-          } else {
-            return hooks.beforeWrite(ctx, inputs, data);
-          }
+          return hooks.beforeWrite(ctx, inputs, data);
         });
       }
 
@@ -43,11 +35,7 @@ function deleteFunction({ model, whereInputs }) {
 
       if (hooks.afterWrite) {
         await runtime.tracing.withSpan("afterWrite", () => {
-          if (!inputs || Object.keys(inputs).length === 0) {
-            return hooks.afterWrite(ctx, data);
-          } else {
-            return hooks.afterWrite(ctx, inputs, data);
-          }
+          return hooks.afterWrite(ctx, inputs, data);
         });
       }
 

--- a/node/templates/functions/get.js
+++ b/node/templates/functions/get.js
@@ -12,11 +12,7 @@ function getFunction({ model, whereInputs }) {
 
       if (hooks.beforeQuery) {
         query = await runtime.tracing.withSpan("beforeQuery", () => {
-          if (!inputs || Object.keys(inputs).length === 0) {
-            return hooks.beforeQuery(ctx, query);
-          } else {
-            return hooks.beforeQuery(ctx, inputs, query);
-          }
+          return hooks.beforeQuery(ctx, inputs, query);
         });
       }
 
@@ -31,11 +27,7 @@ function getFunction({ model, whereInputs }) {
 
       if (hooks.afterQuery) {
         query = await runtime.tracing.withSpan("afterQuery", () => {
-          if (!inputs || Object.keys(inputs).length === 0) {
-            return hooks.afterQuery(ctx, query);
-          } else {
-            return hooks.afterQuery(ctx, inputs, query);
-          }
+          return hooks.afterQuery(ctx, inputs, query);
         });
       }
 

--- a/node/templates/functions/types.d.ts
+++ b/node/templates/functions/types.d.ts
@@ -18,19 +18,6 @@ type GetFunctionHooks<M, QB, I> = {
 };
 
 /**
- * The available hooks for a 'get' function without inputs
- * @typeParam M - The Model this function is declared in
- * @typeParam QB - The QueryBuilder type for the model
- */
-type GetFunctionHooksNoInputs<M, QB> = {
-  beforeQuery?: (
-    ctx: ContextAPI,
-    query: QB
-  ) => Promise<QB | M | null | Error> | QB | M | null | Error;
-  afterQuery?: (ctx: ContextAPI, record: M) => Promise<M | Error> | M | Error;
-};
-
-/**
  * The available hooks for a 'list' function
  * @typeParam M - The Model this function is declared in
  * @typeParam QB - The QueryBuilder type for the model
@@ -69,20 +56,6 @@ type CreateFunctionHooks<M, QB, I, V, C> = {
 };
 
 /**
- * The available hooks for a 'create' function without inputs
- * @typeParam M - The Model this function is declared in
- * @typeParam QB - The QueryBuilder type for the model
- * @typeParam V - The values that will be used to create an M record
- */
-type CreateFunctionHooksNoInputs<M, QB, V> = {
-  beforeWrite?: (ctx: ContextAPI, values: V) => Promise<V | Error> | V | Error;
-  afterWrite?: (
-    ctx: ContextAPI,
-    data: M
-  ) => Promise<M | void | Error> | M | void | Error;
-};
-
-/**
  * The available hooks for a 'create' function
  * @typeParam M - The Model this function is declared in
  * @typeParam QB - The QueryBuilder type for the model
@@ -109,28 +82,6 @@ type UpdateFunctionHooks<M, QB, I, V> = {
 };
 
 /**
- * The available hooks for a 'create' function without inputs
- * @typeParam M - The Model this function is declared in
- * @typeParam QB - The QueryBuilder type for the model
- * @typeParam V - The values that can be used to update an M record
- */
-type UpdateFunctionHooksNoInputs<M, QB, V> = {
-  beforeQuery?: (
-    ctx: ContextAPI,
-    query: QB
-  ) => Promise<M | QB | Error> | M | QB | Error;
-  beforeWrite?: (
-    ctx: ContextAPI,
-    values: V,
-    record: M
-  ) => Promise<Partial<M> | Error> | Partial<M> | Error;
-  afterWrite?: (
-    ctx: ContextAPI,
-    data: M
-  ) => Promise<M | void | Error> | M | void | Error;
-};
-
-/**
  * The available hooks for a 'delete' function
  * @typeParam M - The Model this function is declared in
  * @typeParam QB - The QueryBuilder type for the model
@@ -150,26 +101,6 @@ type DeleteFunctionHooks<M, QB, I> = {
   afterWrite?: (
     ctx: ContextAPI,
     inputs: I,
-    data: M
-  ) => Promise<void | Error> | void | Error;
-};
-
-/**
- * The available hooks for a 'delete' function without inputs
- * @typeParam M - The Model this function is declared in
- * @typeParam QB - The QueryBuilder type for the model
- */
-type DeleteFunctionHooksNoInputs<M, QB> = {
-  beforeQuery?: (
-    ctx: ContextAPI,
-    query: QB
-  ) => Promise<M | QB | Error> | M | QB | Error;
-  beforeWrite?: (
-    ctx: ContextAPI,
-    record: M
-  ) => Promise<void | Error> | void | Error;
-  afterWrite?: (
-    ctx: ContextAPI,
     data: M
   ) => Promise<void | Error> | void | Error;
 };

--- a/node/templates/functions/update.js
+++ b/node/templates/functions/update.js
@@ -18,11 +18,7 @@ function updateFunction({ model, whereInputs, valueInputs }) {
 
       if (hooks.beforeQuery) {
         data = await runtime.tracing.withSpan("beforeQuery", () => {
-          if (!inputs || Object.keys(inputs).length === 0) {
-            return hooks.beforeQuery(ctx, data);
-          } else {
-            return hooks.beforeQuery(ctx, inputs, data);
-          }
+          return hooks.beforeQuery(ctx, inputs, data);
         });
       }
 
@@ -37,11 +33,7 @@ function updateFunction({ model, whereInputs, valueInputs }) {
 
       if (hooks.beforeWrite) {
         values = await runtime.tracing.withSpan("beforeWrite", () => {
-          if (!inputs || Object.keys(inputs).length === 0) {
-            return hooks.beforeWrite(ctx, values, data);
-          } else {
-            return hooks.beforeWrite(ctx, inputs, values, data);
-          }
+          return hooks.beforeWrite(ctx, inputs, values, data);
         });
       }
 
@@ -49,11 +41,7 @@ function updateFunction({ model, whereInputs, valueInputs }) {
 
       if (hooks.afterWrite) {
         const v = await runtime.tracing.withSpan("afterWrite", () => {
-          if (!inputs || Object.keys(inputs).length === 0) {
-            return hooks.afterWrite(ctx, data);
-          } else {
-            return hooks.afterWrite(ctx, inputs, data);
-          }
+          return hooks.afterWrite(ctx, inputs, data);
         });
         if (v !== undefined) {
           data = v;


### PR DESCRIPTION
When no inputs are defined for actions and flows, then keen the `inputs` argument in the function definitions and make it of type `never`.