### PR TITLE
feat: UI elements callbacks

### DIFF
--- a/functions/functions.go
+++ b/functions/functions.go
@@ -451,6 +451,11 @@ func CallFlow(ctx context.Context, args FlowInvocationArgs) (any, *FunctionsRunt
 		span.SetAttributes(attribute.String("action", *args.Action))
 	}
 
+	if args.Callback != nil && args.Element != nil {
+		meta["callback"] = *args.Callback
+		meta["element"] = *args.Element
+	}
+
 	req := &FunctionsRuntimeRequest{
 		ID:     ksuid.New().String(),
 		Method: strcase.ToLowerCamel(args.Flow.GetName()),

--- a/functions/functions.go
+++ b/functions/functions.go
@@ -401,7 +401,7 @@ type FlowInvocationArgs struct {
 	// Inputs for the flow run.
 	Inputs map[string]any
 	// Data that is being sent to the flow as part of a step's input (for UI steps, this represents the user submitted data).
-	Data map[string]any
+	Data any
 	// Action chosen by the user. Applicable only for UI steps that have multiple actions defined.
 	Action *string
 	// Element is the name of the UI Element on which we're executing a UI callback. If set, a Callback must also be set.

--- a/integration/testdata/flows_elements/flows/callbackFlow.ts
+++ b/integration/testdata/flows_elements/flows/callbackFlow.ts
@@ -5,19 +5,23 @@ const config = {
 } as const satisfies FlowConfig;
 
 export default CallbackFlow(config, async (ctx) => {
-  const { numberInput } = await ctx.ui.page("my page", {
+  const { numberInput, boolInput } = await ctx.ui.page("my page", {
     content: [
-         ctx.ui.inputs.number("numberInput", {
-                    label: "How many numbers?",
-                    defaultValue: 1,
-                    onLeave: (callbackInput) => {
-                        return {
-                            result: callbackInput.number * 2,
-                        }
-                    }
-                }),
-    ]
+      ctx.ui.inputs.number("numberInput", {
+        label: "How many numbers?",
+        defaultValue: 1,
+        onLeave: (callbackInput: number) => {
+          return callbackInput * 2;
+        },
+      }),
+      ctx.ui.inputs.boolean("boolInput", {
+        label: "True?",
+        onLeave: (callbackInput: boolean) => {
+          return !callbackInput;
+        },
+      }),
+    ],
   });
 
-  return numberInput;
+  return { numberInput, boolInput };
 });

--- a/integration/testdata/flows_elements/flows/callbackFlow.ts
+++ b/integration/testdata/flows_elements/flows/callbackFlow.ts
@@ -1,0 +1,23 @@
+import { CallbackFlow, FlowConfig } from "@teamkeel/sdk";
+
+const config = {
+  // See https://docs.keel.so/flows for options
+} as const satisfies FlowConfig;
+
+export default CallbackFlow(config, async (ctx) => {
+  const { numberInput } = await ctx.ui.page("my page", {
+    content: [
+         ctx.ui.inputs.number("numberInput", {
+                    label: "How many numbers?",
+                    defaultValue: 1,
+                    onLeave: (callbackInput) => {
+                        return {
+                            result: callbackInput.number * 2,
+                        }
+                    }
+                }),
+    ]
+  });
+
+  return numberInput;
+});

--- a/integration/testdata/flows_elements/schema.keel
+++ b/integration/testdata/flows_elements/schema.keel
@@ -1,3 +1,7 @@
 flow Iterator {
     @permission(expression: true)
 }
+
+flow CallbackFlow {
+    @permission(expression: true)
+}

--- a/integration/testdata/flows_elements/tests.test.ts
+++ b/integration/testdata/flows_elements/tests.test.ts
@@ -37,6 +37,14 @@ test("flows - callback flow", async () => {
               name: "numberInput",
               optional: false,
             },
+            {
+              __type: "ui.input.boolean",
+              disabled: false,
+              label: "True?",
+              mode: "checkbox",
+              name: "boolInput",
+              optional: false,
+            },
           ],
           hasValidationErrors: false,
         },
@@ -48,21 +56,47 @@ test("flows - callback flow", async () => {
       title: "Callback flow",
     },
   });
-  const callbackResponse = await flows.callbackFlow.callback(
+
+  let callbackResponse = await flows.callbackFlow.callback(
     flow.id,
     flow.steps[0].id,
     "numberInput",
     "onLeave",
-    {
-      number: 12
-    }
-  )
+    12
+  );
+  expect(callbackResponse).toEqual(24);
 
-  expect(callbackResponse).toEqual({
-    input: null,
-    result: 24
-  })
-})
+  callbackResponse = await flows.callbackFlow.callback(
+    flow.id,
+    flow.steps[0].id,
+    "numberInput",
+    "onLeave",
+    50
+  );
+  expect(callbackResponse).toEqual(100);
+
+  callbackResponse = await flows.callbackFlow.callback(
+    flow.id,
+    flow.steps[0].id,
+    "boolInput",
+    "onLeave",
+    false
+  );
+  expect(callbackResponse).toEqual(true);
+
+  await expect(
+    flows.callbackFlow.callback(
+      flow.id,
+      flow.steps[0].id,
+      "wrong",
+      "onLeave",
+      false
+    )
+  ).toHaveError({
+    code: "ERR_UNKNOWN",
+    message: "Element with name wrong not found",
+  });
+});
 
 test("flows - iterator element", async () => {
   let flow = await flows.iterator.start({});

--- a/integration/testdata/flows_elements/tests.test.ts
+++ b/integration/testdata/flows_elements/tests.test.ts
@@ -2,6 +2,67 @@ import { resetDatabase, models, flows } from "@teamkeel/testing";
 import { beforeEach, expect, test } from "vitest";
 
 beforeEach(resetDatabase);
+test("flows - callback flow", async () => {
+  let flow = await flows.callbackFlow.start({});
+  expect(flow).toEqual({
+    id: expect.any(String),
+    traceId: expect.any(String),
+    status: "AWAITING_INPUT",
+    name: "CallbackFlow",
+    startedBy: null,
+    input: {},
+    data: null,
+    steps: [
+      {
+        id: expect.any(String),
+        name: "my page",
+        runId: expect.any(String),
+        stage: null,
+        status: "PENDING",
+        type: "UI",
+        value: null,
+        error: null,
+        startTime: expect.any(Date),
+        endTime: null,
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+        ui: {
+          __type: "ui.page",
+          content: [
+            {
+              __type: "ui.input.number",
+              defaultValue: 1,
+              disabled: false,
+              label: "How many numbers?",
+              name: "numberInput",
+              optional: false,
+            },
+          ],
+          hasValidationErrors: false,
+        },
+      },
+    ],
+    createdAt: expect.any(Date),
+    updatedAt: expect.any(Date),
+    config: {
+      title: "Callback flow",
+    },
+  });
+  const callbackResponse = await flows.callbackFlow.callback(
+    flow.id,
+    flow.steps[0].id,
+    "numberInput",
+    "onLeave",
+    {
+      number: 12
+    }
+  )
+
+  expect(callbackResponse).toEqual({
+    input: null,
+    result: 24
+  })
+})
 
 test("flows - iterator element", async () => {
   let flow = await flows.iterator.start({});

--- a/packages/functions-runtime/src/flows/disrupts.ts
+++ b/packages/functions-runtime/src/flows/disrupts.ts
@@ -29,3 +29,12 @@ export class ExhuastedRetriesDisrupt extends FlowDisrupt {
     super();
   }
 }
+
+export class CallbackDisrupt extends FlowDisrupt {
+  constructor(
+    public readonly response: any,
+    public readonly error: boolean
+  ) {
+    super();
+  }
+}

--- a/packages/functions-runtime/src/flows/testingUtils.ts
+++ b/packages/functions-runtime/src/flows/testingUtils.ts
@@ -6,6 +6,8 @@ export const testFlowContext = <T extends FlowConfig>(config?: T) =>
     "test-run-id",
     {},
     null,
+    null,
+    null,
     "test-span-id",
     {
       env: {},

--- a/packages/functions-runtime/src/flows/ui/elements/input/boolean.ts
+++ b/packages/functions-runtime/src/flows/ui/elements/input/boolean.ts
@@ -37,6 +37,7 @@ export const booleanInput: InputElementImplementation<
       mode: options?.mode || "checkbox",
     } satisfies UiElementInputBooleanApiResponse,
     validate: options?.validate,
+    onLeave: options?.onLeave,
     getData: (x: any) => x,
   };
 };

--- a/packages/functions-runtime/src/flows/ui/elements/input/number.ts
+++ b/packages/functions-runtime/src/flows/ui/elements/input/number.ts
@@ -43,6 +43,7 @@ export const numberInput: InputElementImplementation<
       max: options?.max,
     } satisfies UiElementInputNumberApiResponse,
     validate: options?.validate,
+    onLeave: options?.onLeave,
     getData: (x: any) => x,
   };
 };

--- a/packages/functions-runtime/src/flows/ui/elements/input/text.ts
+++ b/packages/functions-runtime/src/flows/ui/elements/input/text.ts
@@ -46,6 +46,7 @@ export const textInput: InputElementImplementation<
       minLength: options?.minLength,
     } satisfies UiElementInputTextApiResponse,
     validate: options?.validate,
+    onLeave: options?.onLeave,
     getData: (x: ElementDataType) => x,
   };
 };

--- a/packages/functions-runtime/src/flows/ui/index.ts
+++ b/packages/functions-runtime/src/flows/ui/index.ts
@@ -182,14 +182,16 @@ export interface BaseInputConfig<T, O extends boolean = boolean> {
   optional?: O;
   disabled?: boolean;
   validate?: ValidateFn<T>;
-  onLeave?: CallbackFn;
+  onLeave?: CallbackFn<T, T>;
 }
 
 export type ValidateFn<T> = (
   data: T
 ) => Promise<boolean | string> | boolean | string;
 
-export type CallbackFn = (data: any) => Promise<any> | any;
+export type CallbackFn<InputT, OutputT> = (
+  data: InputT
+) => Promise<OutputT> | OutputT;
 
 // Base response for all inputs
 export interface BaseUiInputResponse<K, TData> {
@@ -298,7 +300,7 @@ export type InputElementImplementationResponse<TApiResponse, TData> = {
   uiConfig: TApiResponse;
   getData: (data: TData) => TData;
   validate?: ValidateFn<TData>;
-  onLeave?: CallbackFn;
+  onLeave?: CallbackFn<TData, TData>;
 };
 
 export type IteratorElementImplementation<
@@ -314,7 +316,7 @@ export type IteratorElementImplementationResponse<TApiResponse, TData> = {
   uiConfig: TApiResponse;
   getData: (data: TData) => TData;
   validate?: ValidateFn<TData>;
-  onLeave?: CallbackFn;
+  onLeave?: CallbackFn<TData, TData>;
 };
 
 export type DisplayElementImplementation<

--- a/packages/functions-runtime/src/flows/ui/index.ts
+++ b/packages/functions-runtime/src/flows/ui/index.ts
@@ -182,11 +182,14 @@ export interface BaseInputConfig<T, O extends boolean = boolean> {
   optional?: O;
   disabled?: boolean;
   validate?: ValidateFn<T>;
+  onLeave?: CallbackFn;
 }
 
 export type ValidateFn<T> = (
   data: T
 ) => Promise<boolean | string> | boolean | string;
+
+export type CallbackFn = (data: any) => Promise<any> | any;
 
 // Base response for all inputs
 export interface BaseUiInputResponse<K, TData> {
@@ -295,6 +298,7 @@ export type InputElementImplementationResponse<TApiResponse, TData> = {
   uiConfig: TApiResponse;
   getData: (data: TData) => TData;
   validate?: ValidateFn<TData>;
+  onLeave?: CallbackFn;
 };
 
 export type IteratorElementImplementation<
@@ -310,6 +314,7 @@ export type IteratorElementImplementationResponse<TApiResponse, TData> = {
   uiConfig: TApiResponse;
   getData: (data: TData) => TData;
   validate?: ValidateFn<TData>;
+  onLeave?: CallbackFn;
 };
 
 export type DisplayElementImplementation<

--- a/packages/functions-runtime/src/flows/ui/page.ts
+++ b/packages/functions-runtime/src/flows/ui/page.ts
@@ -56,6 +56,33 @@ export interface UiPageApiResponse extends BaseUiDisplayResponse<"ui.page"> {
   validationError?: string;
 }
 
+export async function callbackFn<T extends UIElements>(
+  elements: T,
+  elementName: string,
+  callbackName: string,
+  data: any
+): Promise<any> {
+  // Find the element by name
+  const element = elements.find(
+    (el) => (el as any).uiConfig && (el as any).uiConfig.name === elementName
+  );
+
+  if (!element) {
+    throw new Error(`Element with name ${elementName} not found`);
+  }
+
+  // Check if the callback exists on the element
+  const cb = (element as any)[callbackName];
+  if (typeof cb !== "function") {
+    throw new Error(
+      `Callback ${callbackName} not found on element ${elementName}`
+    );
+  }
+
+  // Call the callback with provided arguments
+  return await cb(data);
+}
+
 export async function page<
   C extends FlowConfig,
   A extends PageActions[],

--- a/packages/testing-runtime/src/FlowExecutor.mjs
+++ b/packages/testing-runtime/src/FlowExecutor.mjs
@@ -97,6 +97,16 @@ export class FlowExecutor {
     }).then(handleResponse);
   }
 
+  async callback(id, stepId, element, callbackName, values)  {
+    let url = this._flowUrl + "/" + id + "/" + stepId + "/callback?element=" + element + "&callback=" + callbackName;
+    
+    return await fetch(url, {
+      method: "POST",
+      body: JSON.stringify(values),
+      headers: this.headers(),
+    }).then(handleResponse);
+  }
+
   async untilFinished(id, timeout = 5000) {
     const startTime = Date.now();
 

--- a/packages/testing-runtime/src/FlowExecutor.mjs
+++ b/packages/testing-runtime/src/FlowExecutor.mjs
@@ -97,9 +97,18 @@ export class FlowExecutor {
     }).then(handleResponse);
   }
 
-  async callback(id, stepId, element, callbackName, values)  {
-    let url = this._flowUrl + "/" + id + "/" + stepId + "/callback?element=" + element + "&callback=" + callbackName;
-    
+  async callback(id, stepId, element, callbackName, values) {
+    let url =
+      this._flowUrl +
+      "/" +
+      id +
+      "/" +
+      stepId +
+      "/callback?element=" +
+      element +
+      "&callback=" +
+      callbackName;
+
     return await fetch(url, {
       method: "POST",
       body: JSON.stringify(values),
@@ -176,7 +185,9 @@ function handleResponse(r) {
 
   return r.text().then((t) => {
     const response = JSON.parse(t, reviver);
-    response.input = parseOutputs(response.input);
+    if (response && response.input) {
+      response.input = parseOutputs(response.input);
+    }
 
     return response;
   });

--- a/packages/testing-runtime/src/index.d.ts
+++ b/packages/testing-runtime/src/index.d.ts
@@ -150,6 +150,12 @@ declare class FlowExecutor<Input = {}> {
     values: Record<string, any>,
     action?: string
   ): Promise<FlowRun<Input>>;
+  callback(
+    id: string,
+    stepId: string,
+    element: string,
+    callbackName: string,
+    values: any): Promise<any>
   untilAwaitingInput(id: string, timeout?: number): Promise<FlowRun<Input>>;
   untilFinished(id: string, timeout?: number): Promise<FlowRun<Input>>;
 }

--- a/packages/testing-runtime/src/index.d.ts
+++ b/packages/testing-runtime/src/index.d.ts
@@ -155,7 +155,8 @@ declare class FlowExecutor<Input = {}> {
     stepId: string,
     element: string,
     callbackName: string,
-    values: any): Promise<any>
+    values: any
+  ): Promise<any>;
   untilAwaitingInput(id: string, timeout?: number): Promise<FlowRun<Input>>;
   untilFinished(id: string, timeout?: number): Promise<FlowRun<Input>>;
 }

--- a/runtime/apis/flowsapi/flow_handler.go
+++ b/runtime/apis/flowsapi/flow_handler.go
@@ -161,12 +161,7 @@ func FlowHandler(s *proto.Schema) common.HandlerFunc {
 				return httpjson.NewErrorResponse(ctx, common.NewInputMalformedError("error parsing POST body"), nil)
 			}
 
-			data, ok := inputs.(map[string]any)
-			if !ok {
-				return httpjson.NewErrorResponse(ctx, common.NewInputMalformedError("data not correctly formatted"), nil)
-			}
-
-			response, err := flows.Callback(ctx, pathParts[1], pathParts[2], data, r.URL.Query().Get("element"), r.URL.Query().Get("callback"))
+			response, err := flows.Callback(ctx, pathParts[1], pathParts[2], inputs, r.URL.Query().Get("element"), r.URL.Query().Get("callback"))
 			if err != nil {
 				return httpjson.NewErrorResponse(ctx, err, nil)
 			}

--- a/runtime/flows/orchestrator.go
+++ b/runtime/flows/orchestrator.go
@@ -365,7 +365,7 @@ func (o *Orchestrator) CallFlow(ctx context.Context, run *Run, inputs map[string
 
 // CallbackFlow calls the functions runtime in the context of a flow callback: the FE will call a UI element's callback
 // function to perform some user defined logic and returns it's response.
-func (o *Orchestrator) CallbackFlow(ctx context.Context, run *Run, data map[string]any, element, callback string) (any, error) {
+func (o *Orchestrator) CallbackFlow(ctx context.Context, run *Run, data any, element, callback string) (any, error) {
 	ctx, span := tracer.Start(ctx, "CallbackFlow")
 	defer span.End()
 

--- a/runtime/flows/run.go
+++ b/runtime/flows/run.go
@@ -296,7 +296,7 @@ func UpdateStep(ctx context.Context, runID string, stepID string, data map[strin
 
 // Callback invokes a callback function defined on a UI element for a flow's UI step.
 // The step must be pending user data.
-func Callback(ctx context.Context, runID string, stepID string, data map[string]any, element, callback string) (response any, err error) {
+func Callback(ctx context.Context, runID string, stepID string, data any, element, callback string) (response any, err error) {
 	ctx, span := tracer.Start(ctx, "Callback")
 	defer span.End()
 

--- a/runtime/openapi/flowsapi.go
+++ b/runtime/openapi/flowsapi.go
@@ -490,5 +490,76 @@ func GenerateFlows(ctx context.Context, schema *proto.Schema) OpenAPI {
 		},
 	}
 
+	spec.Paths["/flows/json/{flow}/{runId}/{stepId}/callback"] = PathItemObject{
+		Parameters: []ParameterObject{
+			{
+				Name:     "flow",
+				In:       "path",
+				Required: true,
+				Schema: jsonschema.JSONSchema{
+					Type: "string",
+				},
+			},
+			{
+				Name:     "runId",
+				In:       "path",
+				Required: true,
+				Schema: jsonschema.JSONSchema{
+					Type: "string",
+				},
+			},
+			{
+				Name:     "stepId",
+				In:       "path",
+				Required: true,
+				Schema:   jsonschema.JSONSchema{Type: "string"},
+			},
+			{
+				Name:     "callback",
+				In:       "query",
+				Required: true,
+				Schema: jsonschema.JSONSchema{
+					Type: "string",
+				},
+			},
+			{
+				Name:     "element",
+				In:       "query",
+				Required: true,
+				Schema: jsonschema.JSONSchema{
+					Type: "string",
+				},
+			},
+		},
+		Post: &OperationObject{
+			OperationID: StringPointer("callback"),
+			RequestBody: &RequestBodyObject{
+				Content: map[string]MediaTypeObject{
+					"application/json": {
+						Schema: jsonschema.JSONSchema{Type: []string{"object", "string", "number", "boolean", "array"}, AdditionalProperties: BoolPointer(true)},
+					},
+				},
+			},
+			Responses: map[string]ResponseObject{
+				"200": {
+					Description: "Callback Response",
+					Content: map[string]MediaTypeObject{
+						"application/json": {
+							Schema: jsonschema.JSONSchema{Type: []string{"object", "string", "number", "boolean", "array"}, AdditionalProperties: BoolPointer(true)},
+						},
+					},
+				},
+				"400": {
+					Description: "Callback Response Errors",
+					Content: map[string]MediaTypeObject{
+						"application/json": {
+							Schema: responseErrorSchema,
+						},
+					},
+				},
+			},
+		},
+	}
+
 	return spec
 }

--- a/runtime/openapi/testdata/flow.json
+++ b/runtime/openapi/testdata/flow.json
@@ -627,6 +627,97 @@
           "schema": { "type": "string" }
         }
       ]
+    },
+    "/flows/json/{flow}/{runId}/{stepId}/callback": {
+      "post": {
+        "operationId": "callback",
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object", "string", "number", "boolean", "array"],
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Callback Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object", "string", "number", "boolean", "array"],
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Callback Response Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": { "type": "string" },
+                    "data": {
+                      "type": ["object", "null"],
+                      "properties": {
+                        "errors": {
+                          "type": "array",
+                          "properties": {
+                            "error": { "type": "string" },
+                            "field": { "type": "string" }
+                          }
+                        }
+                      }
+                    },
+                    "message": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "flow",
+          "in": "path",
+          "required": true,
+          "description": "",
+          "schema": { "type": "string" }
+        },
+        {
+          "name": "runId",
+          "in": "path",
+          "required": true,
+          "description": "",
+          "schema": { "type": "string" }
+        },
+        {
+          "name": "stepId",
+          "in": "path",
+          "required": true,
+          "description": "",
+          "schema": { "type": "string" }
+        },
+        {
+          "name": "callback",
+          "in": "query",
+          "required": true,
+          "description": "",
+          "schema": { "type": "string" }
+        },
+        {
+          "name": "element",
+          "in": "query",
+          "required": true,
+          "description": "",
+          "schema": { "type": "string" }
+        }
+      ]
     }
   },
   "components": {


### PR DESCRIPTION
This PR adds flow UI element callbacks.

Basic inputs now have a `onLeave` callback which can be defined as follows:

```ts
ctx.ui.inputs.number("orderCount", {
    label: "How many orders should I create?",
    defaultValue: 1,
    onLeave: (data:number) => {
        return data * 2
    }
})
```

As these elements are defined on a flow page: `await ctx.ui.page("pageName", ...}` whilst the flow run is Pending input for that particular page, a callback can be perfromed from the frontend to the execute the user defined function. this is done via a new endpoint in the Flows API:

```
// POST flows/json/[flowName]/[runID]/[stepID]/callback?callback={callback}&element={elementName}
```

in our example, `callback=onLeave` and `element=orderCount`.

Support for callbacks is added to the testing package as well, e.g.:

```ts
callbackResponse = await flows.myFlow.callback(
    flow.id,
    flow.steps[0].id,
    "orderCount",
    "onLeave",
    50
  );
  expect(callbackResponse).toEqual(100);
```