### PR TITLE
fix: allow bigint in flow step json constraint

### DIFF
--- a/packages/functions-runtime/src/flows/index.test-d.ts
+++ b/packages/functions-runtime/src/flows/index.test-d.ts
@@ -1,4 +1,4 @@
-import { test } from "vitest";
+import { test, expect } from "vitest";
 import { testFlow } from "./testingUtils";
 
 test("stages types work correctly", () => {
@@ -46,4 +46,26 @@ test("stages types work correctly", () => {
       });
     }
   );
+});
+
+test("json serializable constraint", () => {
+  testFlow({}, async (ctx) => {
+    await ctx.step("step", async () => {
+      return {
+        a: 1,
+        b: "2",
+        c: true,
+        d: [1, 2, 3],
+        e: {
+          f: "g",
+          h: 1,
+          i: true,
+        },
+        j: null,
+        k: undefined,
+        l: BigInt(10),
+        m: [{ n: [1, 2, 3] }],
+      };
+    });
+  });
 });

--- a/packages/functions-runtime/src/flows/index.test-d.ts
+++ b/packages/functions-runtime/src/flows/index.test-d.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "vitest";
+import { test } from "vitest";
 import { testFlow } from "./testingUtils";
 
 test("stages types work correctly", () => {

--- a/packages/functions-runtime/src/flows/index.ts
+++ b/packages/functions-runtime/src/flows/index.ts
@@ -66,8 +66,10 @@ export interface FlowContext<C extends FlowConfig, E, S, Id> {
 type JsonSerializable =
   | string
   | number
+  | bigint
   | boolean
   | null
+  | undefined
   | JsonSerializable[]
   | { [key: string]: JsonSerializable };
 

--- a/tools/testdata/generator/input_get_entry_actions/tools.json
+++ b/tools/testdata/generator/input_get_entry_actions/tools.json
@@ -6,9 +6,7 @@
         "id": "get-product",
         "name": "Get product",
         "actionName": "getProduct",
-        "apiNames": [
-          "Api"
-        ],
+        "apiNames": ["Api"],
         "modelName": "Product",
         "actionType": "ACTION_TYPE_GET",
         "implementation": "ACTION_IMPLEMENTATION_AUTO",
@@ -170,9 +168,7 @@
         "id": "get-product-by-sku",
         "name": "Get product by sku",
         "actionName": "getProductBySku",
-        "apiNames": [
-          "Api"
-        ],
+        "apiNames": ["Api"],
         "modelName": "Product",
         "actionType": "ACTION_TYPE_GET",
         "implementation": "ACTION_IMPLEMENTATION_AUTO",
@@ -344,9 +340,7 @@
         "id": "get-product-with-supplier",
         "name": "Get product with supplier",
         "actionName": "getProductWithSupplier",
-        "apiNames": [
-          "Api"
-        ],
+        "apiNames": ["Api"],
         "modelName": "Product",
         "actionType": "ACTION_TYPE_GET",
         "implementation": "ACTION_IMPLEMENTATION_AUTO",
@@ -541,9 +535,7 @@
         "id": "list-products",
         "name": "List products",
         "actionName": "listProducts",
-        "apiNames": [
-          "Api"
-        ],
+        "apiNames": ["Api"],
         "modelName": "Product",
         "actionType": "ACTION_TYPE_LIST",
         "implementation": "ACTION_IMPLEMENTATION_AUTO",
@@ -851,9 +843,7 @@
         "id": "read-product-func",
         "name": "Read product func",
         "actionName": "readProductFunc",
-        "apiNames": [
-          "Api"
-        ],
+        "apiNames": ["Api"],
         "modelName": "Product",
         "actionType": "ACTION_TYPE_READ",
         "implementation": "ACTION_IMPLEMENTATION_CUSTOM",
@@ -898,9 +888,7 @@
         "id": "request-password-reset",
         "name": "Request password reset",
         "actionName": "requestPasswordReset",
-        "apiNames": [
-          "Api"
-        ],
+        "apiNames": ["Api"],
         "modelName": "Identity",
         "actionType": "ACTION_TYPE_WRITE",
         "implementation": "ACTION_IMPLEMENTATION_RUNTIME",
@@ -938,9 +926,7 @@
         "id": "reset-password",
         "name": "Reset password",
         "actionName": "resetPassword",
-        "apiNames": [
-          "Api"
-        ],
+        "apiNames": ["Api"],
         "modelName": "Identity",
         "actionType": "ACTION_TYPE_WRITE",
         "implementation": "ACTION_IMPLEMENTATION_RUNTIME",
@@ -978,9 +964,7 @@
         "id": "update-product",
         "name": "Update product",
         "actionName": "updateProduct",
-        "apiNames": [
-          "Api"
-        ],
+        "apiNames": ["Api"],
         "modelName": "Product",
         "actionType": "ACTION_TYPE_UPDATE",
         "implementation": "ACTION_IMPLEMENTATION_AUTO",
@@ -1102,9 +1086,7 @@
         "id": "write-product-func",
         "name": "Write product func",
         "actionName": "writeProductFunc",
-        "apiNames": [
-          "Api"
-        ],
+        "apiNames": ["Api"],
         "modelName": "Product",
         "actionType": "ACTION_TYPE_WRITE",
         "implementation": "ACTION_IMPLEMENTATION_CUSTOM",


### PR DESCRIPTION
Values returned from flow steps need to be JSON serialisable, however we were not allowing bigint.