### PR TITLE
fix: update my runs OAS to allow arrays for the status query string 

### DIFF
--- a/runtime/openapi/openapi.go
+++ b/runtime/openapi/openapi.go
@@ -52,6 +52,8 @@ type ParameterObject struct {
 	Required    bool                  `json:"required"`
 	Description string                `json:"description"`
 	Schema      jsonschema.JSONSchema `json:"schema"`
+	Style       string                `json:"style,omitempty"`
+	Explode     *bool                 `json:"explode,omitempty"`
 }
 
 type OperationObject struct {
@@ -483,16 +485,21 @@ func GenerateFlows(ctx context.Context, schema *proto.Schema) OpenAPI {
 				In:       "query",
 				Required: false,
 				Schema: jsonschema.JSONSchema{
-					Type: "string",
-					Enum: []*string{
-						StringPointer(string(flows.StatusNew)),
-						StringPointer(string(flows.StatusRunning)),
-						StringPointer(string(flows.StatusAwaitingInput)),
-						StringPointer(string(flows.StatusFailed)),
-						StringPointer(string(flows.StatusCompleted)),
-						StringPointer(string(flows.StatusCancelled)),
+					Type: "array",
+					Items: &jsonschema.JSONSchema{
+						Type: "string",
+						Enum: []*string{
+							StringPointer(string(flows.StatusNew)),
+							StringPointer(string(flows.StatusRunning)),
+							StringPointer(string(flows.StatusAwaitingInput)),
+							StringPointer(string(flows.StatusFailed)),
+							StringPointer(string(flows.StatusCompleted)),
+							StringPointer(string(flows.StatusCancelled)),
+						},
 					},
 				},
+				Style:   "form",
+				Explode: BoolPointer(false),
 			})
 		}(),
 		Get: &OperationObject{

--- a/runtime/openapi/testdata/flow.json
+++ b/runtime/openapi/testdata/flow.json
@@ -235,16 +235,21 @@
           "required": false,
           "description": "",
           "schema": {
-            "type": "string",
-            "enum": [
-              "NEW",
-              "RUNNING",
-              "AWAITING_INPUT",
-              "FAILED",
-              "COMPLETED",
-              "CANCELLED"
-            ]
-          }
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "NEW",
+                "RUNNING",
+                "AWAITING_INPUT",
+                "FAILED",
+                "COMPLETED",
+                "CANCELLED"
+              ]
+            }
+          },
+          "style": "form",
+          "explode": false
         }
       ]
     },


### PR DESCRIPTION
Adds `style` and `explode` definitions for OperationParameters. 
Updates the `status` paramater for the `myRuns` endpoint to allow arrays passed in an unexploded manner: e.g.: `?status=NEW,RUNNING,FAILED`