### PR TITLE
chore: basic task assignment

### DIFF
--- a/integration/testdata/tasks/schema.keel
+++ b/integration/testdata/tasks/schema.keel
@@ -1,0 +1,13 @@
+task DispatchOrder {
+    fields {
+        name Text
+    }
+
+    @permission(roles: [User])
+}
+
+role User {
+    domains {
+        "keel.xyz"
+    }   
+}

--- a/integration/testdata/tasks/tests.test.ts
+++ b/integration/testdata/tasks/tests.test.ts
@@ -118,7 +118,7 @@ async function getToken({ email }) {
 }
 
 async function createTask({ topic, token }) {
-  const url = `${process.env.KEEL_TESTING_API_URL}/topics/${topic}/tasks`;
+  const url = `${process.env.KEEL_TESTING_API_URL}/topics/json/${topic}/tasks`;
   const res = await fetch(url, {
     method: "POST",
     headers: {

--- a/integration/testdata/tasks/tests.test.ts
+++ b/integration/testdata/tasks/tests.test.ts
@@ -151,7 +151,7 @@ async function listTasks({ topic, token }) {
 }
 
 async function nextTask({ topic, token }) {
-  const url = `${process.env.KEEL_TESTING_API_URL}/topics/${topic}/tasks/next`;
+  const url = `${process.env.KEEL_TESTING_API_URL}/topics/json/${topic}/tasks/next`;
   const res = await fetch(url, {
     method: "POST",
     headers: {

--- a/integration/testdata/tasks/tests.test.ts
+++ b/integration/testdata/tasks/tests.test.ts
@@ -34,7 +34,10 @@ test("tasks - next - no tasks exist", async () => {
   const token = await getToken({ email: "admin@keel.xyz" });
   const res = await nextTask({ topic: "DispatchOrder", token: token });
   expect(res.status).toBe(404);
-  expect(res.body).toEqual({});
+  expect(res.body).toEqual({
+    code: "ERR_RECORD_NOT_FOUND",
+    message: "Not found",
+  });
 });
 
 test("tasks - next - successfully assigned", async () => {

--- a/integration/testdata/tasks/tests.test.ts
+++ b/integration/testdata/tasks/tests.test.ts
@@ -1,0 +1,167 @@
+import { resetDatabase, models } from "@teamkeel/testing";
+import { beforeEach, expect, test } from "vitest";
+
+beforeEach(resetDatabase);
+
+test("tasks - create", async () => {
+  const token = await getToken({ email: "admin@keel.xyz" });
+
+  const resCreate = await createTask({ topic: "DispatchOrder", token: token });
+  expect(resCreate.status).toBe(200);
+  expect(resCreate.body).toEqual({
+    createdAt: expect.any(String),
+    id: expect.any(String),
+    name: "DispatchOrder",
+    status: "NEW",
+    updatedAt: expect.any(String),
+  });
+
+  const res = await listTasks({ topic: "DispatchOrder", token: token });
+  expect(res.status).toBe(200);
+  expect(res.body.length).toBe(1);
+  expect(res.body).toEqual([
+    {
+      createdAt: expect.any(String),
+      id: expect.any(String),
+      name: "DispatchOrder",
+      status: "NEW",
+      updatedAt: expect.any(String),
+    },
+  ]);
+});
+
+test("tasks - next - no tasks exist", async () => {
+  const token = await getToken({ email: "admin@keel.xyz" });
+  const res = await nextTask({ topic: "DispatchOrder", token: token });
+  expect(res.status).toBe(404);
+  expect(res.body).toEqual({});
+});
+
+test("tasks - next - successfully assigned", async () => {
+  const token = await getToken({ email: "admin@keel.xyz" });
+
+  const resCreate = await createTask({ topic: "DispatchOrder", token: token });
+  expect(resCreate.status).toBe(200);
+
+  const res = await nextTask({ topic: "DispatchOrder", token: token });
+  expect(res.status).toBe(200);
+  expect(res.body).toEqual({
+    createdAt: expect.any(String),
+    id: resCreate.body.id,
+    name: "DispatchOrder",
+    status: "ASSIGNED",
+    updatedAt: expect.any(String),
+    assignedTo: expect.any(String),
+    assignedAt: expect.any(String),
+  });
+});
+
+test("tasks - next - already assigned", async () => {
+  const token = await getToken({ email: "admin@keel.xyz" });
+
+  const resCreate1 = await createTask({ topic: "DispatchOrder", token: token });
+  expect(resCreate1.status).toBe(200);
+
+  const resCreate2 = await createTask({ topic: "DispatchOrder", token: token });
+  expect(resCreate2.status).toBe(200);
+
+  const resNext = await nextTask({ topic: "DispatchOrder", token: token });
+  expect(resNext.status).toBe(200);
+  expect(resNext.body).toEqual({
+    createdAt: expect.any(String),
+    id: resCreate1.body.id,
+    name: "DispatchOrder",
+    status: "ASSIGNED",
+    updatedAt: expect.any(String),
+    assignedTo: expect.any(String),
+    assignedAt: expect.any(String),
+  });
+
+  const resNextAgain = await nextTask({ topic: "DispatchOrder", token: token });
+  expect(resNextAgain.status).toBe(200);
+  expect(resNextAgain.body).toEqual(resNext.body);
+
+  const resList = await listTasks({ topic: "DispatchOrder", token: token });
+  expect(resList.status).toBe(200);
+  expect(resList.body).toEqual([resCreate2.body, resNext.body]);
+});
+
+async function getToken({ email }) {
+  const response = await fetch(
+    process.env.KEEL_TESTING_AUTH_API_URL + "/token",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        grant_type: "password",
+        username: email,
+        password: "1234",
+      }),
+    }
+  );
+  expect(response.status).toEqual(200);
+
+  const token = (await response.json()).access_token;
+  await models.identity.update(
+    {
+      email: email,
+      issuer: "https://keel.so",
+    },
+    {
+      emailVerified: true,
+    }
+  );
+
+  return token;
+}
+
+async function createTask({ topic, token }) {
+  const url = `${process.env.KEEL_TESTING_API_URL}/topics/${topic}/tasks`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer " + token,
+    },
+  });
+
+  return {
+    status: res.status,
+    body: await res.json(),
+  };
+}
+
+async function listTasks({ topic, token }) {
+  const url = `${process.env.KEEL_TESTING_API_URL}/topics/${topic}/tasks`;
+
+  const res = await fetch(url, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer " + token,
+    },
+  });
+
+  return {
+    status: res.status,
+    body: await res.json(),
+  };
+}
+
+async function nextTask({ topic, token }) {
+  const url = `${process.env.KEEL_TESTING_API_URL}/topics/${topic}/tasks/next`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer " + token,
+    },
+  });
+
+  return {
+    status: res.status,
+    body: await res.json(),
+  };
+}

--- a/integration/testdata/tasks/tests.test.ts
+++ b/integration/testdata/tasks/tests.test.ts
@@ -134,7 +134,7 @@ async function createTask({ topic, token }) {
 }
 
 async function listTasks({ topic, token }) {
-  const url = `${process.env.KEEL_TESTING_API_URL}/topics/${topic}/tasks`;
+  const url = `${process.env.KEEL_TESTING_API_URL}/topics/json/${topic}/tasks`;
 
   const res = await fetch(url, {
     method: "GET",

--- a/runtime/apis/tasksapi/handler.go
+++ b/runtime/apis/tasksapi/handler.go
@@ -142,7 +142,7 @@ func Handler(s *proto.Schema) common.HandlerFunc {
 				task, err := tasks.NextTask(ctx, identityID)
 				if err != nil {
 					if errors.Is(err, tasks.ErrTaskNotFound) {
-						return common.NewJsonResponse(http.StatusNotFound, map[string]any{}, nil)
+						return httpjson.NewErrorResponse(ctx, common.NewNotFoundError("Not found"), nil)
 					}
 
 					return httpjson.NewErrorResponse(ctx, err, nil)

--- a/runtime/apis/tasksapi/handler.go
+++ b/runtime/apis/tasksapi/handler.go
@@ -139,9 +139,8 @@ func Handler(s *proto.Schema) common.HandlerFunc {
 					return httpjson.NewErrorResponse(ctx, common.NewHttpMethodNotAllowedError("only HTTP POST accepted"), nil)
 				}
 
-				task, err := tasks.NextTask(ctx)
+				task, err := tasks.NextTask(ctx, identityID)
 				if err != nil {
-
 					if errors.Is(err, tasks.ErrTaskNotFound) {
 						return common.NewJsonResponse(http.StatusNotFound, map[string]any{}, nil)
 					}

--- a/runtime/apis/tasksapi/handler.go
+++ b/runtime/apis/tasksapi/handler.go
@@ -133,8 +133,26 @@ func Handler(s *proto.Schema) common.HandlerFunc {
 				return httpjson.NewErrorResponse(ctx, common.NewHttpMethodNotAllowedError("only HTTP GET or POST accepted"), nil)
 			}
 		case 3:
-			// TODO: POST topics/{name}/tasks/next - Assigns next task to me (or returns my current task)
-			return httpjson.NewErrorResponse(ctx, common.NewNotFoundError("Not found"), nil)
+			switch pathParts[2] {
+			case "next":
+				if r.Method != http.MethodPost {
+					return httpjson.NewErrorResponse(ctx, common.NewHttpMethodNotAllowedError("only HTTP POST accepted"), nil)
+				}
+
+				task, err := tasks.NextTask(ctx)
+				if err != nil {
+
+					if errors.Is(err, tasks.ErrTaskNotFound) {
+						return common.NewJsonResponse(http.StatusNotFound, map[string]any{}, nil)
+					}
+
+					return httpjson.NewErrorResponse(ctx, err, nil)
+				}
+
+				return common.NewJsonResponse(http.StatusOK, task, nil)
+			default:
+				return httpjson.NewErrorResponse(ctx, common.NewNotFoundError("Not found"), nil)
+			}
 		case 4:
 			// PUT topics/{name}/tasks/{id}/complete - Completes a task
 			// PUT topics/{name}/tasks/{id}/defer - Defers a task until a later period

--- a/runtime/tasks/tasks.go
+++ b/runtime/tasks/tasks.go
@@ -513,7 +513,7 @@ func NextTask(ctx context.Context) (task *Task, err error) {
 			Clauses(clause.Locking{Strength: "UPDATE", Options: "SKIP LOCKED"}).
 			Where("assigned_to IS NULL").
 			Where("status = ? OR (status = ? AND deferred_until <= now())", StatusNew, StatusDeferred).
-			Order("created_at ASC, id ASC").
+			Order("created_at ASC, id ASC"). // TODO: custom sort order
 			Limit(1).
 			Take(&candidate).Error
 		if errTx != nil {

--- a/runtime/tasks/tasks.go
+++ b/runtime/tasks/tasks.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/teamkeel/keel/db"
 	"github.com/teamkeel/keel/proto"
-	"github.com/teamkeel/keel/runtime/auth"
-	"github.com/teamkeel/keel/schema/parser"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -464,7 +462,7 @@ func AssignTask(ctx context.Context, pbTask *proto.Task, id string, assignedTo, 
 }
 
 // NextTask will assign and return the next available task to the authenticated identity.
-func NextTask(ctx context.Context) (task *Task, err error) {
+func NextTask(ctx context.Context, identityID string) (task *Task, err error) {
 	ctx, span := tracer.Start(ctx, "NextTask")
 	defer span.End()
 
@@ -474,15 +472,6 @@ func NextTask(ctx context.Context) (task *Task, err error) {
 			span.SetStatus(codes.Error, err.Error())
 		}
 	}()
-
-	identity, err := auth.GetIdentity(ctx)
-	if err != nil {
-		return nil, err
-	}
-	identityID, _ := identity[parser.FieldNameId].(string)
-	if identityID == "" {
-		return nil, errors.New("missing identity id in context")
-	}
 
 	dbase, err := db.GetDatabase(ctx)
 	if err != nil {


### PR DESCRIPTION
This performs basic task assignment when calling upon the `POST topics/{name}/tasks/next` endpoint.  The next available task will be assigned to the currently authenticated user.  The following basic rules apply:
 - If the user already has a task assigned to them, then return that task instead
 - The candidate task is the next NEW and unassigned task whose deferred date has passed (if even set)

Still to do is to apply task ordering by the `@order` attribute.  Also need to write a lot more tests.