### PR TITLE
fix: handle filtering by markdown fields on list actions

### DIFF
--- a/schema/makeproto.go
+++ b/schema/makeproto.go
@@ -958,7 +958,7 @@ func (scm *Builder) makeListQueryInputMessage(typeInfo *proto.TypeInfo) (*proto.
 		switch typeInfo.GetType() {
 		case proto.Type_TYPE_ID:
 
-		case proto.Type_TYPE_STRING:
+		case proto.Type_TYPE_STRING, proto.Type_TYPE_MARKDOWN:
 			allQueryMsg = makeStringArrayQueryInputMessage(allQueryMsgName)
 			anyQueryMsg = makeStringArrayQueryInputMessage(anyQueryMsgName)
 		case proto.Type_TYPE_INT:
@@ -1038,7 +1038,7 @@ func (scm *Builder) makeListQueryInputMessage(typeInfo *proto.TypeInfo) (*proto.
 	switch typeInfo.GetType() {
 	case proto.Type_TYPE_ID:
 		return makeIDQueryInputMessage(msgName, typeInfo.GetEntityName()), nil
-	case proto.Type_TYPE_STRING:
+	case proto.Type_TYPE_STRING, proto.Type_TYPE_MARKDOWN:
 		return makeStringQueryInputMessage(msgName), nil
 	case proto.Type_TYPE_INT:
 		return makeIntQueryInputMessage(msgName), nil

--- a/schema/testdata/proto/operations_inputs/proto.json
+++ b/schema/testdata/proto/operations_inputs/proto.json
@@ -26,6 +26,14 @@
         },
         {
           "entityName": "Foo",
+          "name": "f4",
+          "type": {
+            "type": "TYPE_MARKDOWN"
+          },
+          "optional": true
+        },
+        {
+          "entityName": "Foo",
           "name": "id",
           "type": {
             "type": "TYPE_ID"
@@ -497,6 +505,62 @@
       ]
     },
     {
+      "name": "QueryInput",
+      "fields": [
+        {
+          "messageName": "QueryInput",
+          "name": "equals",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true,
+          "nullable": true
+        },
+        {
+          "messageName": "QueryInput",
+          "name": "notEquals",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true,
+          "nullable": true
+        },
+        {
+          "messageName": "QueryInput",
+          "name": "startsWith",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "messageName": "QueryInput",
+          "name": "endsWith",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "messageName": "QueryInput",
+          "name": "contains",
+          "type": {
+            "type": "TYPE_STRING"
+          },
+          "optional": true
+        },
+        {
+          "messageName": "QueryInput",
+          "name": "oneOf",
+          "type": {
+            "type": "TYPE_STRING",
+            "repeated": true
+          },
+          "optional": true
+        }
+      ]
+    },
+    {
       "name": "OpBWhere",
       "fields": [
         {
@@ -516,6 +580,15 @@
             "messageName": "IntQueryInput"
           },
           "target": ["f2"]
+        },
+        {
+          "messageName": "OpBWhere",
+          "name": "f4",
+          "type": {
+            "type": "TYPE_MESSAGE",
+            "messageName": "QueryInput"
+          },
+          "target": ["f4"]
         }
       ]
     },

--- a/schema/testdata/proto/operations_inputs/schema.keel
+++ b/schema/testdata/proto/operations_inputs/schema.keel
@@ -3,11 +3,12 @@ model Foo {
         f1 Text
         f2 Number
         f3 File
+        f4 Markdown?
     }
 
     actions {
         get opA(id)
-        list opB(f1, f2)
+        list opB(f1, f2, f4)
         update opC(id) with (f1)
         create opD() with (f1, f2, f3)
     }


### PR DESCRIPTION
A list action should handle `Markdown` fields used as filters in the same way as `Text` fields