### PR TITLE
fix: flows page validation

### DIFF
--- a/integration/testdata/flows/flows/validationPage.ts
+++ b/integration/testdata/flows/flows/validationPage.ts
@@ -1,0 +1,34 @@
+import { ValidationPage } from "@teamkeel/sdk";
+
+const emailRegex = /^[^@]+@[^@]+\.[^@]+$/;
+const phoneRegex = /^[0-9]{10}$/;
+
+export default ValidationPage({}, async (ctx) => {
+  await ctx.ui.page("first page", {
+    content: [
+      ctx.ui.inputs.text("email", {
+        label: "Email",
+        optional: true,
+        validate(value) {
+          if (!emailRegex.test(value)) {
+            return "Not a valid email";
+          }
+        },
+      }),
+      ctx.ui.inputs.text("phone", {
+        label: "Phone",
+        optional: true,
+        validate(value) {
+          if (!phoneRegex.test(value)) {
+            return "Not a valid phone number";
+          }
+        },
+      }),
+    ],
+    validate: async (data) => {
+      if (!data.email && !data.phone) {
+        return "Email or phone is required";
+      }
+    },
+  });
+});

--- a/integration/testdata/flows/schema.keel
+++ b/integration/testdata/flows/schema.keel
@@ -46,6 +46,10 @@ flow ValidationBoolean {
     @permission(roles: [Admin])
 }
 
+flow ValidationPage {
+    @permission(roles: [Admin])
+}
+
 enum MyEnum {
     Value1
     Value2

--- a/integration/testdata/flows/tests.test.ts
+++ b/integration/testdata/flows/tests.test.ts
@@ -1340,7 +1340,7 @@ test("flows - authorised listing flows", async () => {
   await models.user.create({ team: "myTeam", identityId: identity!.id });
 
   const resListAdmin = await listFlows({ token: adminToken });
-  expect(resListAdmin.body.flows.length).toBe(16);
+  expect(resListAdmin.body.flows.length).toBe(17);
   expect(resListAdmin.body.flows[0].name).toBe("ScalarStep");
   expect(resListAdmin.body.flows[1].name).toBe("MixedStepTypes");
   expect(resListAdmin.body.flows[2].name).toBe("Stepless");
@@ -1350,13 +1350,14 @@ test("flows - authorised listing flows", async () => {
   expect(resListAdmin.body.flows[6].name).toBe("OnlyFunctions");
   expect(resListAdmin.body.flows[7].name).toBe("ValidationText");
   expect(resListAdmin.body.flows[8].name).toBe("ValidationBoolean");
-  expect(resListAdmin.body.flows[9].name).toBe("AllInputs");
-  expect(resListAdmin.body.flows[10].name).toBe("EnvStep");
-  expect(resListAdmin.body.flows[11].name).toBe("MultipleActions");
-  expect(resListAdmin.body.flows[12].name).toBe("WithCompletion");
-  expect(resListAdmin.body.flows[13].name).toBe("WithCompletionMinimal");
-  expect(resListAdmin.body.flows[14].name).toBe("WithReturnedData");
-  expect(resListAdmin.body.flows[15].name).toBe("ExpressionPermissionIsTrue");
+  expect(resListAdmin.body.flows[9].name).toBe("ValidationPage");
+  expect(resListAdmin.body.flows[10].name).toBe("AllInputs");
+  expect(resListAdmin.body.flows[11].name).toBe("EnvStep");
+  expect(resListAdmin.body.flows[12].name).toBe("MultipleActions");
+  expect(resListAdmin.body.flows[13].name).toBe("WithCompletion");
+  expect(resListAdmin.body.flows[14].name).toBe("WithCompletionMinimal");
+  expect(resListAdmin.body.flows[15].name).toBe("WithReturnedData");
+  expect(resListAdmin.body.flows[16].name).toBe("ExpressionPermissionIsTrue");
 
   const resListUser = await listFlows({ token: userToken });
   expect(resListUser.status).toBe(200);

--- a/integration/testdata/flows/tests.test.ts
+++ b/integration/testdata/flows/tests.test.ts
@@ -855,7 +855,7 @@ test("flows - boolean input validation", async () => {
   });
 });
 
-test.only("flows - page validation", async () => {
+test("flows - page validation", async () => {
   const token = await getToken({ email: "admin@keel.xyz" });
   let { status, body } = await startFlow({
     name: "ValidationPage",

--- a/integration/testdata/flows_errors/flows/errorInValidation.ts
+++ b/integration/testdata/flows_errors/flows/errorInValidation.ts
@@ -12,10 +12,6 @@ export default ErrorInValidation({}, async (ctx) => {
       }),
     ],
     validate(value) {
-      // if (value.email === "test@test.com") {
-      //   return "null";
-      // }
-
       throw new Error("something has gone wrong");
     },
   });

--- a/integration/testdata/flows_errors/flows/errorInValidation.ts
+++ b/integration/testdata/flows_errors/flows/errorInValidation.ts
@@ -1,0 +1,22 @@
+import { ErrorInValidation } from "@teamkeel/sdk";
+
+const emailRegex = /^[^@]+@[^@]+\.[^@]+$/;
+const phoneRegex = /^[0-9]{10}$/;
+
+export default ErrorInValidation({}, async (ctx) => {
+  await ctx.ui.page("first page", {
+    content: [
+      ctx.ui.inputs.text("email", {
+        label: "Email",
+        optional: true,
+      }),
+    ],
+    validate(value) {
+      // if (value.email === "test@test.com") {
+      //   return "null";
+      // }
+
+      throw new Error("something has gone wrong");
+    },
+  });
+});

--- a/integration/testdata/flows_errors/schema.keel
+++ b/integration/testdata/flows_errors/schema.keel
@@ -32,6 +32,11 @@ flow DoNotRetry {
     @permission(roles: [Admin])
 }
 
+flow ErrorInValidation {
+    @permission(roles: [Admin])
+}
+
+
 model Thing {
     fields {
         name Text?

--- a/packages/functions-runtime/src/flows/ui/index.ts
+++ b/packages/functions-runtime/src/flows/ui/index.ts
@@ -233,7 +233,7 @@ export type InputElementImplementationResponse<TApiResponse, TData> = {
   __type: "input";
   uiConfig: TApiResponse;
   getData: (data: TData) => TData;
-  validate?: (data: TData) => Promise<null | string> | string | null;
+  validate?: (data: TData) => Promise<null | string | undefined> | string | null | undefined;
 };
 
 export type DisplayElementImplementation<

--- a/packages/functions-runtime/src/flows/ui/index.ts
+++ b/packages/functions-runtime/src/flows/ui/index.ts
@@ -233,7 +233,9 @@ export type InputElementImplementationResponse<TApiResponse, TData> = {
   __type: "input";
   uiConfig: TApiResponse;
   getData: (data: TData) => TData;
-  validate?: (data: TData) => Promise<null | string | undefined> | string | null | undefined;
+  validate?: (
+    data: TData
+  ) => Promise<null | string | undefined> | string | null | undefined;
 };
 
 export type DisplayElementImplementation<

--- a/packages/functions-runtime/src/flows/ui/index.ts
+++ b/packages/functions-runtime/src/flows/ui/index.ts
@@ -143,7 +143,9 @@ export interface BaseInputConfig<T> {
   helpText?: string;
   optional?: boolean;
   disabled?: boolean;
-  validate?: (data: T) => Promise<null | string> | string | null;
+  validate?: (
+    data: T
+  ) => Promise<null | string | undefined> | string | null | undefined;
 }
 
 // Base response for all inputs

--- a/packages/functions-runtime/src/flows/ui/index.ts
+++ b/packages/functions-runtime/src/flows/ui/index.ts
@@ -143,9 +143,7 @@ export interface BaseInputConfig<T> {
   helpText?: string;
   optional?: boolean;
   disabled?: boolean;
-  validate?: (
-    data: T
-  ) => Promise<null | string | undefined> | string | null | undefined;
+  validate?: (data: T) => Promise<null | string | void> | string | null | void;
 }
 
 // Base response for all inputs
@@ -235,7 +233,7 @@ export type InputElementImplementationResponse<TApiResponse, TData> = {
   getData: (data: TData) => TData;
   validate?: (
     data: TData
-  ) => Promise<null | string | undefined> | string | null | undefined;
+  ) => Promise<null | string | void> | string | null | void;
 };
 
 export type DisplayElementImplementation<

--- a/packages/functions-runtime/src/flows/ui/page.ts
+++ b/packages/functions-runtime/src/flows/ui/page.ts
@@ -18,7 +18,7 @@ type PageOptions<
   content: T;
   validate?: (
     data: ExtractFormData<T>
-  ) => Promise<null | string | undefined> | string | null | undefined;
+  ) => Promise<null | string | void> | string | null | void;
   actions?: A;
 };
 

--- a/packages/functions-runtime/src/flows/ui/page.ts
+++ b/packages/functions-runtime/src/flows/ui/page.ts
@@ -16,7 +16,9 @@ type PageOptions<
   title?: string;
   description?: string;
   content: T;
-  validate?: (data: ExtractFormData<T>) => Promise<true | string>;
+  validate?: (
+    data: ExtractFormData<T>
+  ) => Promise<null | string | undefined> | string | null | undefined;
   actions?: A;
 };
 
@@ -65,7 +67,7 @@ export async function page<
   >[];
 
   let hasValidationErrors = false;
-  let validationError;
+  let validationError: string | undefined;
 
   // if we have actions defined, validate that the given action exists
   if (options.actions && action !== null) {
@@ -101,7 +103,13 @@ export async function page<
       .filter(Boolean)
   )) as UiElementApiResponses;
 
-  // TODO support the page level validation function
+  if (data && options.validate) {
+    const validationResult = await options.validate(data);
+    if (typeof validationResult === "string") {
+      hasValidationErrors = true;
+      validationError = validationResult;
+    }
+  }
 
   return {
     page: {

--- a/runtime/flows/orchestrator.go
+++ b/runtime/flows/orchestrator.go
@@ -138,7 +138,6 @@ func (o *Orchestrator) orchestrateRun(ctx context.Context, runID string, inputs 
 		if resp.RunCompleted {
 			if resp.Error != "" {
 				// run was orchestrated and completed successfully, but with an error (e.g. exhaused retries)
-				// TODO: store error message against the flow run
 				_, err = updateRun(ctx, run.ID, StatusFailed, resp.Config)
 				return err, resp.GetUIComponents()
 			}


### PR DESCRIPTION
Validation for pages.  I've also changed the validation functions so that you can also return `undefined` which means you can leave out the return statements entirely which feels good to me.  See example:

```ts
await ctx.ui.page("first page", {
    content: [
      ctx.ui.inputs.text("email", {
        label: "Email",
        optional: true,
        validate(value) {
          if (!emailRegex.test(value)) {
            return "Not a valid email";
          }
        },
      }),
      ctx.ui.inputs.text("phone", {
        label: "Phone",
        optional: true,
        validate(value) {
          if (!phoneRegex.test(value)) {
            return "Not a valid phone number";
          }
        },
      }),
    ],
    validate: async (data) => {
      if (!data.email && !data.phone) {
        return "Email or phone is required";
      }
    },
  });
```