### PR TITLE
fix: add startTime to flow runs openapi schema

### DIFF
--- a/runtime/openapi/openapi.go
+++ b/runtime/openapi/openapi.go
@@ -318,6 +318,7 @@ func GenerateFlows(ctx context.Context, schema *proto.Schema) OpenAPI {
 			},
 			"name":      {Type: "string"},
 			"traceId":   {Type: "string"},
+			"startTime": {Type: "string", Format: "date-time"},
 			"createdAt": {Type: "string", Format: "date-time"},
 			"updatedAt": {Type: "string", Format: "date-time"},
 			"steps":     {Type: "array", Items: &jsonschema.JSONSchema{Ref: "#/components/schemas/Step"}},

--- a/runtime/openapi/testdata/flow.json
+++ b/runtime/openapi/testdata/flow.json
@@ -658,6 +658,7 @@
             "required": ["title"]
           },
           "createdAt": { "type": "string", "format": "date-time" },
+          "startTime": { "type": "string", "format": "date-time" },
           "data": { "type": ["object", "null"] },
           "id": { "type": "string" },
           "input": { "type": ["object", "null"], "additionalProperties": true },


### PR DESCRIPTION
Adds `startTime` to the runs responses as part of the flow api's OpenAPI schema