### PR TITLE
fix: persisting flows config

### DIFF
--- a/integration/testdata/flows/tests.test.ts
+++ b/integration/testdata/flows/tests.test.ts
@@ -70,7 +70,9 @@ test("flows - scalar step", async () => {
     ],
     createdAt: expect.any(String),
     updatedAt: expect.any(String),
-    config: null,
+    config: {
+      title: "Scalar step",
+    },
   });
 });
 
@@ -189,7 +191,22 @@ test("flows - only functions with config", async () => {
     ],
     createdAt: expect.any(String),
     updatedAt: expect.any(String),
-    config: null,
+    config: {
+      description: "This is a description",
+      stages: [
+        {
+          description: "This is stage 1's description",
+          key: "stage1",
+          name: "My stage 1",
+        },
+        {
+          description: "This is stage 2's description",
+          key: "stage2",
+          name: "My stage 2",
+        },
+      ],
+      title: "Flow with two functions",
+    },
   });
 });
 
@@ -393,7 +410,9 @@ test("flows - stepless flow", async () => {
     startedBy: expect.any(String),
     status: "COMPLETED",
     steps: [],
-    config: null,
+    config: {
+      title: "Stepless",
+    },
     traceId: expect.any(String),
     createdAt: expect.any(String),
     updatedAt: expect.any(String),
@@ -481,7 +500,9 @@ test("flows - first step is a function", async () => {
         endTime: expect.any(String),
       },
     ],
-    config: null,
+    config: {
+      title: "Single step",
+    },
     traceId: body.traceId,
     createdAt: body.createdAt,
     updatedAt: expect.any(String),
@@ -1005,7 +1026,9 @@ test("flows - error in step with retries", async () => {
     ],
     createdAt: res.body.createdAt,
     updatedAt: expect.any(String),
-    config: null,
+    config: {
+      title: "Error in step",
+    },
   });
 });
 
@@ -1160,7 +1183,9 @@ test("flows - timeout step", async () => {
     ],
     createdAt: res.body.createdAt,
     updatedAt: expect.any(String),
-    config: null,
+    config: {
+      title: "Timeout step",
+    },
   });
 });
 
@@ -1248,7 +1273,9 @@ test("flows - duplicate step name", async () => {
     ],
     createdAt: res.body.createdAt,
     updatedAt: expect.any(String),
-    config: null,
+    config: {
+      title: "Duplicate step name",
+    },
   });
 });
 
@@ -1340,7 +1367,9 @@ test("flows - duplicate step name and UI name", async () => {
     ],
     createdAt: res.body.createdAt,
     updatedAt: expect.any(String),
-    config: null,
+    config: {
+      title: "Duplicate step ui name",
+    },
   });
 });
 
@@ -1451,7 +1480,21 @@ test("flows - with completion", async () => {
     data: {
       value: "flow value",
     },
-    config: null,
+    config: {
+      stages: [
+        {
+          description: "this is the starting stage",
+          key: "starting",
+          name: "Starting",
+        },
+        {
+          description: "this is the ending stage",
+          key: "ending",
+          name: "Ending",
+        },
+      ],
+      title: "With completion",
+    },
   });
 });
 
@@ -1537,7 +1580,9 @@ test("flows - with completion - no contents and no returns", async () => {
     createdAt: res.body.createdAt,
     updatedAt: expect.any(String),
     data: null,
-    config: null,
+    config: {
+      title: "With completion minimal",
+    },
   });
 });
 
@@ -1611,7 +1656,9 @@ test("flows - with returned data", async () => {
     createdAt: res.body.createdAt,
     updatedAt: expect.any(String),
     data: "hello",
-    config: null,
+    config: {
+      title: "With returned data",
+    },
   });
 });
 
@@ -1794,7 +1841,9 @@ test("flows - env step", async () => {
     ],
     createdAt: expect.any(String),
     updatedAt: expect.any(String),
-    config: null,
+    config: {
+      title: "Env step",
+    },
   });
 });
 

--- a/migrations/flows.sql
+++ b/migrations/flows.sql
@@ -31,6 +31,7 @@ CREATE OR REPLACE TRIGGER "keel_flow_step_updated_at" BEFORE UPDATE ON "keel"."f
 ALTER TABLE "keel"."flow_run" ADD COLUMN IF NOT EXISTS "traceparent" TEXT;
 ALTER TABLE "keel"."flow_run" ADD COLUMN IF NOT EXISTS "started_by" TEXT;
 ALTER TABLE "keel"."flow_run" ADD COLUMN IF NOT EXISTS "data" JSONB DEFAULT NULL;
+ALTER TABLE "keel"."flow_run" ADD COLUMN IF NOT EXISTS "config" JSONB DEFAULT NULL;
 
 ALTER TABLE "keel"."flow_step" ADD COLUMN IF NOT EXISTS "action" TEXT;
 ALTER TABLE "keel"."flow_step" ADD COLUMN IF NOT EXISTS "ui" JSONB DEFAULT NULL;

--- a/runtime/flows/flow.go
+++ b/runtime/flows/flow.go
@@ -228,32 +228,27 @@ func GetTraceparent(ctx context.Context, runID string) (string, error) {
 }
 
 // updateRun will update the status of a flow run.
-func updateRun(ctx context.Context, runID string, status Status, updatedConfig any) (*Run, error) {
+func updateRun(ctx context.Context, runID string, status Status, config any) (*Run, error) {
 	database, err := db.GetDatabase(ctx)
 	if err != nil {
 		return nil, err
 	}
-
-	u := Run{
-		Status: status,
-		Config: updatedConfig,
-	}
-	// if updatedConfig != nil {
-	// 	u.Config = updatedConfig
-	// }
 
 	var run Run
 	result := database.GetDB().
 		Model(&run).
 		Clauses(clause.Returning{}).
 		Where("id = ?", runID).
-		Updates(u)
+		Updates(Run{
+			Status: status,
+			Config: config,
+		})
 
 	return &run, result.Error
 }
 
 // completeRun will complete a flow run.
-func completeRun(ctx context.Context, runID string, data any, config any) (*Run, error) {
+func completeRun(ctx context.Context, runID string, config any, data any) (*Run, error) {
 	database, err := db.GetDatabase(ctx)
 	if err != nil {
 		return nil, err

--- a/runtime/flows/flow.go
+++ b/runtime/flows/flow.go
@@ -236,17 +236,17 @@ func updateRun(ctx context.Context, runID string, status Status, updatedConfig a
 
 	u := Run{
 		Status: status,
+		Config: updatedConfig,
 	}
-	if updatedConfig != nil {
-		u.Config = updatedConfig
-	}
+	// if updatedConfig != nil {
+	// 	u.Config = updatedConfig
+	// }
 
 	var run Run
 	result := database.GetDB().
 		Model(&run).
 		Clauses(clause.Returning{}).
 		Where("id = ?", runID).
-		//Update("status", status)
 		Updates(u)
 
 	return &run, result.Error

--- a/runtime/flows/orchestrator.go
+++ b/runtime/flows/orchestrator.go
@@ -143,7 +143,7 @@ func (o *Orchestrator) orchestrateRun(ctx context.Context, runID string, inputs 
 				return err, resp.GetUIComponents()
 			}
 
-			_, err = completeRun(ctx, run.ID, resp.Data, resp.Config)
+			_, err = completeRun(ctx, run.ID, resp.Config, resp.Data)
 			return err, resp.GetUIComponents()
 		}
 
@@ -157,11 +157,12 @@ func (o *Orchestrator) orchestrateRun(ctx context.Context, runID string, inputs 
 		if run.HasPendingUIStep() {
 			_, err = updateRun(ctx, run.ID, StatusAwaitingInput, resp.Config)
 			return err, resp.GetUIComponents()
-		} else {
-			_, err = updateRun(ctx, run.ID, run.Status, resp.Config)
-			if err != nil {
-				return err, nil
-			}
+		}
+
+		// Set the config
+		_, err = updateRun(ctx, run.ID, run.Status, resp.Config)
+		if err != nil {
+			return err, nil
 		}
 
 		// Continue running the flow

--- a/runtime/flows/orchestrator.go
+++ b/runtime/flows/orchestrator.go
@@ -113,7 +113,7 @@ func (o *Orchestrator) orchestrateRun(ctx context.Context, runID string, inputs 
 	case StatusNew, StatusRunning, StatusAwaitingInput:
 		if run.Status == StatusNew {
 			// this is a new run, set it to running and trigger the flows runtime
-			run, err = updateRun(ctx, run.ID, StatusRunning, nil)
+			run, err = updateRun(ctx, run.ID, StatusRunning, run.Config)
 			if err != nil {
 				return err, nil
 			}
@@ -121,7 +121,7 @@ func (o *Orchestrator) orchestrateRun(ctx context.Context, runID string, inputs 
 
 		if run.Status == StatusAwaitingInput {
 			// we have been awaiting input, we're now going to continue running
-			run, err = updateRun(ctx, run.ID, StatusRunning, nil)
+			run, err = updateRun(ctx, run.ID, StatusRunning, run.Config)
 			if err != nil {
 				return err, nil
 			}
@@ -157,9 +157,7 @@ func (o *Orchestrator) orchestrateRun(ctx context.Context, runID string, inputs 
 		if run.HasPendingUIStep() {
 			_, err = updateRun(ctx, run.ID, StatusAwaitingInput, resp.Config)
 			return err, resp.GetUIComponents()
-		}
-
-		if resp.Config != nil {
+		} else {
 			_, err = updateRun(ctx, run.ID, run.Status, resp.Config)
 			if err != nil {
 				return err, nil

--- a/runtime/flows/orchestrator.go
+++ b/runtime/flows/orchestrator.go
@@ -131,7 +131,7 @@ func (o *Orchestrator) orchestrateRun(ctx context.Context, runID string, inputs 
 		resp, err := o.CallFlow(ctx, run, inputs, data, action)
 		if err != nil {
 			// failed orchestrating, mark the run as failed and return the error
-			_, _ = updateRun(ctx, run.ID, StatusFailed, nil)
+			_, _ = updateRun(ctx, run.ID, StatusFailed, resp.Config)
 			return err, nil
 		}
 
@@ -139,11 +139,11 @@ func (o *Orchestrator) orchestrateRun(ctx context.Context, runID string, inputs 
 			if resp.Error != "" {
 				// run was orchestrated and completed successfully, but with an error (e.g. exhaused retries)
 				// TODO: store error message against the flow run
-				_, err = updateRun(ctx, run.ID, StatusFailed, nil)
+				_, err = updateRun(ctx, run.ID, StatusFailed, resp.Config)
 				return err, resp.GetUIComponents()
 			}
 
-			_, err = updateRun(ctx, run.ID, StatusCompleted, resp.Data)
+			_, err = completeRun(ctx, run.ID, resp.Data, resp.Config)
 			return err, resp.GetUIComponents()
 		}
 
@@ -155,8 +155,15 @@ func (o *Orchestrator) orchestrateRun(ctx context.Context, runID string, inputs 
 
 		// Check to see if we're in a Pending UI step, break orchestration
 		if run.HasPendingUIStep() {
-			_, err = updateRun(ctx, run.ID, StatusAwaitingInput, nil)
+			_, err = updateRun(ctx, run.ID, StatusAwaitingInput, resp.Config)
 			return err, resp.GetUIComponents()
+		}
+
+		if resp.Config != nil {
+			_, err = updateRun(ctx, run.ID, run.Status, resp.Config)
+			if err != nil {
+				return err, nil
+			}
 		}
 
 		// Continue running the flow


### PR DESCRIPTION
We now persist the flows config so that it is available without having to run the actual flow function.  This is particularly important for the final completion step which needs to be redisplayable.