### PR TITLE
fix: allow changing tool links

### DIFF
--- a/tools/config.go
+++ b/tools/config.go
@@ -687,8 +687,9 @@ func (cfg *LinkConfig) applyOn(link *toolsproto.ToolLink) *toolsproto.ToolLink {
 	if cfg.isDeleted() {
 		return nil
 	}
-	// we've added a link
-	if link == nil {
+
+	// we've added a link or changed the target action
+	if link == nil || cfg.ToolID != link.GetToolId() {
 		return &toolsproto.ToolLink{
 			ToolId:      cfg.ToolID,
 			Description: makeStringTemplate(cfg.Description),


### PR DESCRIPTION
When changing a link (such as a lookup action, get entry action), changing the target tool was not effectively applying the configuration. This PR fixes it