### PR TITLE
fix: fix sequences migration bug

### DIFF
--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -360,13 +360,13 @@ func New(ctx context.Context, schema *proto.Schema, database db.Database) (*Migr
 				continue
 			}
 
-			field := proto.FindField(schema.GetModels(), model.GetName(), casing.ToLowerCamel(column.ColumnName))
+			colName := strings.TrimSuffix(column.ColumnName, sequenceSuffix)
+
+			field := proto.FindField(schema.GetModels(), model.GetName(), casing.ToLowerCamel(colName))
 			if field == nil {
 				statements = append(statements, dropColumnStmt(model.GetName(), column.ColumnName))
 
 				// Remove __sequence suffix if present
-				colName := strings.TrimSuffix(column.ColumnName, sequenceSuffix)
-
 				changes = append(changes, &DatabaseChange{
 					Model: model.GetName(),
 					Field: casing.ToLowerCamel(colName),

--- a/migrations/sql.go
+++ b/migrations/sql.go
@@ -211,7 +211,7 @@ func alterColumnStmt(modelName string, field *proto.Field, column *ColumnRow) (s
 
 	alterColumnStmtPrefix := fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s", Identifier(modelName), Identifier(column.ColumnName))
 
-	if field.GetDefaultValue() == nil && column.HasDefault {
+	if field.GetDefaultValue() == nil && field.GetSequence() == nil && column.HasDefault {
 		output := fmt.Sprintf("%s DROP DEFAULT;", alterColumnStmtPrefix)
 		stmts = append(stmts, output)
 	}
@@ -232,8 +232,8 @@ func alterColumnStmt(modelName string, field *proto.Field, column *ColumnRow) (s
 	}
 
 	// these two flags are opposites of each other, so if they are both true
-	// or both false then there is a change to be applied
-	if field.GetOptional() == column.NotNull {
+	// or both false then there is a change to be applied (only for non sequence fields)
+	if field.GetOptional() == column.NotNull && field.GetSequence() == nil {
 		var change string
 		if field.GetOptional() && column.NotNull {
 			change = "DROP NOT NULL"

--- a/migrations/testdata/sequence_field_unchanged.txt
+++ b/migrations/testdata/sequence_field_unchanged.txt
@@ -1,0 +1,25 @@
+model Invoice {
+    fields {
+        reference Text @sequence("INV-")
+    }
+}
+
+===
+
+model Invoice {
+    fields {
+        reference Text @sequence("INV-")
+        comments Text
+    }
+}
+
+===
+
+ALTER TABLE "invoice" ADD COLUMN "comments" TEXT NOT NULL;
+
+===
+
+[
+    {"Model":"Invoice","Field":"comments","Type":"ADDED"}
+]
+


### PR DESCRIPTION
Fixes a bug which was causing the migrations for sequesnce fields to be added at all times.

Sequence fields have a default value, even though the default value in the proto schema is undefined.