### PR TITLE
fix: generate lookup actions only for model ID fields

### DIFF
--- a/tools/generator.go
+++ b/tools/generator.go
@@ -794,10 +794,12 @@ func (g *Generator) makeInputsForMessage(
 		}
 
 		if f.GetType().GetModelName() != nil && f.GetType().GetFieldName() != nil && proto.FindField(g.Schema.GetModels(), f.GetType().GetModelName().GetValue(), f.GetType().GetFieldName().GetValue()).GetUnique() {
-			// generate action link placeholders
-			if lookupToolsIDs := g.findListTools(f.GetType().GetModelName().GetValue()); len(lookupToolsIDs) > 0 {
-				config.LookupAction = &toolsproto.ToolLink{
-					ToolId: lookupToolsIDs[0],
+			// generate lookup action only for ID inputs
+			if f.GetType().GetFieldName().GetValue() == fieldNameID {
+				if lookupToolsIDs := g.findListTools(f.GetType().GetModelName().GetValue()); len(lookupToolsIDs) > 0 {
+					config.LookupAction = &toolsproto.ToolLink{
+						ToolId: lookupToolsIDs[0],
+					}
 				}
 			}
 

--- a/tools/testdata/composition/fields/expected/create-product.json
+++ b/tools/testdata/composition/fields/expected/create-product.json
@@ -36,7 +36,6 @@
         "displayOrder": 2,
         "visible": true,
         "helpText": { "template": "Help text for sku input" },
-        "lookupAction": { "toolId": "list-products" },
         "placeholder": { "template": "Placeholder sku" },
         "modelName": "Product",
         "fieldName": "sku"

--- a/tools/testdata/generate_testdata.go
+++ b/tools/testdata/generate_testdata.go
@@ -39,12 +39,17 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		tools, err := tools.GenerateTools(context.Background(), schema, builder.Config)
+
+		gen, err := tools.NewGenerator(schema, builder.Config)
 		if err != nil {
 			panic(err)
 		}
 
-		response := &rpc.ListToolsResponse{ToolConfigs: tools}
+		if err := gen.Generate(context.Background()); err != nil {
+			panic(err)
+		}
+
+		response := &rpc.ListToolsResponse{ToolConfigs: gen.GetTools()}
 		opts := protojson.MarshalOptions{Indent: "  "}
 		b, err := opts.Marshal(response)
 		if err != nil {

--- a/tools/testdata/generator/input_get_entry_actions/tools.json
+++ b/tools/testdata/generator/input_get_entry_actions/tools.json
@@ -6,7 +6,9 @@
         "id": "get-product",
         "name": "Get product",
         "actionName": "getProduct",
-        "apiNames": ["Api"],
+        "apiNames": [
+          "Api"
+        ],
         "modelName": "Product",
         "actionType": "ACTION_TYPE_GET",
         "implementation": "ACTION_IMPLEMENTATION_AUTO",
@@ -168,7 +170,9 @@
         "id": "get-product-by-sku",
         "name": "Get product by sku",
         "actionName": "getProductBySku",
-        "apiNames": ["Api"],
+        "apiNames": [
+          "Api"
+        ],
         "modelName": "Product",
         "actionType": "ACTION_TYPE_GET",
         "implementation": "ACTION_IMPLEMENTATION_AUTO",
@@ -180,9 +184,6 @@
             "fieldType": "TYPE_STRING",
             "displayName": "Sku",
             "visible": true,
-            "lookupAction": {
-              "toolId": "list-products"
-            },
             "modelName": "Product",
             "fieldName": "sku"
           }
@@ -343,7 +344,9 @@
         "id": "get-product-with-supplier",
         "name": "Get product with supplier",
         "actionName": "getProductWithSupplier",
-        "apiNames": ["Api"],
+        "apiNames": [
+          "Api"
+        ],
         "modelName": "Product",
         "actionType": "ACTION_TYPE_GET",
         "implementation": "ACTION_IMPLEMENTATION_AUTO",
@@ -538,7 +541,9 @@
         "id": "list-products",
         "name": "List products",
         "actionName": "listProducts",
-        "apiNames": ["Api"],
+        "apiNames": [
+          "Api"
+        ],
         "modelName": "Product",
         "actionType": "ACTION_TYPE_LIST",
         "implementation": "ACTION_IMPLEMENTATION_AUTO",
@@ -846,7 +851,9 @@
         "id": "read-product-func",
         "name": "Read product func",
         "actionName": "readProductFunc",
-        "apiNames": ["Api"],
+        "apiNames": [
+          "Api"
+        ],
         "modelName": "Product",
         "actionType": "ACTION_TYPE_READ",
         "implementation": "ACTION_IMPLEMENTATION_CUSTOM",
@@ -891,7 +898,9 @@
         "id": "request-password-reset",
         "name": "Request password reset",
         "actionName": "requestPasswordReset",
-        "apiNames": ["Api"],
+        "apiNames": [
+          "Api"
+        ],
         "modelName": "Identity",
         "actionType": "ACTION_TYPE_WRITE",
         "implementation": "ACTION_IMPLEMENTATION_RUNTIME",
@@ -929,7 +938,9 @@
         "id": "reset-password",
         "name": "Reset password",
         "actionName": "resetPassword",
-        "apiNames": ["Api"],
+        "apiNames": [
+          "Api"
+        ],
         "modelName": "Identity",
         "actionType": "ACTION_TYPE_WRITE",
         "implementation": "ACTION_IMPLEMENTATION_RUNTIME",
@@ -967,7 +978,9 @@
         "id": "update-product",
         "name": "Update product",
         "actionName": "updateProduct",
-        "apiNames": ["Api"],
+        "apiNames": [
+          "Api"
+        ],
         "modelName": "Product",
         "actionType": "ACTION_TYPE_UPDATE",
         "implementation": "ACTION_IMPLEMENTATION_AUTO",
@@ -1089,7 +1102,9 @@
         "id": "write-product-func",
         "name": "Write product func",
         "actionName": "writeProductFunc",
-        "apiNames": ["Api"],
+        "apiNames": [
+          "Api"
+        ],
         "modelName": "Product",
         "actionType": "ACTION_TYPE_WRITE",
         "implementation": "ACTION_IMPLEMENTATION_CUSTOM",


### PR DESCRIPTION
When generating lookup action links for inputs, we should only generate them for fields that reference a model ID.