### PR TITLE
fix: validation for invalid attributes in flow definitions

### DIFF
--- a/schema/parser/consts.go
+++ b/schema/parser/consts.go
@@ -17,6 +17,7 @@ const (
 	KeywordReturns = "returns"
 	KeywordJob     = "job"
 	KeywordInput   = "inputs"
+	KeywordFlow    = "flow"
 )
 
 const (

--- a/schema/query/query.go
+++ b/schema/query/query.go
@@ -223,6 +223,17 @@ func Jobs(asts []*parser.AST) (ret []*parser.JobNode) {
 	return ret
 }
 
+func Flows(asts []*parser.AST) (ret []*parser.FlowNode) {
+	for _, ast := range asts {
+		for _, decl := range ast.Declarations {
+			if decl.Flow != nil {
+				ret = append(ret, decl.Flow)
+			}
+		}
+	}
+	return ret
+}
+
 func IsEnum(asts []*parser.AST, name string) bool {
 	return Enum(asts, name) != nil
 }

--- a/schema/testdata/errors/flow_unsupported_attribute.keel
+++ b/schema/testdata/errors/flow_unsupported_attribute.keel
@@ -1,0 +1,4 @@
+flow MyFlow {
+    //expect-error:5:16:E011:model 'MyFlow' has an unrecognised attribute @whatisthis
+    @whatisthis
+}

--- a/schema/validation/rules/attribute/attribute.go
+++ b/schema/validation/rules/attribute/attribute.go
@@ -49,6 +49,14 @@ func AttributeLocationsRule(asts []*parser.AST) (errs errorhandling.ValidationEr
 		}
 	}
 
+	for _, flow := range query.Flows(asts) {
+		for _, section := range flow.Sections {
+			if section.Attribute != nil {
+				errs.Concat(checkAttributes([]*parser.AttributeNode{section.Attribute}, "flow", flow.Name.Value))
+			}
+		}
+	}
+
 	return
 }
 


### PR DESCRIPTION
Check for invalid attributes in flow definitions.  For example, this should error:

```
flow MyFlow {
    @function
}
```