### PR TITLE
fix: decouple func runtime types

### DIFF
--- a/node/codegen.go
+++ b/node/codegen.go
@@ -43,7 +43,7 @@ func generateSdkPackage(schema *proto.Schema, cfg *config.ProjectConfig) codegen
 	sdkTypes.Writeln(`import { Kysely, Generated } from "kysely"`)
 	sdkTypes.Writeln(`import * as runtime from "@teamkeel/functions-runtime"`)
 	sdkTypes.Writeln(`import { Headers } from 'node-fetch'`)
-	sdkTypes.Writeln(`export { InlineFile, File, Duration, FileWriteTypes, SortDirection, FlowConfig, NonRetriableError } from "@teamkeel/functions-runtime"`)
+	sdkTypes.Writeln(`export * from "@teamkeel/functions-runtime"`)
 	sdkTypes.Writeln("")
 
 	writePermissions(sdk, schema)
@@ -62,7 +62,7 @@ func generateSdkPackage(schema *proto.Schema, cfg *config.ProjectConfig) codegen
 	writeTableConfig(sdk, schema.GetModels())
 	writeAPIFactory(sdk, schema)
 
-	sdk.Writeln("export { useDatabase, ErrorPresets as errors, File, InlineFile, Duration, NonRetriableError } from '@teamkeel/functions-runtime';")
+	sdk.Writeln("export * from '@teamkeel/functions-runtime';")
 
 	for _, model := range schema.GetModels() {
 		writeTableInterface(sdkTypes, model)

--- a/node/codegen.go
+++ b/node/codegen.go
@@ -63,6 +63,7 @@ func generateSdkPackage(schema *proto.Schema, cfg *config.ProjectConfig) codegen
 	writeAPIFactory(sdk, schema)
 
 	sdk.Writeln("export * from '@teamkeel/functions-runtime';")
+	sdk.Writeln("export { ErrorPresets as errors } from '@teamkeel/functions-runtime';")
 
 	for _, model := range schema.GetModels() {
 		writeTableInterface(sdkTypes, model)


### PR DESCRIPTION
If we don't explicitly import each of the function runtime types in the code generated SDK, then we don't risk a TypeError when the runtime is a version ahead of the NPM packages (which is not unlikely at the moment with our current setup)