### PR TITLE
fix: support running scheduled flows locally

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/pulumi/pulumi-aws/sdk/v6 v6.83.0
 	github.com/pulumi/pulumi/sdk/v3 v3.184.0
 	github.com/relvacode/iso8601 v1.6.0
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/rs/cors v1.11.1
 	github.com/samber/lo v1.51.0
 	github.com/sanity-io/litter v1.5.5

--- a/go.sum
+++ b/go.sum
@@ -393,6 +393,8 @@ github.com/relvacode/iso8601 v1.6.0/go.mod h1:FlNp+jz+TXpyRqgmM7tnzHHzBnz776kmAH
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=

--- a/proto/schema.go
+++ b/proto/schema.go
@@ -214,6 +214,30 @@ func (s *Schema) HasFlows() bool {
 	return len(s.GetFlows()) > 0
 }
 
+// HasScheduledFlows checks if there are any scheduled flows defined.
+func (s *Schema) HasScheduledFlows() bool {
+	for _, f := range s.GetFlows() {
+		if f.GetSchedule() != nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ScheduledFlows returns a slice of Flows that have schedules defined.
+func (s *Schema) ScheduledFlows() []*Flow {
+	flows := []*Flow{}
+
+	for _, f := range s.GetFlows() {
+		if f.GetSchedule() != nil {
+			flows = append(flows, f)
+		}
+	}
+
+	return flows
+}
+
 // GetFlowModelInputs returns a map of model names that are used as inputs to the given flow. The boolean
 // value represents whether the input is required or not.
 func (s *Schema) GetFlowModelInputs(f *Flow) map[string]bool {

--- a/runtime/flows/event_sender.go
+++ b/runtime/flows/event_sender.go
@@ -6,10 +6,14 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/robfig/cron/v3"
 )
 
 type EventSender interface {
+	// Send sends the given payload onto the flwos queue.
 	Send(ctx context.Context, payload *EventWrapper) error
+	// Schedule will schedule sending the payload according to the given cron expression.
+	Schedule(ctx context.Context, cronExpr string, payload *EventWrapper) error
 }
 
 type SQSEventSender struct {
@@ -44,16 +48,23 @@ func (s *SQSEventSender) Send(ctx context.Context, payload *EventWrapper) error 
 	return err
 }
 
+func (s *SQSEventSender) Schedule(ctx context.Context, cronExpr string, payload *EventWrapper) error {
+	// TODO: implement via eventbridge
+	return nil
+}
+
 type NoQueueEventSender struct {
 	orchestrator *Orchestrator
+	cronRunner   *cron.Cron
 }
 
 // compile time check that NoQueueEventSender implement the EventSender interface.
 var _ EventSender = &NoQueueEventSender{}
 
-func NewNoQueueEventSender(o *Orchestrator) *NoQueueEventSender {
+func NewNoQueueEventSender(o *Orchestrator, c *cron.Cron) *NoQueueEventSender {
 	return &NoQueueEventSender{
 		orchestrator: o,
+		cronRunner:   c,
 	}
 }
 
@@ -61,4 +72,12 @@ func (s *NoQueueEventSender) Send(ctx context.Context, payload *EventWrapper) er
 	go s.orchestrator.HandleEvent(ctx, payload) //nolint we're "simulating" an async queue
 
 	return nil
+}
+
+func (s *NoQueueEventSender) Schedule(ctx context.Context, cronExpr string, payload *EventWrapper) error {
+	_, err := s.cronRunner.AddFunc(cronExpr, func() {
+		s.orchestrator.HandleEvent(ctx, payload) //nolint
+	})
+
+	return err
 }


### PR DESCRIPTION
This PR adds support for running scheduled flows in a local environment i.e. `keel run`.

After starting the functions server, we start a cron server which executes given functions according to a cron schedule. The functions executed in this instance will be simulate a `FlowRunStarted` event being placed on the orchestrator's queue; then the orchestrator will handle the event, create a new flow run and then the normal flow of execution takes place. 

Since the functions server is restarted/updated every time the schema changes, this resets the cron jobs thus ensuring that schedule updates are reflected accordingly