### PR TITLE
fix: change stats return format

### DIFF
--- a/integration/testdata/flows/tests.test.ts
+++ b/integration/testdata/flows/tests.test.ts
@@ -2378,40 +2378,38 @@ test("flows - stats", async () => {
   });
 
   expect(stats.status).toBe(200);
-  expect(stats.body).toEqual({
-    stats: [
-      {
-        activeRuns: 0,
-        completedToday: 0,
-        errorRate: 1,
-        lastRun: expect.any(String),
-        name: "ErrorInFlow",
-        timeSeries: [
-          {
-            failedRuns: 1,
-            time: expect.any(String),
-            totalRuns: 1,
-          },
-        ],
-        totalRuns: 1,
-      },
-      {
-        activeRuns: 0,
-        completedToday: 1,
-        errorRate: 0,
-        lastRun: expect.any(String),
-        name: "ScalarStep",
-        timeSeries: [
-          {
-            failedRuns: 0,
-            time: expect.any(String),
-            totalRuns: 1,
-          },
-        ],
-        totalRuns: 1,
-      },
-    ],
-  });
+  expect(stats.body).toEqual([
+    {
+      activeRuns: 0,
+      completedToday: 0,
+      errorRate: 1,
+      lastRun: expect.any(String),
+      name: "ErrorInFlow",
+      timeSeries: [
+        {
+          failedRuns: 1,
+          time: expect.any(String),
+          totalRuns: 1,
+        },
+      ],
+      totalRuns: 1,
+    },
+    {
+      activeRuns: 0,
+      completedToday: 1,
+      errorRate: 0,
+      lastRun: expect.any(String),
+      name: "ScalarStep",
+      timeSeries: [
+        {
+          failedRuns: 0,
+          time: expect.any(String),
+          totalRuns: 1,
+        },
+      ],
+      totalRuns: 1,
+    },
+  ]);
   const res = await fetch(`${process.env.KEEL_TESTING_API_URL}/flows/json`, {
     method: "GET",
     headers: {

--- a/runtime/apis/flowsapi/list_flows_endpoint.go
+++ b/runtime/apis/flowsapi/list_flows_endpoint.go
@@ -128,7 +128,7 @@ func ListFlowsStatsHandler(p *proto.Schema) common.HandlerFunc {
 			return httpjson.NewErrorResponse(ctx, err, nil)
 		}
 
-		return common.NewJsonResponse(http.StatusOK, map[string]any{"stats": stats}, nil)
+		return common.NewJsonResponse(http.StatusOK, stats, nil)
 	}
 }
 


### PR DESCRIPTION
Changing the return format of the stats endpoint from `{stats: [...]}` to `{[...]}`