### PR TITLE
fix: flow context generic type def improvement

### DIFF
--- a/packages/functions-runtime/src/flows/index.ts
+++ b/packages/functions-runtime/src/flows/index.ts
@@ -44,7 +44,7 @@ const defaultOpts = {
   timeout: 60000,
 };
 
-export interface FlowContext<C extends FlowConfig, E = any, S = any, Id = any> {
+export interface FlowContext<C extends FlowConfig, E, S, Id> {
   // Defines a function step that will be run in the flow.
   step: Step<C>;
   // Defines a UI step that will be run in the flow.
@@ -117,13 +117,7 @@ export interface FlowConfigAPI {
   description?: string;
 }
 
-export type FlowFunction<
-  C extends FlowConfig,
-  E extends any = {},
-  S extends any = {},
-  Id extends any = {},
-  I extends any = {},
-> = (
+export type FlowFunction<C extends FlowConfig, E, S, Id, I = {}> = (
   ctx: FlowContext<C, E, S, Id>,
   inputs: I
 ) => Promise<CompleteOptions<C> | any | void>;
@@ -154,12 +148,7 @@ type StageConfigObject = {
 
 type StageConfig = string | StageConfigObject;
 
-export function createFlowContext<
-  C extends FlowConfig,
-  E = any,
-  S = any,
-  I = any,
->(
+export function createFlowContext<C extends FlowConfig, E, S, I>(
   runId: string,
   data: any,
   action: string | null,

--- a/packages/functions-runtime/src/flows/testingUtils.ts
+++ b/packages/functions-runtime/src/flows/testingUtils.ts
@@ -2,7 +2,7 @@ import { createFlowContext, FlowFunction } from ".";
 import { FlowConfig } from ".";
 
 export const testFlowContext = <T extends FlowConfig>(config?: T) =>
-  createFlowContext<T, any, any, any>("test-run-id", {}, null, "test-span-id", {
+  createFlowContext<T, {}, {}, {}>("test-run-id", {}, null, "test-span-id", {
     env: {},
     now: new Date(),
     secrets: {},
@@ -11,7 +11,7 @@ export const testFlowContext = <T extends FlowConfig>(config?: T) =>
 
 export const testFlow = <const C extends FlowConfig>(
   config: C,
-  fn: FlowFunction<C, {}>
+  fn: FlowFunction<C, {}, {}, {}>
 ) => {
   return { config, fn };
 };

--- a/packages/functions-runtime/src/flows/ui/index.ts
+++ b/packages/functions-runtime/src/flows/ui/index.ts
@@ -1,4 +1,4 @@
-import { createFlowContext, FlowConfig } from "..";
+import { FlowConfig } from "..";
 import {
   UiElementSelectOne,
   UiElementSelectOneApiResponse,


### PR DESCRIPTION
As far as I can understand, these serve no purpose for us.   Removing them makes our flow API a bit cleaner.