### PR TITLE
fix: filter out flows api traces from local monitoring

### DIFF
--- a/rpc/rpcApi/server.go
+++ b/rpc/rpcApi/server.go
@@ -109,6 +109,10 @@ func (s *Server) ListTraces(ctx context.Context, input *rpc.ListTracesRequest) (
 			if v.RootName == "GET /_health" {
 				continue
 			}
+			// filter out flows API requests
+			if strings.Contains(v.RootName, "flows/json") {
+				continue
+			}
 			if strings.HasSuffix(v.RootName, "openapi.json") {
 				continue
 			}


### PR DESCRIPTION
Filters out requests to the flows api from the monitoring page when running a local project.