### PR TITLE
fix: tool links configurations to treat changed targets as new links

### DIFF
--- a/tools/config.go
+++ b/tools/config.go
@@ -693,7 +693,7 @@ func (cfg *LinkConfig) applyOn(link *toolsproto.ToolLink) *toolsproto.ToolLink {
 		return nil
 	}
 
-	// we've added a link or changed the target action
+	// we've added a link or changed the target
 	if link == nil || cfg.ToolID != link.GetToolId() {
 		return &toolsproto.ToolLink{
 			ToolId:      cfg.ToolID,

--- a/tools/diff.go
+++ b/tools/diff.go
@@ -322,8 +322,8 @@ func extractLinkConfig(generated, updated *toolsproto.ToolLink) *LinkConfig {
 		}
 	}
 
-	// we didn't have a link, and now we've added it
-	if generated == nil && updated != nil {
+	// we didn't have a link, and now we've added it OR we changed the target tool, therefore the updated link overrides the generated link
+	if (generated == nil && updated != nil) || (generated != nil && updated != nil && generated.GetToolId() != updated.GetToolId()) {
 		return &LinkConfig{
 			ToolID:           updated.GetToolId(),
 			AsDialog:         updated.AsDialog,
@@ -339,7 +339,7 @@ func extractLinkConfig(generated, updated *toolsproto.ToolLink) *LinkConfig {
 
 	// we may have updated the link config
 	cfg := LinkConfig{
-		ToolID:           generated.GetToolId(),
+		ToolID:           updated.GetToolId(),
 		AsDialog:         diffBool(generated.GetAsDialog(), updated.GetAsDialog()),
 		Title:            diffStringTemplate(generated.GetTitle(), updated.GetTitle()),
 		Description:      diffStringTemplate(generated.GetDescription(), updated.GetDescription()),

--- a/tools/generator.go
+++ b/tools/generator.go
@@ -946,10 +946,16 @@ func (g *Generator) findListTools(modelName string) []string {
 
 // findCreateTool will search for a get tool for the given model.
 func (g *Generator) findCreateTool(modelName string) string {
+	toolIds := []string{}
 	for id, tool := range g.actionTools() {
 		if tool.Model.GetName() == modelName && tool.Action.IsCreate() {
-			return id
+			toolIds = append(toolIds, id)
 		}
+	}
+
+	if len(toolIds) > 0 {
+		sort.Strings(toolIds)
+		return toolIds[0]
 	}
 
 	return ""
@@ -972,10 +978,16 @@ func (g *Generator) findGetByIDTool(modelName string) string {
 
 // findGetByIDTool will search for a get tool for the given model that takes in an ID and has no @embeds defined.
 func (g *Generator) findGetByIDWithoutEmbedsTool(modelName string) string {
+	toolIds := []string{}
 	for id, tool := range g.actionTools() {
 		if tool.Model.GetName() == modelName && tool.Action.IsGet() && tool.hasOnlyIDInput() && len(tool.Action.GetResponseEmbeds()) == 0 {
-			return id
+			toolIds = append(toolIds, id)
 		}
+	}
+
+	if len(toolIds) > 0 {
+		sort.Strings(toolIds)
+		return toolIds[0]
 	}
 
 	return ""


### PR DESCRIPTION
Fixing a few edge cases of tools configurations:

* having multiple tools contenders for a get entry action; we will now always choose the first one from an alphabetically sorted list
* when changing the target tool for a link, the configuration diffing will now treat the link as a new one, in order to prevent passing through data mappings from generated links pointing to other tools