### PR TITLE
fix: add identity to flow context

### DIFF
--- a/node/codegen.go
+++ b/node/codegen.go
@@ -1072,6 +1072,7 @@ func writeAPIFactory(w *codegen.Writer, schema *proto.Schema) {
 	w.Writeln("function createFlowContextAPI({ meta }) {")
 	w.Indent()
 	w.Writeln("const now = () => { return new Date(); };")
+	w.Writeln("const { identity } = meta;")
 	w.Writeln("const env = {")
 	w.Indent()
 
@@ -1092,7 +1093,7 @@ func writeAPIFactory(w *codegen.Writer, schema *proto.Schema) {
 
 	w.Dedent()
 	w.Writeln("};")
-	w.Writeln("return { env, now, secrets };")
+	w.Writeln("return { env, now, secrets, identity };")
 	w.Dedent()
 	w.Writeln("};")
 
@@ -1433,7 +1434,7 @@ func writeFlowFunctionWrapperType(w *codegen.Writer, flow *proto.Flow) {
 		inputsType = flow.GetInputMessageName()
 	}
 
-	w.Writef("export declare const %s: { <const C extends runtime.FlowConfig>(config: C, fn: runtime.FlowFunction<C, Environment, Secrets, %s>) };", flow.GetName(), inputsType)
+	w.Writef("export declare const %s: { <const C extends runtime.FlowConfig>(config: C, fn: runtime.FlowFunction<C, Environment, Secrets, Identity, %s>) };", flow.GetName(), inputsType)
 
 	w.Writeln("")
 }

--- a/node/codegen_test.go
+++ b/node/codegen_test.go
@@ -440,13 +440,14 @@ function createJobContextAPI({ meta }) {
 };
 function createFlowContextAPI({ meta }) {
 	const now = () => { return new Date(); };
+	const { identity } = meta;
 	const env = {
 		TEST: process.env["TEST"] || "",
 	};
 	const secrets = {
 		SECRET_KEY: meta.secrets.SECRET_KEY || "",
 	};
-	return { env, now, secrets };
+	return { env, now, secrets, identity };
 };
 function createSubscriberContextAPI({ meta }) {
 	const now = () => { return new Date(); };
@@ -1962,8 +1963,8 @@ flow MyFlow {
 flow MyFlowWithoutInputs {}`
 
 	expected := `
-export declare const MyFlow: { <const C extends runtime.FlowConfig>(config: C, fn: runtime.FlowFunction<C, Environment, Secrets, MyFlowMessage>) };
-export declare const MyFlowWithoutInputs: { <const C extends runtime.FlowConfig>(config: C, fn: runtime.FlowFunction<C, Environment, Secrets, never>) };`
+export declare const MyFlow: { <const C extends runtime.FlowConfig>(config: C, fn: runtime.FlowFunction<C, Environment, Secrets, Identity, MyFlowMessage>) };
+export declare const MyFlowWithoutInputs: { <const C extends runtime.FlowConfig>(config: C, fn: runtime.FlowFunction<C, Environment, Secrets, Identity, never>) };`
 
 	runWriterTest(t, schema, expected, func(s *proto.Schema, w *codegen.Writer) {
 		for _, f := range s.GetFlows() {

--- a/packages/functions-runtime/src/flows/index.ts
+++ b/packages/functions-runtime/src/flows/index.ts
@@ -39,7 +39,7 @@ const defaultOpts = {
   timeout: 60000,
 };
 
-export interface FlowContext<C extends FlowConfig, E = any, S = any> {
+export interface FlowContext<C extends FlowConfig, E = any, S = any, Id = any> {
   // Defines a function step that will be run in the flow.
   step: Step<C>;
   // Defines a UI step that will be run in the flow.
@@ -47,6 +47,7 @@ export interface FlowContext<C extends FlowConfig, E = any, S = any> {
   env: E;
   now: Date;
   secrets: S;
+  identity: Id;
 }
 
 // Steps can only return values that can be serialized to JSON and then
@@ -114,8 +115,9 @@ export type FlowFunction<
   C extends FlowConfig,
   E extends any = {},
   S extends any = {},
+  Id extends any = {},
   I extends any = {},
-> = (ctx: FlowContext<C, E, S>, inputs: I) => Promise<void>;
+> = (ctx: FlowContext<C, E, S, Id>, inputs: I) => Promise<void>;
 
 // Extract the stage keys from the flow config supporting either a string or an object with a key property
 export type ExtractStageKeys<T extends FlowConfig> = T extends {
@@ -125,8 +127,8 @@ export type ExtractStageKeys<T extends FlowConfig> = T extends {
     ? U extends string
       ? U
       : U extends { key: infer K extends string }
-      ? K
-      : never
+        ? K
+        : never
     : never
   : never;
 
@@ -143,7 +145,12 @@ type StageConfigObject = {
 
 type StageConfig = string | StageConfigObject;
 
-export function createFlowContext<C extends FlowConfig, E = any, S = any>(
+export function createFlowContext<
+  C extends FlowConfig,
+  E = any,
+  S = any,
+  I = any,
+>(
   runId: string,
   data: any,
   action: string | null,
@@ -152,12 +159,14 @@ export function createFlowContext<C extends FlowConfig, E = any, S = any>(
     env: E;
     now: Date;
     secrets: S;
+    identity: I;
   }
-): FlowContext<C, E, S> {
+): FlowContext<C, E, S, I> {
   // Track step and page names to prevent duplicates
   const usedNames = new Set<string>();
 
   return {
+    identity: ctx.identity,
     env: ctx.env,
     now: ctx.now,
     secrets: ctx.secrets,

--- a/runtime/flows/orchestrator.go
+++ b/runtime/flows/orchestrator.go
@@ -10,6 +10,7 @@ import (
 	"github.com/teamkeel/keel/functions"
 	"github.com/teamkeel/keel/proto"
 	"github.com/teamkeel/keel/runtime/actions"
+	"github.com/teamkeel/keel/runtime/auth"
 	"github.com/teamkeel/keel/util"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -269,6 +270,12 @@ func (o *Orchestrator) CallFlow(ctx context.Context, run *Run, inputs map[string
 		inputs, err = actions.TransformInputs(o.schema, message, inputs, true)
 		if err != nil {
 			return nil, err
+		}
+	}
+
+	if !auth.IsAuthenticated(ctx) && run.StartedBy != nil {
+		if identity, err := actions.FindIdentityById(ctx, o.schema, *run.StartedBy); err == nil {
+			ctx = auth.WithIdentity(ctx, identity)
 		}
 	}
 


### PR DESCRIPTION
`ctx.identity` will now be available within flow functions and steps.