### PR TITLE
feat: bulkScan element

### DIFF
--- a/packages/functions-runtime/src/flows/index.ts
+++ b/packages/functions-runtime/src/flows/index.ts
@@ -27,6 +27,7 @@ import { iterator } from "./ui/elements/iterator";
 import { print } from "./ui/elements/interactive/print";
 import { pickList } from "./ui/elements/interactive/pickList";
 import { NonRetriableError } from "./errors";
+import { bulkScan } from "./ui/elements/interactive/bulkScan";
 
 export const enum STEP_STATUS {
   NEW = "NEW",
@@ -513,6 +514,7 @@ export function createFlowContext<C extends FlowConfig, E, S, Id, I>(
       interactive: {
         print: print as any,
         pickList: pickList as any,
+        bulkScan: bulkScan as any,
       },
     },
   };

--- a/packages/functions-runtime/src/flows/ui/elements/interactive/bulkScan.test-d.ts
+++ b/packages/functions-runtime/src/flows/ui/elements/interactive/bulkScan.test-d.ts
@@ -1,0 +1,54 @@
+import { describe, expectTypeOf, test } from "vitest";
+import { testFlow } from "../../../testingUtils";
+
+describe("bulk input element", () => {
+  test("simple bulk input", () => {
+    testFlow({}, async (ctx) => {
+      const bulk = ctx.ui.interactive.bulkScan("bulkScan");
+
+      const res = await ctx.ui.page("page", {
+        content: [bulk],
+      });
+
+      expectTypeOf(res.bulkScan.scans).toBeArray();
+      expectTypeOf(res.bulkScan.scans).toEqualTypeOf<string[]>();
+    });
+  });
+  test("quantity bulk input", () => {
+    testFlow({}, async (ctx) => {
+      type a = Parameters<typeof ctx.ui.interactive.bulkScan>["1"];
+      type b = NonNullable<NonNullable<a>["duplicateHandling"]>;
+
+      const bulk = ctx.ui.interactive.bulkScan("bulkScan", {
+        duplicateHandling: "trackQuantity",
+      });
+
+      const res = await ctx.ui.page("page", {
+        content: [bulk],
+      });
+
+      expectTypeOf(res.bulkScan.scans).toBeArray();
+      expectTypeOf(res.bulkScan.scans).toEqualTypeOf<
+        {
+          value: string;
+          quantity: number;
+        }[]
+      >;
+    });
+  });
+
+  test("reject duplicates bulk input", () => {
+    testFlow({}, async (ctx) => {
+      const bulk = ctx.ui.interactive.bulkScan("bulkScan", {
+        duplicateHandling: "rejectDuplicates",
+      });
+
+      const res = await ctx.ui.page("page", {
+        content: [bulk],
+      });
+
+      expectTypeOf(res.bulkScan.scans).toBeArray();
+      expectTypeOf(res.bulkScan.scans).toEqualTypeOf<string[]>();
+    });
+  });
+});

--- a/packages/functions-runtime/src/flows/ui/elements/interactive/bulkScan.ts
+++ b/packages/functions-runtime/src/flows/ui/elements/interactive/bulkScan.ts
@@ -1,0 +1,105 @@
+import {
+  BaseUiMinimalInputResponse,
+  InputElementImplementation,
+  InputElementResponse,
+  ValidateFn,
+} from "../..";
+
+export type UiElementBulkScan = {
+  // Overloaded so without a config we return the simple string array response
+  <N extends string>(
+    name: N
+  ): InputElementResponse<
+    N,
+    {
+      scans: string[];
+    }
+  >;
+  <N extends string, const M extends BulkScanDuplicateMode>(
+    name: N,
+    options?: BulkScanOptions<M>
+  ): InputElementResponse<
+    N,
+    {
+      scans: BulkScanResponseItem<M>[];
+    }
+  >;
+};
+
+type BulkScanResponseItem<M> = M extends "trackQuantity"
+  ? {
+      value: string;
+      quantity: number;
+    }
+  : string;
+
+/**
+ * Defines how duplicate scans should be handled.
+ * @default "none"
+ */
+type BulkScanDuplicateMode =
+  /** No duplicate handling - all scans are accepted as separate entries */
+  | "none"
+  /** Track quantity when duplicates are scanned */
+  | "trackQuantity"
+  /** Reject duplicate scans with an error message */
+  | "rejectDuplicates";
+
+type BulkScanOptions<M> = {
+  /** The singular unit of the item being scanned. E.g. "box", "bottle", "product" etc */
+  unit?: string;
+  /** The title of the input block
+   * @default "Scan {unit plural | 'items'}"
+   */
+  title?: string;
+  description?: string;
+  max?: number;
+  min?: number;
+  duplicateHandling?: M;
+
+  validate?: ValidateFn<BulkScanResponseItem<M>>;
+};
+
+// The shape of the response over the API
+export interface UiElementBulkScanApiResponse
+  extends BaseUiMinimalInputResponse<"ui.interactive.bulkScan"> {
+  title?: string;
+  description?: string;
+  unit?: string;
+  max?: number;
+  min?: number;
+  duplicateHandling: BulkScanDuplicateMode;
+}
+
+export const bulkScan: InputElementImplementation<
+  any,
+  UiElementBulkScan,
+  UiElementBulkScanApiResponse
+> = (name, options) => {
+  return {
+    __type: "input",
+    uiConfig: {
+      __type: "ui.interactive.bulkScan",
+      name,
+      title: options?.title ?? undefined,
+      description: options?.description ?? undefined,
+      unit: options?.unit ?? undefined,
+      max: options?.max ?? undefined,
+      min: options?.min ?? undefined,
+      duplicateHandling: options?.duplicateHandling ?? "none",
+    } satisfies UiElementBulkScanApiResponse,
+    validate: async (data) => {
+      // Ensure the response is an object with an items array
+      if (!("scans" in data)) {
+        return "Missing scans in response";
+      }
+
+      if (!Array.isArray(data.scans)) {
+        return "Scans must be an array";
+      }
+
+      return options?.validate?.(data) ?? true;
+    },
+    getData: (x: any) => x,
+  };
+};

--- a/packages/functions-runtime/src/flows/ui/elements/interactive/pickList.test-d.ts
+++ b/packages/functions-runtime/src/flows/ui/elements/interactive/pickList.test-d.ts
@@ -35,7 +35,8 @@ describe("pick list element", () => {
       expectTypeOf(res.pickList.items).branded.toEqualTypeOf<
         {
           id: string;
-          qty: number;
+          quantity: number;
+          targetQuantity: number;
         }[]
       >;
     });

--- a/packages/functions-runtime/src/flows/ui/index.ts
+++ b/packages/functions-runtime/src/flows/ui/index.ts
@@ -77,6 +77,10 @@ import {
   UiElementPickList,
   UiElementPickListApiResponse,
 } from "./elements/interactive/pickList";
+import {
+  UiElementBulkScan,
+  UiElementBulkScanApiResponse,
+} from "./elements/interactive/bulkScan";
 
 export interface UI<C extends FlowConfig> {
   page: UiPage<C>;
@@ -119,6 +123,7 @@ type UiDisplayElements = {
 type UiInteractiveElements = {
   print: UiElementPrint;
   pickList: UiElementPickList;
+  bulkScan: UiElementBulkScan;
 };
 
 // The base input element function. All inputs must be named and can optionally have a config
@@ -233,6 +238,7 @@ export type UIApiResponses = {
   interactive: {
     print: UiElementPrintApiResponse;
     pickList: UiElementPickListApiResponse;
+    bulkScan: UiElementBulkScanApiResponse;
   };
 };
 
@@ -264,7 +270,8 @@ export type UiElementApiResponse =
 
   // Interactive elements
   | UiElementPrintApiResponse
-  | UiElementPickListApiResponse;
+  | UiElementPickListApiResponse
+  | UiElementBulkScanApiResponse;
 
 export type UiElementApiResponses = UiElementApiResponse[];
 

--- a/runtime/openapi/testdata/flow.json
+++ b/runtime/openapi/testdata/flow.json
@@ -905,6 +905,9 @@
               },
               {
                 "$ref": "#/components/schemas/__UiConfigSchemas/$defs/UiElementPickListApiResponse"
+              },
+              {
+                "$ref": "#/components/schemas/__UiConfigSchemas/$defs/UiElementBulkScanApiResponse"
               }
             ]
           },
@@ -1242,6 +1245,46 @@
             },
             "additionalProperties": false,
             "required": ["__type", "data", "name"]
+          },
+          "UiElementBulkScanApiResponse": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "unit": {
+                "type": "string"
+              },
+              "max": {
+                "type": "number"
+              },
+              "min": {
+                "type": "number"
+              },
+              "duplicateHandling": {
+                "$ref": "#/components/schemas/__UiConfigSchemas/$defs/BulkScanDuplicateMode"
+              },
+              "__type": {
+                "type": "string",
+                "const": "ui.interactive.bulkScan"
+              },
+              "name": {
+                "type": "string"
+              },
+              "validationError": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false,
+            "required": ["__type", "duplicateHandling", "name"]
+          },
+          "BulkScanDuplicateMode": {
+            "default": "none",
+            "enum": ["none", "rejectDuplicates", "trackQuantity"],
+            "type": "string"
           },
           "UiElementPrintApiResponse": {
             "type": "object",

--- a/runtime/openapi/uiConfig.json
+++ b/runtime/openapi/uiConfig.json
@@ -114,6 +114,9 @@
         },
         {
           "$ref": "#/$defs/UiElementPickListApiResponse"
+        },
+        {
+          "$ref": "#/$defs/UiElementBulkScanApiResponse"
         }
       ]
     },
@@ -1039,6 +1042,55 @@
         "data",
         "name"
       ]
+    },
+    "UiElementBulkScanApiResponse": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "unit": {
+          "type": "string"
+        },
+        "max": {
+          "type": "number"
+        },
+        "min": {
+          "type": "number"
+        },
+        "duplicateHandling": {
+          "$ref": "#/$defs/BulkScanDuplicateMode"
+        },
+        "__type": {
+          "type": "string",
+          "const": "ui.interactive.bulkScan"
+        },
+        "name": {
+          "type": "string"
+        },
+        "validationError": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "__type",
+        "duplicateHandling",
+        "name"
+      ]
+    },
+    "BulkScanDuplicateMode": {
+      "description": "Defines how duplicate scans should be handled.",
+      "default": "none",
+      "enum": [
+        "none",
+        "rejectDuplicates",
+        "trackQuantity"
+      ],
+      "type": "string"
     },
     "UiPageApiResponse": {
       "type": "object",


### PR DESCRIPTION
* Element to support bulk barcode capture
* Supports 3 strategies to handle duplicates
  * Treat each scan as a separate entry (default behaviour) 
  *  Reject duplicates
  * Track quality of each unique code

