### PR TITLE
fix: gracefully handle missing ts files or functions

### DIFF
--- a/deploy/build.go
+++ b/deploy/build.go
@@ -272,7 +272,7 @@ func buildFunctions(ctx context.Context, args *BuildFunctionsArgs) (*BuildFuncti
 		return nil, err
 	}
 
-	functionsHandler, err := generateFunctionsHandler(args.Schema, args.Config)
+	functionsHandler, err := generateFunctionsHandler(args.Schema, args.Config, args.ProjectRoot)
 	if err != nil {
 		return nil, err
 	}
@@ -416,7 +416,7 @@ func buildCollectorConfig(ctx context.Context, args *BuildCollectorConfigArgs) (
 	return &result, nil
 }
 
-func generateFunctionsHandler(schema *proto.Schema, cfg *config.ProjectConfig) (*codegen.GeneratedFile, error) {
+func generateFunctionsHandler(schema *proto.Schema, cfg *config.ProjectConfig, projectRoot string) (*codegen.GeneratedFile, error) {
 	functions := map[string]string{}
 	jobs := []string{}
 	subscribers := []string{}
@@ -429,8 +429,14 @@ func generateFunctionsHandler(schema *proto.Schema, cfg *config.ProjectConfig) (
 			if op.GetImplementation() != proto.ActionImplementation_ACTION_IMPLEMENTATION_CUSTOM {
 				continue
 			}
-			functions[op.GetName()] = op.GetName()
-			actionTypes[op.GetName()] = op.GetType().String()
+
+			// Check if the file actually exists before requiring it
+			path := filepath.Join(projectRoot, "functions", op.GetName()+".ts")
+			if _, err := os.Stat(path); err == nil {
+
+				functions[op.GetName()] = op.GetName()
+				actionTypes[op.GetName()] = op.GetType().String()
+			}
 		}
 	}
 
@@ -441,18 +447,33 @@ func generateFunctionsHandler(schema *proto.Schema, cfg *config.ProjectConfig) (
 	}
 
 	for _, job := range schema.GetJobs() {
-		jobName := strcase.ToLowerCamel(job.GetName())
-		jobs = append(jobs, jobName)
+		name := strcase.ToLowerCamel(job.GetName())
+
+		// Check if the file actually exists before requiring it
+		path := filepath.Join(projectRoot, "jobs", name+".ts")
+		if _, err := os.Stat(path); err == nil {
+			jobs = append(jobs, name)
+		}
 	}
 
 	for _, subscriber := range schema.GetSubscribers() {
-		subscriberName := strcase.ToLowerCamel(subscriber.GetName())
-		subscribers = append(subscribers, subscriberName)
+		name := strcase.ToLowerCamel(subscriber.GetName())
+
+		// Check if the file actually exists before requiring it
+		path := filepath.Join(projectRoot, "subscribers", name+".ts")
+		if _, err := os.Stat(path); err == nil {
+			subscribers = append(subscribers, name)
+		}
 	}
 
 	for _, flow := range schema.GetFlows() {
-		flowName := strcase.ToLowerCamel(flow.GetName())
-		flows = append(flows, flowName)
+		name := strcase.ToLowerCamel(flow.GetName())
+
+		// Check if the file actually exists before requiring it
+		path := filepath.Join(projectRoot, "flows", name+".ts")
+		if _, err := os.Stat(path); err == nil {
+			flows = append(flows, name)
+		}
 	}
 
 	for _, route := range schema.GetRoutes() {

--- a/deploy/build.go
+++ b/deploy/build.go
@@ -433,7 +433,6 @@ func generateFunctionsHandler(schema *proto.Schema, cfg *config.ProjectConfig, p
 			// Check if the file actually exists before requiring it
 			path := filepath.Join(projectRoot, "functions", op.GetName()+".ts")
 			if _, err := os.Stat(path); err == nil {
-
 				functions[op.GetName()] = op.GetName()
 				actionTypes[op.GetName()] = op.GetType().String()
 			}

--- a/packages/functions-runtime/src/handleFlow.test.js
+++ b/packages/functions-runtime/src/handleFlow.test.js
@@ -1,0 +1,62 @@
+import { createJSONRPCRequest, JSONRPCErrorCode } from "json-rpc-2.0";
+import { handleFlow, RuntimeErrors } from "./handleFlow";
+import { test, expect } from "vitest";
+
+test("when a flow does not exist or has not been implemented", async () => {
+  const config = {
+    flows: {
+      myFlow: {
+        fn: async (ctx, inputs) => {},
+        config: {
+          title: "My Flow",
+          stages: ["step1", "step2"],
+        },
+      },
+    },
+    createFlowContextAPI: () => ({}),
+  };
+
+  const rpcReq = createJSONRPCRequest("123", "nonExistentFlow", {});
+  rpcReq.meta = {
+    runId: "test-run-id",
+    data: {},
+    action: "test-action",
+  };
+
+  expect(await handleFlow(rpcReq, config)).toEqual({
+    id: "123",
+    jsonrpc: "2.0",
+    error: {
+      code: JSONRPCErrorCode.MethodNotFound,
+      message:
+        "flow 'nonExistentFlow' does not exist or has not been implemented",
+    },
+  });
+});
+
+test("when no runId is provided", async () => {
+  const config = {
+    flows: {
+      myFlow: {
+        fn: async (ctx, inputs) => {},
+        config: {
+          title: "My Flow",
+          stages: ["step1", "step2"],
+        },
+      },
+    },
+    createFlowContextAPI: () => ({}),
+  };
+
+  const rpcReq = createJSONRPCRequest("123", "myFlow", {});
+  // No runId in meta
+
+  expect(await handleFlow(rpcReq, config)).toEqual({
+    id: "123",
+    jsonrpc: "2.0",
+    error: {
+      code: RuntimeErrors.UnknownError,
+      message: "no runId provided",
+    },
+  });
+});

--- a/packages/functions-runtime/src/handleFlow.ts
+++ b/packages/functions-runtime/src/handleFlow.ts
@@ -45,8 +45,8 @@ async function handleFlow(request: any, config: any) {
 
         const { flows, createFlowContextAPI } = config;
 
-        if (!(request.method in flows)) {
-          const message = `no corresponding flow found for '${request.method}'`;
+        if (!flows[request.method]) {
+          const message = `flow '${request.method}' does not exist or has not been implemented`;
           span.setStatus({
             code: opentelemetry.SpanStatusCode.ERROR,
             message: message,

--- a/packages/functions-runtime/src/handleJob.js
+++ b/packages/functions-runtime/src/handleJob.js
@@ -30,8 +30,8 @@ async function handleJob(request, config) {
       try {
         const { createJobContextAPI, jobs } = config;
 
-        if (!(request.method in jobs)) {
-          const message = `no corresponding job found for '${request.method}'`;
+        if (!jobs[request.method]) {
+          const message = `job '${request.method}' does not exist or has not been implemented`;
           span.setStatus({
             code: opentelemetry.SpanStatusCode.ERROR,
             message: message,

--- a/packages/functions-runtime/src/handleJob.test.js
+++ b/packages/functions-runtime/src/handleJob.test.js
@@ -86,7 +86,7 @@ test("when there is no matching job for the path", async () => {
     jsonrpc: "2.0",
     error: {
       code: JSONRPCErrorCode.MethodNotFound,
-      message: "no corresponding job found for 'unknown'",
+      message: "job 'unknown' does not exist or has not been implemented",
     },
   });
 });

--- a/packages/functions-runtime/src/handleRequest.js
+++ b/packages/functions-runtime/src/handleRequest.js
@@ -34,8 +34,8 @@ async function handleRequest(request, config) {
         const { createContextAPI, functions, permissionFns, actionTypes } =
           config;
 
-        if (!(request.method in functions)) {
-          const message = `no corresponding function found for '${request.method}'`;
+        if (!functions[request.method]) {
+          const message = `function '${request.method}' does not exist or has not been implemented`;
           span.setStatus({
             code: opentelemetry.SpanStatusCode.ERROR,
             message: message,

--- a/packages/functions-runtime/src/handleRequest.test.js
+++ b/packages/functions-runtime/src/handleRequest.test.js
@@ -72,7 +72,7 @@ test("when there is no matching function for the path", async () => {
     jsonrpc: "2.0",
     error: {
       code: JSONRPCErrorCode.MethodNotFound,
-      message: "no corresponding function found for 'unknown'",
+      message: "function 'unknown' does not exist or has not been implemented",
     },
   });
 });
@@ -269,6 +269,38 @@ test("when a BadRequest error preset is thrown in the custom function", async ()
     error: {
       code: RuntimeErrors.BadRequestError,
       message: "invalid inputs",
+    },
+  });
+});
+
+test("when a function does not exist or has not been implemented", async () => {
+  const config = {
+    functions: {
+      createPost: async (ctx, inputs) => {},
+    },
+    actionTypes: {
+      createPost: PROTO_ACTION_TYPES.CREATE,
+    },
+    createContextAPI: () => {
+      return {
+        response: {
+          headers: new Headers(),
+        },
+      };
+    },
+  };
+
+  const rpcReq = createJSONRPCRequest("123", "nonExistentFunction", {
+    title: "a post",
+  });
+
+  expect(await handleRequest(rpcReq, config)).toEqual({
+    id: "123",
+    jsonrpc: "2.0",
+    error: {
+      code: JSONRPCErrorCode.MethodNotFound,
+      message:
+        "function 'nonExistentFunction' does not exist or has not been implemented",
     },
   });
 });

--- a/packages/functions-runtime/src/handleRoute.js
+++ b/packages/functions-runtime/src/handleRoute.js
@@ -25,8 +25,8 @@ async function handleRoute(request, config) {
       try {
         const { createContextAPI, functions } = config;
 
-        if (!(request.method in functions)) {
-          const message = `no route function found for '${request.method}'`;
+        if (!functions[request.method]) {
+          const message = `route function '${request.method}' does not exist or has not been implemented`;
           span.setStatus({
             code: opentelemetry.SpanStatusCode.ERROR,
             message: message,

--- a/packages/functions-runtime/src/handleRoute.test.js
+++ b/packages/functions-runtime/src/handleRoute.test.js
@@ -1,0 +1,35 @@
+import { createJSONRPCRequest, JSONRPCErrorCode } from "json-rpc-2.0";
+import { handleRoute, RuntimeErrors } from "./handleRoute";
+import { test, expect } from "vitest";
+
+test("when a route function does not exist or has not been implemented", async () => {
+  const config = {
+    functions: {
+      myRoute: async (params, ctx) => {
+        return {
+          body: "Hello World",
+          headers: {},
+        };
+      },
+    },
+    createContextAPI: () => {
+      return {
+        response: {
+          headers: new Headers(),
+        },
+      };
+    },
+  };
+
+  const rpcReq = createJSONRPCRequest("123", "nonExistentRoute", {});
+
+  expect(await handleRoute(rpcReq, config)).toEqual({
+    id: "123",
+    jsonrpc: "2.0",
+    error: {
+      code: JSONRPCErrorCode.MethodNotFound,
+      message:
+        "route function 'nonExistentRoute' does not exist or has not been implemented",
+    },
+  });
+});

--- a/packages/functions-runtime/src/handleSubscriber.js
+++ b/packages/functions-runtime/src/handleSubscriber.js
@@ -30,8 +30,8 @@ async function handleSubscriber(request, config) {
       try {
         const { createSubscriberContextAPI, subscribers } = config;
 
-        if (!(request.method in subscribers)) {
-          const message = `no corresponding subscriber found for '${request.method}'`;
+        if (!subscribers[request.method]) {
+          const message = `subscriber '${request.method}' does not exist or has not been implemented`;
           span.setStatus({
             code: opentelemetry.SpanStatusCode.ERROR,
             message: message,

--- a/packages/functions-runtime/src/handleSubscriber.test.js
+++ b/packages/functions-runtime/src/handleSubscriber.test.js
@@ -1,0 +1,26 @@
+import { createJSONRPCRequest, JSONRPCErrorCode } from "json-rpc-2.0";
+import { handleSubscriber, RuntimeErrors } from "./handleSubscriber";
+import { test, expect } from "vitest";
+
+test("when a subscriber does not exist or has not been implemented", async () => {
+  const config = {
+    subscribers: {
+      mySubscriber: async (ctx, inputs) => {
+        // Handle the event
+      },
+    },
+    createSubscriberContextAPI: () => ({}),
+  };
+
+  const rpcReq = createJSONRPCRequest("123", "nonExistentSubscriber", {});
+
+  expect(await handleSubscriber(rpcReq, config)).toEqual({
+    id: "123",
+    jsonrpc: "2.0",
+    error: {
+      code: JSONRPCErrorCode.MethodNotFound,
+      message:
+        "subscriber 'nonExistentSubscriber' does not exist or has not been implemented",
+    },
+  });
+});

--- a/runtime/flows/orchestrator.go
+++ b/runtime/flows/orchestrator.go
@@ -130,8 +130,12 @@ func (o *Orchestrator) orchestrateRun(ctx context.Context, runID string, inputs 
 		// call the flow runtime
 		resp, err := o.CallFlow(ctx, run, inputs, data, action)
 		if err != nil {
+			cfg := JSON(nil)
+			if resp != nil {
+				cfg = resp.Config
+			}
 			// failed orchestrating, mark the run as failed and return the error
-			_, _ = updateRun(ctx, run.ID, StatusFailed, resp.Config)
+			_, _ = updateRun(ctx, run.ID, StatusFailed, cfg)
 			return err, nil
 		}
 


### PR DESCRIPTION
Previously the CLI would bomb when a function file was missing.  Or if the file exists, but is empty, then we'd see `Cannot read properties of undefined (reading 'fn')` in the traces.

This PR fixes these two issues by gracefully handling missing files or functions.  The CLI won't bomb out and the following will be recorded in the span:

<img width="328" alt="image" src="https://github.com/user-attachments/assets/9198978b-fc37-4c4c-9c9d-e3d37d4e0c35" />
