### PR TITLE
chore: add runtime flow's API handler for callbacks

### DIFF
--- a/functions/functions.go
+++ b/functions/functions.go
@@ -404,6 +404,10 @@ type FlowInvocationArgs struct {
 	Data map[string]any
 	// Action chosen by the user. Applicable only for UI steps that have multiple actions defined.
 	Action *string
+	// Element is the name of the UI Element on which we're executing a UI callback. If set, a Callback must also be set.
+	Element *string
+	// Callback is the name of the callback that needs to be executed when invoking the flow via a UI callback. If set, an Element must also be set
+	Callback *string
 }
 
 // CallFlow will invoke the flow function on the runtime node server.

--- a/runtime/apis/flowsapi/flow_handler.go
+++ b/runtime/apis/flowsapi/flow_handler.go
@@ -144,9 +144,9 @@ func FlowHandler(s *proto.Schema) common.HandlerFunc {
 
 			return common.NewJsonResponse(http.StatusOK, run, nil)
 		case 4:
-			// UI Callback: POST flows/json/[flowName]/[runID]/[stepID]/callback?name={callbackName}}&element={elementName}
+			// UI Callback: POST flows/json/[flowName]/[runID]/[stepID]/callback?callback={callbackName}&element={elementName}
 
-			// we're operating on a flow run (cancel/put values), we now need to set the tracing span context to the flow's trace
+			// we're operating on a flow run (cancel/put values), we now need to set the tracing span context to the flow's trace.
 			if traceparent, err := flows.GetTraceparent(ctx, pathParts[1]); err == nil {
 				sc := util.ParseTraceparent(traceparent)
 				ctx = trace.ContextWithSpanContext(ctx, sc)

--- a/runtime/flows/flow.go
+++ b/runtime/flows/flow.go
@@ -65,14 +65,8 @@ func (Run) TableName() string {
 
 // HasPendingUIStep tells us if the current run is waiting for UI input.
 func (r *Run) HasPendingUIStep() bool {
-	if r == nil || (r.Status != StatusAwaitingInput && r.Status != StatusRunning) {
-		return false
-	}
-
-	for _, step := range r.Steps {
-		if step.Type == StepTypeUI && step.Status == StepStatusPending {
-			return true
-		}
+	if s := r.PendingUIStep(); s != nil {
+		return true
 	}
 
 	return false
@@ -91,6 +85,22 @@ func (r *Run) SetUIComponents(c *FlowUIComponents) {
 			}
 		}
 	}
+}
+
+// PendingUIStep returns the pending UI step for this flow run.
+// If the flow does not have a pending UI step then nil will be returned.
+func (r *Run) PendingUIStep() *Step {
+	if r == nil || (r.Status != StatusAwaitingInput && r.Status != StatusRunning) {
+		return nil
+	}
+
+	for _, step := range r.Steps {
+		if step.Type == StepTypeUI && step.Status == StepStatusPending {
+			return &step
+		}
+	}
+
+	return nil
 }
 
 type FlowStats struct {


### PR DESCRIPTION
Adds a new handler to the flows API for callbacks:

```
POST flows/json/[flowName]/[runID]/[stepID]/callback?name={callbackName}}&element={elementName}
```

This will invoke the functions runtime synchronously in order to perform the requested callback and proxy back the response.