### PR TITLE
refactor: change flow calling args

### DIFF
--- a/runtime/flows/orchestrator.go
+++ b/runtime/flows/orchestrator.go
@@ -310,14 +310,21 @@ func (o *Orchestrator) CallFlow(ctx context.Context, run *Run, inputs map[string
 		}
 	}
 
-	resp, meta, err := functions.CallFlow(
-		ctx,
-		flow,
-		run.ID,
-		inputs,
-		data,
-		action,
-	)
+	args := functions.FlowInvocationArgs{
+		Flow:   flow,
+		RunID:  run.ID,
+		Inputs: inputs,
+		Data:   data,
+		Action: func() *string {
+			if action != "" {
+				return &action
+			}
+
+			return nil
+		}(),
+	}
+
+	resp, meta, err := functions.CallFlow(ctx, args)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Introduces a struct that contains all flow invocation args. This will make it easier to add future optional data without having to refactor other functions (i.e. `orchestrator.CallFlow`)