### PR TITLE
fix: set end time when cancelling steps

### DIFF
--- a/integration/testdata/flows/tests.test.ts
+++ b/integration/testdata/flows/tests.test.ts
@@ -2048,7 +2048,7 @@ test("flows - cancelling - with pending ui step", async () => {
     createdAt: expect.any(Date),
     updatedAt: expect.any(Date),
     startTime: expect.any(Date),
-    endTime: null,
+    endTime: expect.any(Date),
   });
 });
 

--- a/runtime/flows/flow.go
+++ b/runtime/flows/flow.go
@@ -339,10 +339,12 @@ func updateRun(ctx context.Context, runID string, status Status, config any) (*R
 
 		// if we've cancelled the flow, we need to cancel any UI steps that are PENDING
 		if status == StatusCancelled {
+			now := time.Now()
 			if err := tx.Model(&Step{}).
 				Where("run_id = ? AND type = ? AND status = ?", runID, StepTypeUI, StepStatusPending).
 				Updates(Step{
-					Status: StepStatusCancelled,
+					Status:  StepStatusCancelled,
+					EndTime: &now,
 				}).Error; err != nil {
 				return err
 			}


### PR DESCRIPTION
When cancelling steps, set the endTime for the cancelled step to be the current timestamp